### PR TITLE
Style recipe times and yield in full screen

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1354,7 +1354,7 @@ li {
   
   /* Adjust timing info on mobile */
   .recipe-timing-info {
-    gap: 0.8rem;
+    gap: 1.5rem;
     margin-top: 0.8rem;
     margin-bottom: 0.4rem;
   }
@@ -1408,7 +1408,7 @@ li {
   
   /* Further adjust timing info on very small screens */
   .recipe-timing-info {
-    gap: 0.5rem;
+    gap: 1rem;
     margin-top: 0.6rem;
   }
   
@@ -2741,7 +2741,7 @@ button:disabled:hover {
 /* Recipe Timing Info */
 .recipe-timing-info {
   display: flex;
-  gap: 1.5rem;
+  gap: 2.5rem;
   margin-top: 1rem;
   margin-bottom: 0.5rem;
   flex-wrap: wrap;
@@ -2751,14 +2751,10 @@ button:disabled:hover {
 
 .timing-item {
   display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 0.3rem;
-  background: rgba(255, 255, 255, 0.15);
-  backdrop-filter: blur(10px);
   padding: 0.5rem 1rem;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 .timing-icon {
@@ -2768,13 +2764,16 @@ button:disabled:hover {
 
 .timing-label {
   color: rgba(255, 255, 255, 0.8);
-  font-size: 0.9em;
+  font-size: 0.85em;
   font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
 }
 
 .timing-value {
   color: white;
   font-weight: 600;
+  font-size: 1.1em;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
Remove glass effect and update styling for recipe timing info in full-screen view to match card format.

---
<a href="https://cursor.com/background-agent?bcId=bc-f261b720-c03b-48d7-a702-225d3f53f63c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f261b720-c03b-48d7-a702-225d3f53f63c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

