### PR TITLE
Create ads.txt file for ad integration

### DIFF
--- a/frontend/public/ads.txt
+++ b/frontend/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9428191017435559, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Add `ads.txt` file to the public directory to enable ad integration and authorize the Google AdSense publisher ID.

---
<a href="https://cursor.com/background-agent?bcId=bc-d98d0af2-cfa7-477c-9297-4733351efbd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d98d0af2-cfa7-477c-9297-4733351efbd0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

