### PR TITLE
Update share recipe link to view worker url

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2860,12 +2860,9 @@ function App() {
                 if (RECIPE_VIEW_URL && selectedRecipe.id) {
                   // Use the recipe view worker for a proper shareable page
                   shareableUrl = `${RECIPE_VIEW_URL}/recipe/${selectedRecipe.id}`;
-                } else if (selectedRecipe.source_url) {
-                  // Fallback to original recipe URL if available
-                  shareableUrl = selectedRecipe.source_url;
                 } else {
                   // No shareable URL available
-                  alert('This recipe cannot be shared at this time. Please ensure it has been saved.');
+                  alert('This recipe cannot be shared at this time. Please ensure the recipe has been saved and the recipe view service is configured.');
                   setShowSharePanel(false);
                   return;
                 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2861,8 +2861,7 @@ function App() {
                   // Use the recipe view worker for a proper shareable page
                   shareableUrl = `${RECIPE_VIEW_URL}/recipe/${selectedRecipe.id}`;
                 } else {
-                  // No shareable URL available
-                  alert('This recipe cannot be shared at this time. Please ensure the recipe has been saved and the recipe view service is configured.');
+                  // No shareable URL available - silently close the share panel
                   setShowSharePanel(false);
                   return;
                 }


### PR DESCRIPTION
Update the share recipe link to always share the recipe view worker URL instead of falling back to the source URL.

This ensures that a properly formatted, shareable recipe page is always used when sharing, rather than just linking to the original source URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-987ab59f-eea9-4c56-a6ef-e68d30d01253">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-987ab59f-eea9-4c56-a6ef-e68d30d01253">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

