### PR TITLE
Skip failed to save alert for existing recipe

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1070,13 +1070,12 @@ function App() {
         });
         
         if (checkRes.ok) {
-          // Recipe already exists in KV store
+          // Recipe already exists in KV store - just proceed silently
           fetchRecipes(); // Refresh the recipe list
           setClippedRecipePreview(null);
           setClipError('');
           setIsEditingPreview(false);
           setEditablePreview(null);
-          alert('This recipe is already saved in your collection!');
           return;
         }
       } catch (checkError) {
@@ -1107,13 +1106,12 @@ function App() {
         
         // Handle duplicate errors from backend
         if (errorText.includes('already exists')) {
-          // Instead of showing an error, treat this as success
+          // Recipe already exists - just proceed silently
           fetchRecipes(); // Refresh the recipe list
           setClippedRecipePreview(null);
           setClipError('');
           setIsEditingPreview(false);
           setEditablePreview(null);
-          alert('This recipe is already saved in your collection!');
         } else {
           throw new Error(`Failed to save recipe: ${errorText}`);
         }
@@ -1121,13 +1119,12 @@ function App() {
     } catch (error) {
       console.error('Error saving recipe:', error);
       if (error.message.includes('already exists')) {
-        // Instead of showing an error, treat this as success
+        // Recipe already exists - just proceed silently
         fetchRecipes(); // Refresh the recipe list
         setClippedRecipePreview(null);
         setClipError('');
         setIsEditingPreview(false);
         setEditablePreview(null);
-        alert('This recipe is already saved in your collection!');
       } else {
         alert('Failed to save recipe. Please try again.');
       }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1062,6 +1062,27 @@ function App() {
         throw new Error('No source URL found for clipped recipe');
       }
       
+      // First check if the recipe already exists by trying to get it from the clipper
+      try {
+        const checkRes = await fetch(`${CLIPPER_API_URL}/cached?url=${encodeURIComponent(sourceUrl)}`, {
+          method: 'GET',
+          headers: { 'Accept': 'application/json' },
+        });
+        
+        if (checkRes.ok) {
+          // Recipe already exists in KV store
+          fetchRecipes(); // Refresh the recipe list
+          setClippedRecipePreview(null);
+          setClipError('');
+          setIsEditingPreview(false);
+          setEditablePreview(null);
+          alert('This recipe is already saved in your collection!');
+          return;
+        }
+      } catch (checkError) {
+        console.log('Error checking existing recipe, proceeding with save:', checkError);
+      }
+      
       const res = await fetch(`${API_URL}/scrape?url=${encodeURIComponent(sourceUrl)}&save=true`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1086,7 +1107,13 @@ function App() {
         
         // Handle duplicate errors from backend
         if (errorText.includes('already exists')) {
-          alert('This recipe already exists in your collection. Please check if you have already saved it.');
+          // Instead of showing an error, treat this as success
+          fetchRecipes(); // Refresh the recipe list
+          setClippedRecipePreview(null);
+          setClipError('');
+          setIsEditingPreview(false);
+          setEditablePreview(null);
+          alert('This recipe is already saved in your collection!');
         } else {
           throw new Error(`Failed to save recipe: ${errorText}`);
         }
@@ -1094,7 +1121,13 @@ function App() {
     } catch (error) {
       console.error('Error saving recipe:', error);
       if (error.message.includes('already exists')) {
-        alert('This recipe already exists in your collection. Please check if you have already saved it.');
+        // Instead of showing an error, treat this as success
+        fetchRecipes(); // Refresh the recipe list
+        setClippedRecipePreview(null);
+        setClipError('');
+        setIsEditingPreview(false);
+        setEditablePreview(null);
+        alert('This recipe is already saved in your collection!');
       } else {
         alert('Failed to save recipe. Please try again.');
       }


### PR DESCRIPTION
Prevent "failed to save" alerts when a clipped recipe already exists by showing a success message instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e47c9cd-5cab-4d7d-95da-0899b5bf0bae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e47c9cd-5cab-4d7d-95da-0899b5bf0bae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

