### PR TITLE
Add recipe view endpoint without saving

### DIFF
--- a/recipe-view-worker/src/index.js
+++ b/recipe-view-worker/src/index.js
@@ -7,7 +7,7 @@ export default {
     // CORS headers
     const corsHeaders = {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type'
     };
 
@@ -25,6 +25,65 @@ export default {
           'Content-Type': 'text/html;charset=UTF-8'
         }
       });
+    }
+    
+    // Handle POST /recipe/preview - Preview recipe without saving
+    if (url.pathname === '/recipe/preview' && request.method === 'POST') {
+      try {
+        // Parse the request body
+        const contentType = request.headers.get('content-type') || '';
+        if (!contentType.includes('application/json')) {
+          return new Response(JSON.stringify({ 
+            error: 'Content-Type must be application/json' 
+          }), {
+            status: 400,
+            headers: {
+              ...corsHeaders,
+              'Content-Type': 'application/json'
+            }
+          });
+        }
+
+        const requestBody = await request.json();
+        
+        // Extract recipe data - support both direct recipe data and wrapped in 'data' property
+        const recipeData = requestBody && requestBody.data ? requestBody.data : requestBody;
+        
+        // Validate that we have some recipe data
+        if (!recipeData || typeof recipeData !== 'object') {
+          return new Response(JSON.stringify({ 
+            error: 'Invalid recipe data' 
+          }), {
+            status: 400,
+            headers: {
+              ...corsHeaders,
+              'Content-Type': 'application/json'
+            }
+          });
+        }
+
+        // Generate HTML page from the recipe data
+        const html = generateRecipeHTML(recipeData);
+        
+        return new Response(html, {
+          headers: {
+            ...corsHeaders,
+            'Content-Type': 'text/html;charset=UTF-8'
+          }
+        });
+      } catch (error) {
+        console.error('Error processing recipe preview:', error);
+        return new Response(JSON.stringify({ 
+          error: 'Failed to process recipe data',
+          details: error.message 
+        }), {
+          status: 500,
+          headers: {
+            ...corsHeaders,
+            'Content-Type': 'application/json'
+          }
+        });
+      }
     }
     
     // Match /recipe/:id pattern
@@ -174,6 +233,17 @@ function generateHomePage() {
     </div>
     <div class="example">
       Example: /recipe/abc123def456
+    </div>
+  </div>
+
+  <div class="endpoint">
+    <span class="method" style="background: #27ae60;">POST</span> <span class="path">/recipe/preview</span>
+    <div class="description">
+      Preview a recipe without saving. Send recipe JSON-LD data in the request body.
+    </div>
+    <div class="example">
+      Content-Type: application/json<br>
+      Body: { "name": "Recipe Name", "ingredients": [...], ... }
     </div>
   </div>
   


### PR DESCRIPTION
Add a `/recipe/preview` POST endpoint to the recipe view worker to display recipe JSON-LD data without persistence.

---
<a href="https://cursor.com/background-agent?bcId=bc-e46c05ae-5389-4b23-9848-8631f51a17f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e46c05ae-5389-4b23-9848-8631f51a17f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

