### PR TITLE
Make ada.txt not public in root

### DIFF
--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,0 +1,3 @@
+/ads.txt
+  Content-Type: text/plain
+  Cache-Control: public, max-age=3600

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -1,5 +1,6 @@
 name = "seasoned-frontend"
 compatibility_date = "2024-01-01"
+pages_build_output_dir = "dist"
 
 [observability.logs]
 enabled = true 


### PR DESCRIPTION
Configure Cloudflare Pages to correctly serve `ads.txt` by adding header rules and specifying the build output directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-af0a0e9d-7d1b-427b-b7a6-703cb5c77ee5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af0a0e9d-7d1b-427b-b7a6-703cb5c77ee5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

