### PR TITLE
Update cursor rules to exclude files

### DIFF
--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -22,19 +22,25 @@ Each rule is stored as an individual MDC (Markdown with metadata) file containin
 - **Purpose**: Maintains consistent code quality
 - Covers: Error handling, documentation, commit standards
 
-### 3. Automated Workflows (`automated-workflows.mdc`)
+### 3. Pull Request Guidelines (`pull-request-guidelines.mdc`)
+- **Type**: `always` - Applied to all operations
+- **Priority**: 1
+- **Purpose**: Keeps PRs focused on production code only
+- Covers: Excludes .md files, temporary scripts, one-time operations
+
+### 4. Automated Workflows (`automated-workflows.mdc`)
 - **Type**: `agent-requested` - AI decides when to apply
 - **Priority**: 3
 - **Purpose**: Suggests CI/CD and testing improvements
 - Covers: GitHub Actions, testing strategies
 
-### 4. Release Workflow (`release-workflow.mdc`)
+### 5. Release Workflow (`release-workflow.mdc`)
 - **Type**: `always` - Applied to all operations
 - **Priority**: 1
 - **Purpose**: Ensures proper release process from staging to production
 - Covers: Rebasing, merging, conflict resolution, rollback procedures
 
-### 5. Cloudflare Worker Setup (`cloudflare-worker-setup.mdc`)
+### 6. Cloudflare Worker Setup (`cloudflare-worker-setup.mdc`)
 - **Type**: `agent-requested` - AI decides when to apply
 - **Priority**: 2
 - **Purpose**: Guidelines for setting up new Cloudflare Workers with proper structure

--- a/.cursor/rules/pull-request-guidelines.mdc
+++ b/.cursor/rules/pull-request-guidelines.mdc
@@ -1,0 +1,63 @@
+## Pull Request Best Practices
+
+When creating pull requests, follow these guidelines to maintain a clean and focused codebase:
+
+### Files to Exclude from Pull Requests
+
+#### 1. Documentation Files
+- **NEVER** include `.md` (Markdown) files in pull requests unless they are:
+  - Critical API documentation that is part of the codebase
+  - README files specifically requested by the project maintainers
+  - Part of the application's functionality (e.g., content served by the app)
+
+#### 2. One-Time Operation Scripts
+- **EXCLUDE** all temporary or one-time scripts such as:
+  - Data migration scripts that have already been run
+  - Database seed scripts for development
+  - Temporary debugging or analysis scripts
+  - Quick fix scripts that won't be reused
+  - Personal utility scripts
+
+### What Should Be in a Pull Request
+
+Focus your pull requests on:
+- Source code changes that implement features or fix bugs
+- Configuration files necessary for the application
+- Test files that validate the changes
+- Dependencies updates in package files
+- CI/CD workflow updates (only if part of the feature)
+
+### Handling Temporary Files
+
+If you need temporary scripts or documentation during development:
+1. Add them to `.gitignore` before creating them
+2. Use a dedicated `temp/` or `scripts/temp/` directory that's gitignored
+3. Document their purpose in PR comments if they're needed for review
+4. Delete them before finalizing the PR
+
+### Documentation Strategy
+
+Instead of adding .md files to PRs:
+1. Use PR description to document changes thoroughly
+2. Add inline code comments for complex logic
+3. Update existing documentation in separate PRs
+4. Use commit messages to explain the "why" behind changes
+
+### Pre-PR Checklist
+
+Before creating a pull request:
+- [ ] Remove all `.md` files unless explicitly required
+- [ ] Delete one-time scripts and temporary files
+- [ ] Ensure `.gitignore` excludes temporary directories
+- [ ] Verify only production code is included
+- [ ] Check that no debug logs or personal notes are committed
+
+### Exception Process
+
+If you absolutely must include documentation or scripts:
+1. Justify in the PR description why it's necessary
+2. Get explicit approval from maintainers
+3. Ensure they're placed in appropriate directories
+4. Consider if they should be in a separate PR
+
+Remember: **Keep PRs focused on the code that will run in production!**

--- a/.cursorrules
+++ b/.cursorrules
@@ -7,8 +7,9 @@ This project uses modular rules stored in `.cursor/rules/`. The following rules 
 1. **Testing and Deployment Workflow** - Ensures proper testing and deployment practices
 2. **Code Quality Standards** - Maintains consistent code quality  
 3. **Release Workflow** - Guides the release process from staging to production
-4. **Automated Workflows** (on-demand) - Suggests CI/CD and testing improvements
-5. **Cloudflare Worker Setup** (on-demand) - Guidelines for setting up new Cloudflare Workers
+4. **Pull Request Guidelines** - Keeps PRs focused on production code only
+5. **Automated Workflows** (on-demand) - Suggests CI/CD and testing improvements
+6. **Cloudflare Worker Setup** (on-demand) - Guidelines for setting up new Cloudflare Workers
 
 ## Key Guidelines
 
@@ -23,5 +24,11 @@ This project uses modular rules stored in `.cursor/rules/`. The following rules 
 - Test thoroughly on staging before production release
 - Document significant changes and decisions
 - Follow semantic versioning for releases
+
+### Pull Request Guidelines
+- Never include .md files unless explicitly required
+- Exclude one-time operation scripts and temporary files
+- Keep PRs focused on production code only
+- Use PR descriptions for documentation instead of adding .md files
 
 For detailed rules, see the individual `.mdc` files in `.cursor/rules/`.


### PR DESCRIPTION
Introduce new cursor rules to prevent `.md` files and one-time scripts in pull requests, ensuring PRs remain focused on production code.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cedb9db-28a6-41a9-9960-b6921878ee0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1cedb9db-28a6-41a9-9960-b6921878ee0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

