### PR TITLE
Start timer at time range start

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -169,13 +169,12 @@ function App() {
 
   // Timer utility functions
   const parseTimeString = (timeString) => {
-    // Handle ranges like "5-10 minutes" by taking the average
+    // Handle ranges like "5-10 minutes" by using the lower value
     const rangeMatch = timeString.match(/(\d+)\s*[-–—]\s*(\d+)/);
     if (rangeMatch) {
       const min = parseInt(rangeMatch[1]);
       const max = parseInt(rangeMatch[2]);
-      const avg = Math.round((min + max) / 2);
-      timeString = timeString.replace(/\d+\s*[-–—]\s*\d+/, avg.toString());
+      timeString = timeString.replace(/\d+\s*[-–—]\s*\d+/, min.toString());
     }
     
     // Handle "X to Y" format
@@ -183,8 +182,7 @@ function App() {
     if (toMatch) {
       const min = parseInt(toMatch[1]);
       const max = parseInt(toMatch[2]);
-      const avg = Math.round((min + max) / 2);
-      timeString = timeString.replace(/\d+\s+to\s+\d+/, avg.toString());
+      timeString = timeString.replace(/\d+\s+to\s+\d+/, min.toString());
     }
     
     // Extract number and unit

--- a/frontend/src/__tests__/TimerFunctionality.test.jsx
+++ b/frontend/src/__tests__/TimerFunctionality.test.jsx
@@ -16,13 +16,12 @@ describe('Timer Functionality', () => {
     it('should parse time strings correctly', () => {
       // Test parseTimeString function
       const parseTimeString = (timeString) => {
-        // Handle ranges like "5-10 minutes" by taking the average
+        // Handle ranges like "5-10 minutes" by using the lower value
         const rangeMatch = timeString.match(/(\d+)\s*[-–—]\s*(\d+)/);
         if (rangeMatch) {
           const min = parseInt(rangeMatch[1]);
           const max = parseInt(rangeMatch[2]);
-          const avg = Math.round((min + max) / 2);
-          timeString = timeString.replace(/\d+\s*[-–—]\s*\d+/, avg.toString());
+          timeString = timeString.replace(/\d+\s*[-–—]\s*\d+/, min.toString());
         }
         
         // Handle "X to Y" format
@@ -30,8 +29,7 @@ describe('Timer Functionality', () => {
         if (toMatch) {
           const min = parseInt(toMatch[1]);
           const max = parseInt(toMatch[2]);
-          const avg = Math.round((min + max) / 2);
-          timeString = timeString.replace(/\d+\s+to\s+\d+/, avg.toString());
+          timeString = timeString.replace(/\d+\s+to\s+\d+/, min.toString());
         }
         
         // Extract number and unit
@@ -69,8 +67,8 @@ describe('Timer Functionality', () => {
       expect(parseTimeString('5 minutes')).toBe(300); // 5 minutes = 300 seconds
       expect(parseTimeString('1 hour')).toBe(3600); // 1 hour = 3600 seconds
       expect(parseTimeString('30 seconds')).toBe(30); // 30 seconds = 30 seconds
-      expect(parseTimeString('5-10 minutes')).toBe(480); // Average of 5-10 = 7.5 minutes = 480 seconds (7.5 * 60 = 450, but the function rounds to 8 minutes = 480)
-      expect(parseTimeString('1 to 2 hours')).toBe(7200); // Average of 1-2 = 1.5 hours = 7200 seconds (1.5 * 3600 = 5400, but the function rounds to 2 hours = 7200)
+      expect(parseTimeString('5-10 minutes')).toBe(300); // Lower value of 5-10 = 5 minutes = 300 seconds
+      expect(parseTimeString('1 to 2 hours')).toBe(3600); // Lower value of 1-2 = 1 hour = 3600 seconds
       
       // Test time formatting
       expect(formatTime(65)).toBe('1:05'); // 1 minute 5 seconds

--- a/recipe-view-worker/timer-demo.html
+++ b/recipe-view-worker/timer-demo.html
@@ -39,7 +39,7 @@
         <li>✅ Play/pause functionality</li>
         <li>✅ Stop button to cancel timer</li>
         <li>✅ Audio notification when timer completes</li>
-        <li>✅ Supports ranges (uses maximum time)</li>
+        <li>✅ Supports ranges (uses lower time value)</li>
         <li>✅ Multiple timers can run simultaneously</li>
     </ul>
 </body>


### PR DESCRIPTION
Start timers at the lower value for time ranges (e.g., "5-10 minutes" starts at 5 minutes) instead of the average, providing users with more control.

---
<a href="https://cursor.com/background-agent?bcId=bc-5762b36a-fae4-4b81-ad64-014a8ec93134">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5762b36a-fae4-4b81-ad64-014a8ec93134">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

