### PR TITLE
Add nutrition info to recipe view

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2731,7 +2731,7 @@ function App() {
           </div>
           
           {/* Recipe Content */}
-          <div className="recipe-fullscreen-content">
+          <div className={`recipe-fullscreen-content ${showNutrition ? 'nutrition-view' : ''}`}>
             {showNutrition ? (
               /* Nutrition Panel */
               <div className="recipe-panel glass nutrition-panel">

--- a/frontend/src/styles/recipe-fullscreen.scss
+++ b/frontend/src/styles/recipe-fullscreen.scss
@@ -416,6 +416,13 @@
   box-sizing: border-box; // Ensure padding is included in width calculations
 }
 
+/* Center nutrition panel when it's the only content */
+.recipe-fullscreen-content.nutrition-view {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+}
+
 /* Recipe Panels */
 .recipe-panel {
   padding: 30px;
@@ -691,6 +698,11 @@
     max-width: 800px; // Further reduce max-width for tablets
   }
   
+  .recipe-fullscreen-content.nutrition-view {
+    display: flex;
+    justify-content: center;
+  }
+  
   .recipe-panel {
     margin-left: 0;
     margin-right: 0;
@@ -929,10 +941,12 @@
 /* Nutrition Panel Specific Styles */
 .nutrition-panel {
   max-width: 400px;
+  width: 100%;
   margin: 0 auto;
   background: transparent !important;
   border: none !important;
   box-shadow: none !important;
+  padding: 30px 0; // Add vertical padding for better spacing
   
   // Override default recipe-panel h2 styles
   h2 {


### PR DESCRIPTION
Adds a nutrition information panel to the full-screen recipe view, accessible via a FAB that only appears when nutrition data is available.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b4d1688-d1e7-463a-9607-f5e526186c30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b4d1688-d1e7-463a-9607-f5e526186c30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

