### PR TITLE
Simplify recipe timer display

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -126,42 +126,36 @@ function App() {
       return text;
     }
     
-    // Return the full text followed by timer buttons
+    // Only take the first timer if multiple are found
+    const firstTimer = timers[0];
+    
+    // Return the full text followed by timer button
     return (
       <div className="instruction-with-timers">
         <div className="instruction-text">{text}</div>
         <div className="timer-buttons-container">
-                      {timers.map((timer, index) => {
-              const timerId = `timer-${timer.index}-${index}`;
-              const activeTimer = activeTimers.get(timerId);
-              const isFloatingActive = floatingTimer && floatingTimer.id === timerId;
-              
-              // Show disabled button when timer is active (either inline or floating)
-              return (
-                <button 
-                  key={timerId}
-                  className={`timer-button-inline ${activeTimer ? 'timer-button-disabled' : ''}`}
-                  title={activeTimer ? `Timer active: ${activeTimer.timeText}` : `Set timer for ${timer.text}`}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    if (!activeTimer) {
-                      startNewTimer(timerId, timer.text);
-                    }
-                  }}
-                  disabled={activeTimer}
-                >
-                  <img 
-                    src="/timer.svg" 
-                    alt="Timer" 
-                    className="timer-icon-inline"
-                  />
-                  <span className="timer-text">
-                    {activeTimer ? `Timer: ${formatTime(activeTimer.remainingSeconds)}` : `Set timer for ${timer.text}`}
-                  </span>
-                </button>
-              );
-            })}
+          <button 
+            key={`timer-${firstTimer.index}-0`}
+            className={`timer-button-inline ${activeTimers.get(`timer-${firstTimer.index}-0`) ? 'timer-button-disabled' : ''}`}
+            title={activeTimers.get(`timer-${firstTimer.index}-0`) ? `Timer active: ${activeTimers.get(`timer-${firstTimer.index}-0`).timeText}` : `Set timer for ${firstTimer.text}`}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (!activeTimers.get(`timer-${firstTimer.index}-0`)) {
+                startNewTimer(`timer-${firstTimer.index}-0`, firstTimer.text);
+              }
+            }}
+            disabled={activeTimers.get(`timer-${firstTimer.index}-0`)}
+          >
+            <img 
+              src="/timer.svg" 
+              alt="Timer" 
+              className="timer-icon-inline"
+            />
+            <span className="timer-text">
+              {activeTimers.get(`timer-${firstTimer.index}-0`) ? `Timer: ${formatTime(activeTimers.get(`timer-${firstTimer.index}-0`).remainingSeconds)}` : `Set timer for ${firstTimer.text}`}
+            </span>
+          </button>
         </div>
       </div>
     );
@@ -169,22 +163,22 @@ function App() {
 
   // Timer utility functions
   const parseTimeString = (timeString) => {
-    // Handle ranges like "5-10 minutes" by taking the average
+    // Handle ranges like "5-10 minutes" by taking the smaller time
     const rangeMatch = timeString.match(/(\d+)\s*[-–—]\s*(\d+)/);
     if (rangeMatch) {
       const min = parseInt(rangeMatch[1]);
       const max = parseInt(rangeMatch[2]);
-      const avg = Math.round((min + max) / 2);
-      timeString = timeString.replace(/\d+\s*[-–—]\s*\d+/, avg.toString());
+      const smaller = Math.min(min, max);
+      timeString = timeString.replace(/\d+\s*[-–—]\s*\d+/, smaller.toString());
     }
     
-    // Handle "X to Y" format
+    // Handle "X to Y" format by taking the smaller time
     const toMatch = timeString.match(/(\d+)\s+to\s+(\d+)/);
     if (toMatch) {
       const min = parseInt(toMatch[1]);
       const max = parseInt(toMatch[2]);
-      const avg = Math.round((min + max) / 2);
-      timeString = timeString.replace(/\d+\s+to\s+\d+/, avg.toString());
+      const smaller = Math.min(min, max);
+      timeString = timeString.replace(/\d+\s+to\s+\d+/, smaller.toString());
     }
     
     // Extract number and unit

--- a/frontend/src/__tests__/TimerFunctionality.test.jsx
+++ b/frontend/src/__tests__/TimerFunctionality.test.jsx
@@ -16,22 +16,22 @@ describe('Timer Functionality', () => {
     it('should parse time strings correctly', () => {
       // Test parseTimeString function
       const parseTimeString = (timeString) => {
-        // Handle ranges like "5-10 minutes" by taking the average
+        // Handle ranges like "5-10 minutes" by taking the smaller time
         const rangeMatch = timeString.match(/(\d+)\s*[-–—]\s*(\d+)/);
         if (rangeMatch) {
           const min = parseInt(rangeMatch[1]);
           const max = parseInt(rangeMatch[2]);
-          const avg = Math.round((min + max) / 2);
-          timeString = timeString.replace(/\d+\s*[-–—]\s*\d+/, avg.toString());
+          const smaller = Math.min(min, max);
+          timeString = timeString.replace(/\d+\s*[-–—]\s*\d+/, smaller.toString());
         }
         
-        // Handle "X to Y" format
+        // Handle "X to Y" format by taking the smaller time
         const toMatch = timeString.match(/(\d+)\s+to\s+(\d+)/);
         if (toMatch) {
           const min = parseInt(toMatch[1]);
           const max = parseInt(toMatch[2]);
-          const avg = Math.round((min + max) / 2);
-          timeString = timeString.replace(/\d+\s+to\s+\d+/, avg.toString());
+          const smaller = Math.min(min, max);
+          timeString = timeString.replace(/\d+\s+to\s+\d+/, smaller.toString());
         }
         
         // Extract number and unit
@@ -69,8 +69,8 @@ describe('Timer Functionality', () => {
       expect(parseTimeString('5 minutes')).toBe(300); // 5 minutes = 300 seconds
       expect(parseTimeString('1 hour')).toBe(3600); // 1 hour = 3600 seconds
       expect(parseTimeString('30 seconds')).toBe(30); // 30 seconds = 30 seconds
-      expect(parseTimeString('5-10 minutes')).toBe(480); // Average of 5-10 = 7.5 minutes = 480 seconds (7.5 * 60 = 450, but the function rounds to 8 minutes = 480)
-      expect(parseTimeString('1 to 2 hours')).toBe(7200); // Average of 1-2 = 1.5 hours = 7200 seconds (1.5 * 3600 = 5400, but the function rounds to 2 hours = 7200)
+      expect(parseTimeString('5-10 minutes')).toBe(300); // Smaller of 5-10 = 5 minutes = 300 seconds
+      expect(parseTimeString('1 to 2 hours')).toBe(3600); // Smaller of 1-2 = 1 hour = 3600 seconds
       
       // Test time formatting
       expect(formatTime(65)).toBe('1:05'); // 1 minute 5 seconds


### PR DESCRIPTION
Refactor recipe timer display logic to show only the first timer per step and the minimum value for time ranges.

---
<a href="https://cursor.com/background-agent?bcId=bc-90fa881e-2954-40e9-a473-5a2cb5cd5b30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-90fa881e-2954-40e9-a473-5a2cb5cd5b30">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

