### PR TITLE
Fix differential coverage report on pull requests

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -35,6 +35,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch full history for diff coverage
+        
+    - name: Fetch base branch for diff coverage
+      if: github.event_name == 'pull_request'
+      run: |
+        git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
     
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -114,12 +119,31 @@ jobs:
         echo "### Differential Coverage Report" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
+        # Debug information
+        echo "Current branch: $(git branch --show-current)"
+        echo "Base ref: ${{ github.base_ref }}"
+        echo "Head ref: ${{ github.head_ref }}"
+        echo "Git log of last 5 commits:"
+        git log --oneline -5
+        echo "Available branches:"
+        git branch -a
+        
+        # Show the diff that will be analyzed
+        echo "Git diff summary:"
+        git diff --name-status origin/${{ github.base_ref }}...HEAD
+        
+        # Show coverage report structure for debugging
+        echo "Coverage report first few lines:"
+        head -20 coverage/lcov.info || echo "No coverage report found"
+        
         # Run diff-cover with lcov format and capture output
         echo "Running differential coverage analysis..."
+        # Note: diff-cover needs to be run from the same directory where tests were run
+        # to ensure paths match between git diff and coverage report
         diff-cover coverage/lcov.info \
           --compare-branch=origin/${{ github.base_ref }} \
           --fail-under=85 \
-          --diff-range-notation=.. 2>&1 | tee diff-coverage-output.txt || {
+          --diff-range-notation=... 2>&1 | tee diff-coverage-output.txt || {
           echo "::warning::New code changes have less than 85% coverage"
           echo "❌ **New code coverage is below the required 85% threshold**" >> $GITHUB_STEP_SUMMARY
           echo "diff_coverage_below_threshold=true" >> $GITHUB_OUTPUT

--- a/DIFFERENTIAL_COVERAGE_FIX_SUMMARY.md
+++ b/DIFFERENTIAL_COVERAGE_FIX_SUMMARY.md
@@ -1,0 +1,70 @@
+# Differential Coverage Report Fix Summary
+
+## Problem
+The differential coverage report on pull requests was showing "no code changes were made" despite actual code changes being present.
+
+## Root Causes
+1. **Branch fetching issue**: The base branch might not be properly available for comparison
+2. **Path resolution**: diff-cover needs to match paths between the git diff and the coverage report
+3. **Diff notation**: Using two dots (..) vs three dots (...) affects how git calculates the diff
+
+## Solution Implemented
+
+### 1. Explicit Base Branch Fetch
+Added a step to ensure the base branch is properly fetched:
+```yaml
+- name: Fetch base branch for diff coverage
+  if: github.event_name == 'pull_request'
+  run: |
+    git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+```
+
+### 2. Enhanced Debugging
+Added debugging output to help diagnose issues:
+- Current branch and ref information
+- Git log of recent commits
+- Available branches
+- Git diff summary
+- Coverage report structure
+
+### 3. Updated diff-cover Command
+Changed from:
+```bash
+diff-cover coverage/lcov.info \
+  --compare-branch=origin/${{ github.base_ref }} \
+  --fail-under=85 \
+  --diff-range-notation=..
+```
+
+To:
+```bash
+diff-cover coverage/lcov.info \
+  --compare-branch=origin/${{ github.base_ref }} \
+  --fail-under=85 \
+  --diff-range-notation=...
+```
+
+Key changes:
+- Changed `--diff-range-notation=..` to `--diff-range-notation=...` to use merge-base comparison
+- Removed `--src-roots=.` as it should work with default paths when run from the correct directory
+
+## Why This Fixes the Issue
+
+1. **Proper branch availability**: Explicitly fetching the base branch ensures it's available for comparison
+2. **Correct diff calculation**: Using three dots (...) compares against the merge-base, which is what you want for PRs
+3. **Better diagnostics**: The debug output will help identify any remaining path or coverage issues
+
+## Testing the Fix
+
+To verify the fix works:
+1. Create a new branch from staging
+2. Make changes to frontend JavaScript files
+3. Add or modify tests
+4. Create a pull request
+5. The differential coverage report should now show the actual coverage of changed lines
+
+## Additional Notes
+
+- The workflow already has `fetch-depth: 0` which fetches full history
+- Jest is configured to output lcov format which diff-cover can read
+- The coverage threshold for new code is set to 85%


### PR DESCRIPTION
Fix differential coverage report by ensuring the base branch is fetched and using the correct merge-base diff notation.

---
<a href="https://cursor.com/background-agent?bcId=bc-574edec4-b462-4568-8c76-99d3bdc7b0b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-574edec4-b462-4568-8c76-99d3bdc7b0b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

