### PR TITLE
Adjust card position on mobile for no overlap

### DIFF
--- a/frontend/src/styles/recipe-card.scss
+++ b/frontend/src/styles/recipe-card.scss
@@ -425,21 +425,21 @@
 /* Responsive adjustments for recipe grid */
 @media (max-width: 768px) {
   .recipe-grid {
-    margin-top: $spacing-md; /* Reduced margin since container has padding */
+    margin-top: $spacing-xl + $spacing-md; /* Increased from $spacing-md to add more space */
     gap: $spacing-md;
   }
 }
 
 @media (max-width: 640px) {
   .recipe-grid {
-    margin-top: $spacing-sm; /* Small margin to add some separation */
+    margin-top: $spacing-xl + $spacing-lg; /* Increased from $spacing-sm to ensure cards are below glass panel */
     gap: $spacing-md;
   }
 }
 
 @media (max-width: 480px) {
   .recipe-grid {
-    margin-top: 0; /* Remove top margin as container already has sufficient padding */
+    margin-top: $spacing-xl + $spacing-md; /* Added more space instead of 0 */
     gap: $spacing-sm;
   }
 }


### PR DESCRIPTION
Increase top margin of recipe cards on mobile to prevent overlap with the searchbar's glass panel.

The `margin-top` for `.recipe-grid` was adjusted for various mobile breakpoints:
- `max-width: 768px`: Increased to 60px (from 20px)
- `max-width: 640px`: Increased to 70px (from 10px)
- `max-width: 480px`: Set to 60px (from 0)
This ensures sufficient spacing below the fixed header on smaller screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ff26c36-a683-47b9-b25b-137d4109fb3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ff26c36-a683-47b9-b25b-137d4109fb3f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

