### PR TITLE
Remove 'Serves' line from recipe formatting

### DIFF
--- a/recipe-generation-worker/src/handlers/generate-handler.js
+++ b/recipe-generation-worker/src/handlers/generate-handler.js
@@ -530,9 +530,6 @@ function formatFullRecipeContext(recipeData) {
   // Times and servings
   if (recipeData.prepTime) parts.push(`Prep time: ${recipeData.prepTime}`);
   if (recipeData.cookTime) parts.push(`Cook time: ${recipeData.cookTime}`);
-  if (recipeData.recipeYield || recipeData.yield) {
-    parts.push(`Serves: ${recipeData.recipeYield || recipeData.yield}`);
-  }
 
   return parts.join('\n');
 }


### PR DESCRIPTION
This PR removes the 'Serves' line from the recipe formatting in the generate-handler to clean up the output format. All tests are passing and the change has been verified.