### PR TITLE
Remove try again button from clip preview

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1994,32 +1994,7 @@ function App() {
                         >
                           {isSavingRecipe ? '🔄 Saving...' : 'Save Recipe'}
                         </button>
-                        <button 
-                          onClick={() => {
-                            if (!isSavingRecipe) {
-                              // Store the current URL to retry with
-                              const currentUrl = clippedRecipePreview.source_url;
-                              setClippedRecipePreview(null);
-                              setSearchInput(currentUrl);
-                              setClipError('');
-                              setIsEditingPreview(false);
-                              setEditablePreview(null);
-                                                          // Focus on search bar for retry
-                                setTimeout(() => {
-                                  const searchInput = document.querySelector('.title-search-input');
-                                  if (searchInput) {
-                                    searchInput.focus();
-                                    searchInput.select();
-                                  }
-                                }, 100);
-                            }
-                          }} 
-                          className="try-again-btn"
-                          disabled={isSavingRecipe}
-                          title="Try clipping this recipe again"
-                        >
-                          🔄 Try Again
-                        </button>
+
                         <button 
                           onClick={() => {
                             if (!isSavingRecipe) {


### PR DESCRIPTION
Remove the "Try Again" button from the clip preview to simplify the interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c71e24a-f620-492b-bc1a-b9d817e47989">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c71e24a-f620-492b-bc1a-b9d817e47989">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

