### PR TITLE
Fix differential coverage check not running

### DIFF
--- a/.github/COVERAGE_REQUIREMENTS.md
+++ b/.github/COVERAGE_REQUIREMENTS.md
@@ -99,3 +99,5 @@ If differential coverage check fails or shows warnings:
 2. Add tests for the new/modified code in your PR
 3. The differential coverage only applies to lines changed in the PR
 4. Use `diff-cover coverage/lcov.info --compare-branch=origin/main` locally to test
+
+**Note:** If your PR only contains changes to documentation, configuration files, or other non-executable code, the differential coverage will show "No lines with coverage information in this diff" - this is normal and expected.

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -134,6 +134,12 @@ jobs:
           echo "diff_coverage_available=true" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "📊 ${coverage_line}" >> $GITHUB_STEP_SUMMARY
+        elif grep -q "No lines with coverage information in this diff" diff-coverage-output.txt; then
+          # Handle case where there are no lines with coverage information
+          echo "diff_coverage_percentage=N/A" >> $GITHUB_OUTPUT
+          echo "diff_coverage_available=true" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📊 No lines with coverage information in this diff - this is normal when changes don't affect testable code" >> $GITHUB_STEP_SUMMARY
         else
           echo "diff_coverage_available=false" >> $GITHUB_OUTPUT
         fi
@@ -291,16 +297,21 @@ jobs:
             // Differential Coverage Section
             comment += '### Differential Coverage\n';
             if (diffCoverageAvailable && diffCoveragePercentage) {
-              comment += `**Coverage of new/modified code: ${diffCoveragePercentage}%**\n\n`;
-              comment += '| Type | Coverage | Threshold | Status |\n';
-              comment += '|------|----------|-----------|--------|\n';
-              const diffPercent = parseFloat(diffCoveragePercentage);
-              comment += `| New/Modified Code | ${diffCoveragePercentage}% | 85% | ${diffPercent >= 85 ? '✅' : '❌'} |\n\n`;
-              
-              if (diffCoverageBelowThreshold) {
-                comment += '❌ **New code coverage is below the required 85% threshold**\n\n';
+              if (diffCoveragePercentage === 'N/A') {
+                comment += '**Coverage of new/modified code: N/A**\n\n';
+                comment += 'ℹ️ _No lines with coverage information in this diff. This is normal when changes don\'t affect testable code (e.g., documentation, configuration, or non-executable code)._\n\n';
               } else {
-                comment += '✅ **New code coverage meets the required 85% threshold**\n\n';
+                comment += `**Coverage of new/modified code: ${diffCoveragePercentage}%**\n\n`;
+                comment += '| Type | Coverage | Threshold | Status |\n';
+                comment += '|------|----------|-----------|--------|\n';
+                const diffPercent = parseFloat(diffCoveragePercentage);
+                comment += `| New/Modified Code | ${diffCoveragePercentage}% | 85% | ${diffPercent >= 85 ? '✅' : '❌'} |\n\n`;
+                
+                if (diffCoverageBelowThreshold) {
+                  comment += '❌ **New code coverage is below the required 85% threshold**\n\n';
+                } else {
+                  comment += '✅ **New code coverage meets the required 85% threshold**\n\n';
+                }
               }
             } else {
               comment += 'ℹ️ _No differential coverage data available. This may happen if there are no code changes in the PR._\n\n';


### PR DESCRIPTION
Fixes differential coverage checks to correctly report when no testable code changes, preventing "No differential coverage data available" messages.

The GitHub Actions workflow previously only parsed `diff-cover` output for a percentage. When changes didn't affect testable code (e.g., docs, config), `diff-cover` outputs "No lines with coverage information in this diff", which the workflow misinterpreted as no data, leading to misleading messages and incomplete checks. This update ensures the workflow correctly identifies and reports this specific scenario.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d996102-cdd3-4046-8ca2-5ac648dbe0a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d996102-cdd3-4046-8ca2-5ac648dbe0a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

