### PR TITLE
Investigate clipper save failures

### DIFF
--- a/clipper/tests/test-comprehensive-coverage.js
+++ b/clipper/tests/test-comprehensive-coverage.js
@@ -33,6 +33,7 @@ const createMockEnv = (overrides = {}) => ({
     delete: async (key) => { return { success: true }; },
     ...(overrides.RECIPE_STORAGE || overrides.RECIPES || {})
   },
+  SAVE_WORKER_URL: 'https://recipe-save-worker.example.com',
   AI: {
     run: async (model, options) => {
       // Return properly formatted AI response

--- a/clipper/tests/test-integration.js
+++ b/clipper/tests/test-integration.js
@@ -33,6 +33,7 @@ const createMockEnv = (overrides = {}) => ({
     delete: async (key) => {},
     ...(overrides.RECIPE_STORAGE || overrides.RECIPES || {})
   },
+  SAVE_WORKER_URL: 'https://recipe-save-worker.example.com',
   AI: {
     run: async (model, options) => ({
       response: JSON.stringify({

--- a/clipper/tests/test-kv-only-behavior.js
+++ b/clipper/tests/test-kv-only-behavior.js
@@ -34,6 +34,7 @@ const createMockEnv = (kvOperations = {}) => ({
     delete: kvOperations.delete || (async (key) => {}),
     list: kvOperations.list || (async (options) => ({ keys: [], cursor: null, list_complete: true }))
   },
+  SAVE_WORKER_URL: 'https://recipe-save-worker.example.com',
   AI: {
     run: async (model, options) => ({
       output: [{


### PR DESCRIPTION
Fixes clipper save failures in tests by mocking `SAVE_WORKER_URL` in the test environment.

The `TypeError: recipeSaveResponse.json is not a function` occurred because `env.SAVE_WORKER_URL` was undefined in the test environment, causing `fetch` to fail and return an unexpected object instead of a `Response` object. Adding `SAVE_WORKER_URL` to `createMockEnv` resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a870bd0-73eb-4412-acfd-5b246ff93742">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a870bd0-73eb-4412-acfd-5b246ff93742">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

