### PR TITLE
Fix test environment variable configuration

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -32,11 +32,5 @@ module.exports = {
   ],
   transformIgnorePatterns: [
     'node_modules/(?!(starback)/)'
-  ],
-  globals: {
-    'import.meta.env': {
-      VITE_API_URL: 'https://test-api.example.com',
-      VITE_CLIPPER_API_URL: 'https://test-clipper-api.example.com'
-    }
-  }
+  ]
 };

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -50,7 +50,23 @@ beforeEach(() => {
   }
 });
 
-// Mock import.meta.env -> process.env for tests
-process.env.VITE_API_URL = 'https://test-api.example.com';
-process.env.VITE_CLIPPER_API_URL = 'https://test-clipper-api.example.com';
-process.env.VITE_SEARCH_DB_URL = 'https://test-search-db.example.com';
+// Setup test environment variables
+import { setupTestEnvironment } from '../../shared/test-env-setup.js';
+
+// Load environment variables from .env.test
+const testEnv = setupTestEnvironment();
+
+// Mock import.meta.env for Vite
+global.import = {
+  meta: {
+    env: {
+      MODE: 'test',
+      ...Object.keys(testEnv).reduce((acc, key) => {
+        if (key.startsWith('VITE_')) {
+          acc[key] = testEnv[key];
+        }
+        return acc;
+      }, {})
+    }
+  }
+};

--- a/recipe-save-worker/tests/worker.test.js
+++ b/recipe-save-worker/tests/worker.test.js
@@ -2,6 +2,7 @@
 // Mock environment for testing
 
 import worker, { RecipeSaver } from '../src/index.js';
+import { createMockWorkerEnv, resetMockWorkerEnv } from '../../shared/test-env-setup.js';
 
 // Test utilities
 const describe = (name, fn) => {

--- a/shared/test-env-setup.js
+++ b/shared/test-env-setup.js
@@ -1,0 +1,165 @@
+/**
+ * Shared test environment setup utility
+ * Loads environment variables from .env.test file for consistent test configuration
+ */
+
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+// Get the directory of the current module
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Load environment variables from .env.test file
+ * @param {string} envPath - Optional custom path to .env file
+ * @returns {Object} Parsed environment variables
+ */
+export function loadTestEnv(envPath = null) {
+  const defaultPath = join(__dirname, '..', '.env.test');
+  const path = envPath || defaultPath;
+  
+  try {
+    const envContent = readFileSync(path, 'utf8');
+    const envVars = {};
+    
+    envContent.split('\n').forEach(line => {
+      // Skip comments and empty lines
+      if (line.trim() === '' || line.trim().startsWith('#')) {
+        return;
+      }
+      
+      const [key, ...valueParts] = line.split('=');
+      if (key) {
+        const value = valueParts.join('=').trim();
+        envVars[key.trim()] = value;
+      }
+    });
+    
+    return envVars;
+  } catch (error) {
+    console.warn(`Warning: Could not load test environment from ${path}:`, error.message);
+    return {};
+  }
+}
+
+/**
+ * Setup test environment variables
+ * Merges loaded env vars with existing process.env
+ */
+export function setupTestEnvironment() {
+  const testEnv = loadTestEnv();
+  
+  // Merge with process.env
+  Object.keys(testEnv).forEach(key => {
+    if (!process.env[key]) {
+      process.env[key] = testEnv[key];
+    }
+  });
+  
+  // For frontend tests, also set up import.meta.env mock
+  if (global.import && global.import.meta) {
+    global.import.meta.env = {
+      ...global.import.meta.env,
+      ...testEnv
+    };
+  }
+  
+  return testEnv;
+}
+
+/**
+ * Create a mock Cloudflare Worker environment
+ * @param {Object} overrides - Optional overrides for specific bindings
+ * @returns {Object} Mock environment object for Cloudflare Workers
+ */
+export function createMockWorkerEnv(overrides = {}) {
+  const testEnv = loadTestEnv();
+  
+  return {
+    // Environment variables from wrangler.toml [vars]
+    SEARCH_DB_URL: testEnv.SEARCH_DB_URL,
+    IMAGE_DOMAIN: testEnv.IMAGE_DOMAIN,
+    FDC_API_KEY: testEnv.FDC_API_KEY,
+    SAVE_WORKER_URL: testEnv.SAVE_WORKER_URL,
+    GPT_API_URL: testEnv.GPT_API_URL,
+    
+    // KV Namespace binding
+    RECIPE_STORAGE: {
+      get: jest?.fn() || (() => Promise.resolve(null)),
+      put: jest?.fn() || (() => Promise.resolve()),
+      delete: jest?.fn() || (() => Promise.resolve()),
+      list: jest?.fn() || (() => Promise.resolve({ keys: [] }))
+    },
+    
+    // R2 Bucket binding
+    RECIPE_IMAGES: {
+      get: jest?.fn() || (() => Promise.resolve(null)),
+      put: jest?.fn() || (() => Promise.resolve()),
+      delete: jest?.fn() || (() => Promise.resolve()),
+      list: jest?.fn() || (() => Promise.resolve({ objects: [] }))
+    },
+    
+    // D1 Database binding
+    SEARCH_DB: {
+      prepare: jest?.fn() || (() => ({
+        bind: () => ({
+          all: () => Promise.resolve({ results: [] }),
+          first: () => Promise.resolve(null),
+          run: () => Promise.resolve({ success: true })
+        })
+      }))
+    },
+    
+    // Durable Object binding
+    RECIPE_SAVER: {
+      idFromName: jest?.fn() || ((name) => ({ toString: () => `id-${name}` })),
+      get: jest?.fn() || ((id) => ({
+        fetch: () => Promise.resolve(new Response('{}', { status: 200 }))
+      }))
+    },
+    
+    // AI binding for Cloudflare Workers AI
+    AI: {
+      run: jest?.fn() || (() => Promise.resolve({ response: 'Mock AI response' }))
+    },
+    
+    // Analytics Engine binding
+    ANALYTICS: {
+      writeDataPoint: jest?.fn() || (() => {})
+    },
+    
+    // Apply any overrides
+    ...overrides
+  };
+}
+
+/**
+ * Reset all mock functions in a worker environment
+ * @param {Object} env - The mock worker environment to reset
+ */
+export function resetMockWorkerEnv(env) {
+  // Reset KV mocks
+  if (env.RECIPE_STORAGE) {
+    Object.values(env.RECIPE_STORAGE).forEach(fn => {
+      if (fn.mockReset) fn.mockReset();
+    });
+  }
+  
+  // Reset R2 mocks
+  if (env.RECIPE_IMAGES) {
+    Object.values(env.RECIPE_IMAGES).forEach(fn => {
+      if (fn.mockReset) fn.mockReset();
+    });
+  }
+  
+  // Reset other mocks
+  ['SEARCH_DB', 'RECIPE_SAVER', 'AI', 'ANALYTICS'].forEach(binding => {
+    if (env[binding] && typeof env[binding] === 'object') {
+      Object.values(env[binding]).forEach(fn => {
+        if (fn && fn.mockReset) fn.mockReset();
+      });
+    }
+  });
+}


### PR DESCRIPTION
Standardize environment variable configuration across test setups for consistency and proper mocking.

Previously, frontend tests had inconsistent environment variable handling (`process.env` vs `import.meta.env`), worker tests lacked proper environment mocking, and there was no centralized `.env` file for test configurations. This PR introduces a shared utility to centralize environment variable loading from `.env.test`, correctly mocks `import.meta.env` for frontend tests, and provides a consistent way to create mock worker environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-89ad1344-93e5-45de-abd4-45c93c4e80bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89ad1344-93e5-45de-abd4-45c93c4e80bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

