### PR TITLE
Convert ingredient decimals to fractions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
-import { formatDuration, isValidUrl } from '../../shared/utility-functions.js'
+import { formatDuration, isValidUrl, formatIngredientAmount } from '../../shared/utility-functions.js'
 import VideoPopup from './components/VideoPopup.jsx'
 import Recommendations from './components/Recommendations.jsx'
 import SwipeableRecipeGrid from './components/SwipeableRecipeGrid.jsx'
@@ -2251,7 +2251,7 @@ function App() {
                             <h4>Ingredients ({(clippedRecipePreview.recipeIngredient || clippedRecipePreview.ingredients || []).length})</h4>
                             <ul className="recipe-preview-ingredients">
                               {(clippedRecipePreview.recipeIngredient || clippedRecipePreview.ingredients || []).map((ingredient, index) => (
-                                <li key={index}>{ingredient}</li>
+                                <li key={index}>{formatIngredientAmount(ingredient)}</li>
                               ))}
                             </ul>
                           </div>
@@ -2830,7 +2830,7 @@ function App() {
                   <h2>Ingredients</h2>
                   <ul className="ingredients-list">
                     {(selectedRecipe.recipeIngredient || selectedRecipe.ingredients || []).map((ingredient, index) => (
-                      <li key={index}>{ingredient}</li>
+                      <li key={index}>{formatIngredientAmount(ingredient)}</li>
                     ))}
                   </ul>
                 </div>

--- a/shared/utility-functions.js
+++ b/shared/utility-functions.js
@@ -66,6 +66,102 @@ export function formatDuration(duration) {
 }
 
 /**
+ * Convert a decimal number to a fraction string
+ * @param {number} decimal - Decimal number to convert
+ * @returns {string} Fraction string (e.g., "1/3")
+ */
+export function decimalToFraction(decimal) {
+  if (!decimal || isNaN(decimal)) return '';
+  
+  // Handle whole numbers
+  const whole = Math.floor(decimal);
+  const fractionalPart = decimal - whole;
+  
+  // If it's a whole number, return it as is
+  if (fractionalPart < 0.01) {
+    return whole.toString();
+  }
+  
+  // Common fractions mapping for better accuracy
+  const commonFractions = [
+    { decimal: 0.125, fraction: '1/8' },
+    { decimal: 0.25, fraction: '1/4' },
+    { decimal: 0.333, fraction: '1/3' },
+    { decimal: 0.375, fraction: '3/8' },
+    { decimal: 0.5, fraction: '1/2' },
+    { decimal: 0.625, fraction: '5/8' },
+    { decimal: 0.666, fraction: '2/3' },
+    { decimal: 0.75, fraction: '3/4' },
+    { decimal: 0.875, fraction: '7/8' }
+  ];
+  
+  // Check for common fractions (within tolerance)
+  for (const { decimal: commonDec, fraction } of commonFractions) {
+    if (Math.abs(fractionalPart - commonDec) < 0.01) {
+      return whole > 0 ? `${whole} ${fraction}` : fraction;
+    }
+  }
+  
+  // Calculate fraction using continued fractions algorithm
+  const tolerance = 0.01;
+  let numerator = 1;
+  let denominator = 1;
+  let previousNumerator = 0;
+  let previousDenominator = 1;
+  let currentValue = fractionalPart;
+  
+  for (let i = 0; i < 10; i++) {
+    const integerPart = Math.floor(currentValue);
+    const temp = numerator;
+    numerator = integerPart * numerator + previousNumerator;
+    previousNumerator = temp;
+    
+    const temp2 = denominator;
+    denominator = integerPart * denominator + previousDenominator;
+    previousDenominator = temp2;
+    
+    if (Math.abs(fractionalPart - numerator / denominator) < tolerance) {
+      break;
+    }
+    
+    currentValue = 1 / (currentValue - integerPart);
+  }
+  
+  // Format the result
+  if (whole > 0) {
+    return `${whole} ${numerator}/${denominator}`;
+  } else {
+    return `${numerator}/${denominator}`;
+  }
+}
+
+/**
+ * Format an ingredient string, converting decimals to fractions
+ * @param {string} ingredient - Ingredient string that may contain decimal amounts
+ * @returns {string} Formatted ingredient string with fractions
+ */
+export function formatIngredientAmount(ingredient) {
+  if (!ingredient || typeof ingredient !== 'string') return ingredient || '';
+  
+  // Regular expression to match decimal numbers with optional leading digits
+  // This will match patterns like "0.33333", "1.5", "2.25", etc.
+  const decimalPattern = /\b(\d+\.?\d*)\b/g;
+  
+  return ingredient.replace(decimalPattern, (match) => {
+    const decimal = parseFloat(match);
+    if (isNaN(decimal)) return match;
+    
+    // Only convert if it looks like it should be a fraction
+    // (has decimal places or is a common fraction value)
+    if (decimal % 1 === 0) {
+      return match; // Keep whole numbers as is
+    }
+    
+    return decimalToFraction(decimal);
+  });
+}
+
+/**
  * Check if a string is a valid URL
  * @param {string} string - String to validate as URL
  * @returns {boolean} True if valid URL, false otherwise


### PR DESCRIPTION
Convert decimal ingredient amounts to fractions for improved readability in recipes.

---
<a href="https://cursor.com/background-agent?bcId=bc-9258414a-cf6f-44d5-a309-7a7385aa1541">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9258414a-cf6f-44d5-a309-7a7385aa1541">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

