### PR TITLE
Fix recipe instructions display bug

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -731,7 +731,10 @@ function App() {
       description: editableRecipe.description,
       image: editingRecipe.image || editingRecipe.image_url || '',
       recipeIngredient: editableRecipe.ingredients.filter(i => i.trim()),
-      recipeInstructions: editableRecipe.instructions.filter(i => i.trim()),
+      recipeInstructions: editableRecipe.instructions.filter(i => i.trim()).map(instruction => ({
+        "@type": "HowToStep",
+        text: instruction
+      })),
       // Backward compatibility
       ingredients: editableRecipe.ingredients.filter(i => i.trim()),
       instructions: editableRecipe.instructions.filter(i => i.trim()),
@@ -846,11 +849,23 @@ function App() {
     const recipeIngredients = recipe.recipeIngredient || recipe.ingredients || [];
     const recipeInstructions = recipe.recipeInstructions || recipe.instructions || [];
     
+    // Extract text from instruction objects if they are objects
+    const processedInstructions = Array.isArray(recipeInstructions) 
+      ? recipeInstructions.map(instruction => {
+          if (typeof instruction === 'string') {
+            return instruction;
+          } else if (instruction && typeof instruction === 'object' && instruction.text) {
+            return instruction.text;
+          }
+          return '';
+        })
+      : [];
+    
     setEditableRecipe({
       name: recipe.name,
       description: recipe.description || '',
       ingredients: Array.isArray(recipeIngredients) ? [...recipeIngredients] : [],
-      instructions: Array.isArray(recipeInstructions) ? [...recipeInstructions] : [],
+      instructions: processedInstructions,
       image: recipe.image || recipe.image_url || ''
     });
     setIsEditingRecipe(true);

--- a/frontend/src/__tests__/RecipeInstructionsEdit.test.jsx
+++ b/frontend/src/__tests__/RecipeInstructionsEdit.test.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from '../App';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+describe('Recipe Instructions Editing', () => {
+  beforeEach(() => {
+    fetch.mockClear();
+    fetch.mockImplementation((url) => {
+      if (url.includes('/health')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: 'healthy' })
+        });
+      }
+      if (url.includes('/recipes')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{
+            id: 1,
+            name: 'Test Recipe',
+            description: 'Test Description',
+            recipeIngredient: ['Ingredient 1', 'Ingredient 2'],
+            recipeInstructions: [
+              { "@type": "HowToStep", text: "Step 1: Do something" },
+              { "@type": "HowToStep", text: "Step 2: Do something else" }
+            ],
+            image: 'https://example.com/image.jpg'
+          }])
+        });
+      }
+      return Promise.resolve({ ok: true });
+    });
+  });
+
+  test('instructions display as text (not objects) when editing a recipe', async () => {
+    render(<App />);
+    
+    // Wait for recipes to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Recipe')).toBeInTheDocument();
+    });
+
+    // Click on the recipe
+    fireEvent.click(screen.getByText('Test Recipe'));
+
+    // Wait for recipe details to show
+    await waitFor(() => {
+      expect(screen.getByTitle('Edit Recipe')).toBeInTheDocument();
+    });
+
+    // Click edit button
+    fireEvent.click(screen.getByTitle('Edit Recipe'));
+
+    // Wait for edit form to appear
+    await waitFor(() => {
+      expect(screen.getByText('Instructions')).toBeInTheDocument();
+    });
+
+    // Check that instructions are displayed as text, not as [object Object]
+    const instructionTextareas = screen.getAllByPlaceholderText(/Step \d+/);
+    expect(instructionTextareas).toHaveLength(2);
+    expect(instructionTextareas[0]).toHaveValue('Step 1: Do something');
+    expect(instructionTextareas[1]).toHaveValue('Step 2: Do something else');
+    
+    // Verify no [object Object] text appears
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+  });
+
+  test('edited instructions are saved in correct format', async () => {
+    render(<App />);
+    
+    // Wait for recipes to load
+    await waitFor(() => {
+      expect(screen.getByText('Test Recipe')).toBeInTheDocument();
+    });
+
+    // Click on the recipe
+    fireEvent.click(screen.getByText('Test Recipe'));
+
+    // Click edit button
+    await waitFor(() => {
+      expect(screen.getByTitle('Edit Recipe')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTitle('Edit Recipe'));
+
+    // Wait for edit form
+    await waitFor(() => {
+      expect(screen.getByText('Instructions')).toBeInTheDocument();
+    });
+
+    // Find and modify an instruction
+    const instructionTextareas = screen.getAllByPlaceholderText(/Step \d+/);
+    fireEvent.change(instructionTextareas[0], { target: { value: 'Updated Step 1' } });
+
+    // Mock successful update response
+    fetch.mockImplementationOnce(() => Promise.resolve({ ok: true }));
+
+    // Save the recipe
+    const saveButton = screen.getByText('✓ Update Recipe');
+    fireEvent.click(saveButton);
+
+    // Verify the PUT request was made with correct format
+    await waitFor(() => {
+      const putCall = fetch.mock.calls.find(call => call[1]?.method === 'PUT');
+      expect(putCall).toBeDefined();
+      
+      const requestBody = JSON.parse(putCall[1].body);
+      expect(requestBody.recipeInstructions).toEqual([
+        { "@type": "HowToStep", text: "Updated Step 1" },
+        { "@type": "HowToStep", text: "Step 2: Do something else" }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes recipe instructions displaying as objects in the edit form and ensures they are saved in the correct object format.

---
<a href="https://cursor.com/background-agent?bcId=bc-4db61f12-dfc5-4410-a2c8-b2ff2981dd4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4db61f12-dfc5-4410-a2c8-b2ff2981dd4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

