### PR TITLE
Change timer button icons to white

### DIFF
--- a/frontend/public/pause.svg
+++ b/frontend/public/pause.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="6" y="4" width="4" height="16"/>
+  <rect x="14" y="4" width="4" height="16"/>
+</svg>

--- a/frontend/public/play.svg
+++ b/frontend/public/play.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="5 3 19 12 5 21"/>
+</svg>

--- a/frontend/public/stop.svg
+++ b/frontend/public/stop.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="6" y="6" width="12" height="12"/>
+</svg>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3141,14 +3141,18 @@ function App() {
                     }}
                     title={floatingTimer.isRunning ? "Pause timer" : "Start timer"}
                   >
-                    {floatingTimer.isRunning ? "⏸️" : "▶️"}
+                    {floatingTimer.isRunning ? (
+                      <img src="/pause.svg" alt="Pause" className="timer-icon" />
+                    ) : (
+                      <img src="/play.svg" alt="Play" className="timer-icon" />
+                    )}
                   </button>
                   <button 
                     className="header-timer-stop-btn"
                     onClick={() => stopTimer(floatingTimer.id)}
                     title="Stop timer"
                   >
-                    ⏹️
+                    <img src="/stop.svg" alt="Stop" className="timer-icon" />
                   </button>
                   <button 
                     className="header-timer-dismiss"

--- a/frontend/src/styles/timer-button-update.scss
+++ b/frontend/src/styles/timer-button-update.scss
@@ -158,6 +158,14 @@
   -webkit-backdrop-filter: blur(10px);
 }
 
+/* Timer icon styling for white icons */
+.timer-icon {
+  width: 16px;
+  height: 16px;
+  filter: brightness(0) invert(1); /* Make the icon white */
+  display: block;
+}
+
 .header-timer-control-btn:hover,
 .header-timer-stop-btn:hover,
 .header-timer-dismiss:hover {
@@ -342,6 +350,11 @@
     font-size: 12px;
   }
   
+  .timer-icon {
+    width: 14px;
+    height: 14px;
+  }
+  
   .nutrition-slide-right {
     transform: translateX(100px);
   }
@@ -390,5 +403,10 @@
   
   .nutrition-slide-right {
     transform: translateX(110px);
+  }
+  
+  .timer-icon {
+    width: 15px;
+    height: 15px;
   }
 }


### PR DESCRIPTION
Replace timer popup pause and stop button emojis with white SVG icons to achieve consistent white iconography.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9798385-4358-497f-948d-2f30e7803572">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e9798385-4358-497f-948d-2f30e7803572">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

