### PR TITLE
Stack recipe panels on small screens

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1480,51 +1480,48 @@ function App() {
               </ul>
             </div>
             
-            {/* Instructions Panel with Links Panel on Top */}
-            <div className="instructions-panel-container">
-              {/* Links Panel - positioned on top of instructions */}
-              {(selectedRecipe.source_url || selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl)) && (
-                <div className="recipe-links-panel glass">
-                  <h3>Recipe Links</h3>
-                  <div className="recipe-links-content">
-                    {selectedRecipe.source_url && (
-                      <a 
-                        href={selectedRecipe.source_url} 
-                        target="_blank" 
-                        rel="noopener noreferrer" 
-                        className="recipe-link source-link"
-                        title="View original recipe"
-                      >
-                        🌐 Source Recipe
-                      </a>
-                    )}
-                    {(selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl)) && (
-                      <button 
-                        className="recipe-link video-link"
-                        title="Watch recipe video"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          openVideoPopup(selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl));
-                        }}
-                      >
-                        🎥 Watch Video
-                      </button>
-                    )}
-                  </div>
+            {/* Links Panel - moved outside of instructions panel container */}
+            {(selectedRecipe.source_url || selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl)) && (
+              <div className="recipe-links-panel glass">
+                <h3>Recipe Links</h3>
+                <div className="recipe-links-content">
+                  {selectedRecipe.source_url && (
+                    <a 
+                      href={selectedRecipe.source_url} 
+                      target="_blank" 
+                      rel="noopener noreferrer" 
+                      className="recipe-link source-link"
+                      title="View original recipe"
+                    >
+                      🌐 Source Recipe
+                    </a>
+                  )}
+                  {(selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl)) && (
+                    <button 
+                      className="recipe-link video-link"
+                      title="Watch recipe video"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openVideoPopup(selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl));
+                      }}
+                    >
+                      🎥 Watch Video
+                    </button>
+                  )}
                 </div>
-              )}
-              
-              {/* Instructions Panel */}
-              <div className="recipe-panel glass">
-                <h2>Instructions</h2>
-                <ol className="instructions-list">
-                  {(selectedRecipe.recipeInstructions || selectedRecipe.instructions || []).map((instruction, index) => (
-                    <li key={index}>
-                      {typeof instruction === 'string' ? instruction : instruction.text || ''}
-                    </li>
-                  ))}
-                </ol>
               </div>
+            )}
+            
+            {/* Instructions Panel */}
+            <div className="recipe-panel glass">
+              <h2>Instructions</h2>
+              <ol className="instructions-list">
+                {(selectedRecipe.recipeInstructions || selectedRecipe.instructions || []).map((instruction, index) => (
+                  <li key={index}>
+                    {typeof instruction === 'string' ? instruction : instruction.text || ''}
+                  </li>
+                ))}
+              </ol>
             </div>
           </div>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -962,12 +962,7 @@ li {
   z-index: 3001;
 }
 
-/* Instructions Panel Container */
-.instructions-panel-container {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
+/* Removed instructions-panel-container - links panel is now a direct child */
 
 /* Recipe Links Panel */
 .recipe-links-panel {
@@ -1099,15 +1094,24 @@ li {
 @media (max-width: 768px) {
   .recipe-links-panel {
     padding: 15px;
+    margin-bottom: 0; /* Remove any bottom margin since we use gap */
   }
   
   .recipe-links-content {
     gap: 10px;
+    justify-content: center; /* Center the links on mobile */
   }
   
   .recipe-links-panel .recipe-link {
     padding: 0.5rem 1rem;
     font-size: 0.8rem;
+    flex: 1; /* Make links expand to fill available space */
+    min-width: 120px; /* Ensure minimum width for readability */
+  }
+  
+  /* Ensure panels have consistent spacing on mobile */
+  .recipe-panel {
+    margin-bottom: 0; /* Remove bottom margins since we use gap */
   }
 }
 
@@ -1404,9 +1408,26 @@ li {
   }
   
   .recipe-fullscreen-content {
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
     padding: 20px;
     margin-top: 20px; /* Reduced margin-top since header is now relative */
+    gap: 20px; /* Add gap between panels */
+  }
+  
+  /* Order the panels: links (1), ingredients (2), instructions (3) */
+  .recipe-links-panel {
+    order: 1;
+  }
+  
+  /* Ingredients panel - first .recipe-panel */
+  .recipe-fullscreen-content > .recipe-panel:first-of-type {
+    order: 2;
+  }
+  
+  /* Instructions panel - last .recipe-panel */
+  .recipe-fullscreen-content > .recipe-panel:last-of-type {
+    order: 3;
   }
   
   .recipe-title-section {
@@ -1454,6 +1475,7 @@ li {
   .recipe-fullscreen-content {
     padding: 15px;
     margin-top: 15px;
+    gap: 15px; /* Smaller gap on very small screens */
   }
   
   .recipe-panel {


### PR DESCRIPTION
Reorder recipe page panels for mobile to display links, then ingredients, then instructions.

This improves the mobile user experience by prioritizing recipe links and providing a more logical flow of content on smaller screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce4bb21f-f920-46f9-a000-a33bb20e515c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce4bb21f-f920-46f9-a000-a33bb20e515c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

