### PR TITLE
Fix auto doc resource access error

### DIFF
--- a/.github/workflows/README-auto-docs-fix.md
+++ b/.github/workflows/README-auto-docs-fix.md
@@ -1,0 +1,44 @@
+# Auto-Docs Workflow Fix
+
+## Issue
+The auto-docs GitHub Action was failing with the error:
+```
+RequestError [HttpError]: Resource not accessible by integration
+```
+
+This occurred when the workflow tried to create a comment on pull requests.
+
+## Root Cause
+The workflow was missing the required permissions to interact with issues and pull requests. GitHub Actions requires explicit permissions to be granted for workflows to perform certain operations.
+
+## Solution
+Added the following permissions to the workflow file (`.github/workflows/auto-docs.yml`):
+
+```yaml
+permissions:
+  contents: write      # Required for pushing documentation changes
+  issues: write        # Required for creating issue comments
+  pull-requests: write # Required for creating PR comments
+```
+
+Additionally:
+1. Explicitly passed the GitHub token to the `github-script` action
+2. Added error handling for cases where the issue/PR number might not be available
+3. Used `await` for the async API call to ensure proper error handling
+
+## Changes Made
+1. Added `permissions` section to the workflow
+2. Added `github-token: ${{ secrets.GITHUB_TOKEN }}` to the github-script action
+3. Improved PR number detection with fallback logic
+4. Added error handling for missing PR context
+
+## Testing
+After these changes, the workflow should:
+- Successfully generate documentation on code changes
+- Post comments on pull requests when documentation is updated
+- Work correctly for both push and pull request events
+
+## Additional Notes
+- No changes to repository settings are required
+- The default `GITHUB_TOKEN` has sufficient permissions when explicitly granted in the workflow
+- The workflow will skip commenting if no PR context is found (e.g., on direct pushes)

--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -21,6 +21,11 @@ on:
       - 'crawler/**'
   workflow_dispatch: # Allow manual triggering
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   update-documentation:
     runs-on: ubuntu-latest
@@ -87,9 +92,16 @@ jobs:
         if: github.event_name == 'pull_request' && steps.check_changes.outputs.changes == 'true'
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
+            const issue_number = context.issue.number || context.payload.pull_request.number;
+            if (!issue_number) {
+              console.log('No issue/PR number found in context');
+              return;
+            }
+            
+            await github.rest.issues.createComment({
+              issue_number: issue_number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `🤖 **Documentation Auto-Updated!**


### PR DESCRIPTION
Fixes auto-documentation workflow by adding necessary GitHub Actions permissions to create PR comments.

The workflow was failing with a `403 Resource not accessible by integration` error when attempting to post comments on pull requests. This was due to the workflow's default `GITHUB_TOKEN` lacking explicit `issues: write` and `pull-requests: write` permissions. This PR grants the required permissions and includes minor improvements for robustness and proper async handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d4b56a8-2599-4f46-9631-da1088618d1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d4b56a8-2599-4f46-9631-da1088618d1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

