### PR TITLE
Move source links under recipe title

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1425,6 +1425,34 @@ function App() {
             </button>
             <div className="recipe-title-section">
               <h1 className="recipe-fullscreen-title">{selectedRecipe.name}</h1>
+              {/* Recipe Links - moved under title */}
+              {(selectedRecipe.source_url || selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl)) && (
+                <div className="recipe-links">
+                  {selectedRecipe.source_url && (
+                    <a 
+                      href={selectedRecipe.source_url} 
+                      target="_blank" 
+                      rel="noopener noreferrer" 
+                      className="recipe-link source-link"
+                      title="View original recipe"
+                    >
+                      🌐 Source Recipe
+                    </a>
+                  )}
+                  {(selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl)) && (
+                    <button 
+                      className="recipe-link video-link"
+                      title="Watch recipe video"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        openVideoPopup(selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl));
+                      }}
+                    >
+                      🎥 Watch Video
+                    </button>
+                  )}
+                </div>
+              )}
             </div>
             <div className="recipe-fullscreen-actions">
               <button 
@@ -1479,38 +1507,6 @@ function App() {
                 ))}
               </ul>
             </div>
-            
-            {/* Links Panel - moved outside of instructions panel container */}
-            {(selectedRecipe.source_url || selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl)) && (
-              <div className="recipe-links-panel glass">
-                <h3>Recipe Links</h3>
-                <div className="recipe-links-content">
-                  {selectedRecipe.source_url && (
-                    <a 
-                      href={selectedRecipe.source_url} 
-                      target="_blank" 
-                      rel="noopener noreferrer" 
-                      className="recipe-link source-link"
-                      title="View original recipe"
-                    >
-                      🌐 Source Recipe
-                    </a>
-                  )}
-                  {(selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl)) && (
-                    <button 
-                      className="recipe-link video-link"
-                      title="Watch recipe video"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        openVideoPopup(selectedRecipe.video_url || (selectedRecipe.video && selectedRecipe.video.contentUrl));
-                      }}
-                    >
-                      🎥 Watch Video
-                    </button>
-                  )}
-                </div>
-              </div>
-            )}
             
             {/* Instructions Panel */}
             <div className="recipe-panel glass">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -962,158 +962,7 @@ li {
   z-index: 3001;
 }
 
-/* Removed instructions-panel-container - links panel is now a direct child */
-
-/* Recipe Links Panel */
-.recipe-links-panel {
-  padding: 20px;
-  background: rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 15px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
-  margin-bottom: 0;
-}
-
-.recipe-links-panel h3 {
-  color: white;
-  margin: 0 0 15px 0;
-  font-size: 1.2em;
-  font-weight: 600;
-  text-align: center;
-}
-
-.recipe-links-content {
-  display: flex;
-  gap: 15px;
-  flex-wrap: wrap;
-}
-
-.recipe-links-panel .recipe-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.6rem 1.2rem;
-  background: rgba(255, 255, 255, 0.1);
-  color: white;
-  text-decoration: none;
-  border-radius: 25px;
-  font-size: 0.9rem;
-  font-weight: 500;
-  transition: all 0.3s ease;
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-}
-
-.recipe-links-panel .recipe-link:hover {
-  background: rgba(255, 255, 255, 0.2);
-  transform: translateY(-1px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
-}
-
-.recipe-links-panel .recipe-link.source-link {
-  background: rgba(52, 152, 219, 0.2);
-  color: white;
-  border: 1px solid rgba(52, 152, 219, 0.3);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-}
-
-.recipe-links-panel .recipe-link.source-link:hover {
-  background: rgba(52, 152, 219, 1);
-  transform: translateY(-1px);
-}
-
-.recipe-links-panel .recipe-link.video-link {
-  background: rgba(231, 76, 60, 0.2);
-  color: white;
-  border: 1px solid rgba(231, 76, 60, 0.3);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
-}
-
-.recipe-links-panel .recipe-link.video-link:hover {
-  background: rgba(231, 76, 60, 1);
-  transform: translateY(-1px);
-}
-
-/* Dark mode overrides for recipe links panel */
-@media (prefers-color-scheme: dark) {
-  .recipe-links-panel {
-    background: rgba(0, 0, 0, 0.4);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-  }
-  
-  .recipe-links-panel h3 {
-    color: white;
-  }
-  
-  .recipe-links-panel .recipe-link {
-    background: rgba(255, 255, 255, 0.1);
-    color: white;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-  }
-  
-  .recipe-links-panel .recipe-link:hover {
-    background: rgba(255, 255, 255, 0.2);
-    transform: translateY(-1px);
-  }
-  
-  .recipe-links-panel .recipe-link.source-link {
-    background: rgba(52, 152, 219, 0.2);
-    color: white;
-    border: 1px solid rgba(52, 152, 219, 0.4);
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-  }
-  
-  .recipe-links-panel .recipe-link.source-link:hover {
-    background: rgba(52, 152, 219, 1);
-    transform: translateY(-1px);
-  }
-  
-  .recipe-links-panel .recipe-link.video-link {
-    background: rgba(231, 76, 60, 0.2);
-    color: white;
-    border: 1px solid rgba(231, 76, 60, 0.4);
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-  }
-  
-  .recipe-links-panel .recipe-link.video-link:hover {
-    background: rgba(231, 76, 60, 1);
-    transform: translateY(-1px);
-  }
-}
-
-/* Mobile responsiveness for recipe links panel */
-@media (max-width: 768px) {
-  .recipe-links-panel {
-    padding: 15px;
-    margin-bottom: 0; /* Remove any bottom margin since we use gap */
-  }
-  
-  .recipe-links-content {
-    gap: 10px;
-    justify-content: center; /* Center the links on mobile */
-  }
-  
-  .recipe-links-panel .recipe-link {
-    padding: 0.5rem 1rem;
-    font-size: 0.8rem;
-    flex: 1; /* Make links expand to fill available space */
-    min-width: 120px; /* Ensure minimum width for readability */
-  }
-  
-  /* Ensure panels have consistent spacing on mobile */
-  .recipe-panel {
-    margin-bottom: 0; /* Remove bottom margins since we use gap */
-  }
-}
+/* Removed instructions-panel-container and recipe-links-panel - links are now in the header */
 
 .recipe-panel {
   padding: 30px;
@@ -1415,19 +1264,15 @@ li {
     gap: 20px; /* Add gap between panels */
   }
   
-  /* Order the panels: links (1), ingredients (2), instructions (3) */
-  .recipe-links-panel {
-    order: 1;
-  }
-  
+  /* Order the panels: ingredients (1), instructions (2) */
   /* Ingredients panel - first .recipe-panel */
   .recipe-fullscreen-content > .recipe-panel:first-of-type {
-    order: 2;
+    order: 1;
   }
   
   /* Instructions panel - last .recipe-panel */
   .recipe-fullscreen-content > .recipe-panel:last-of-type {
-    order: 3;
+    order: 2;
   }
   
   .recipe-title-section {
@@ -1595,42 +1440,46 @@ li {
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  background: rgba(255, 255, 255, 0.9);
-  color: #333;
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
   text-decoration: none;
   border-radius: 25px;
   font-size: 0.9rem;
   font-weight: 500;
   transition: all 0.3s ease;
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
 }
 
 .recipe-link:hover {
-  background: rgba(255, 255, 255, 1);
+  background: rgba(255, 255, 255, 0.2);
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
 }
 
 .recipe-link.source-link {
-  background: rgba(52, 152, 219, 0.9);
+  background: rgba(52, 152, 219, 0.2);
   color: white;
   border: 1px solid rgba(52, 152, 219, 0.3);
 }
 
 .recipe-link.source-link:hover {
-  background: rgba(52, 152, 219, 1);
+  background: rgba(52, 152, 219, 0.4);
+  border-color: rgba(52, 152, 219, 0.5);
 }
 
 .recipe-link.video-link {
-  background: rgba(231, 76, 60, 0.9);
+  background: rgba(231, 76, 60, 0.2);
   color: white;
   border: 1px solid rgba(231, 76, 60, 0.3);
 }
 
 .recipe-link.video-link:hover {
-  background: rgba(231, 76, 60, 1);
+  background: rgba(231, 76, 60, 0.4);
+  border-color: rgba(231, 76, 60, 0.5);
 }
 
 /* Full Background Image */


### PR DESCRIPTION
Remove source links panel and move link buttons under the recipe title for a cleaner fullscreen view.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d5f508c-3a04-4fd1-9ba3-586f2011d040">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d5f508c-3a04-4fd1-9ba3-586f2011d040">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

