### PR TITLE
Make recipe description white in full screen

### DIFF
--- a/frontend/src/styles/recipe-fullscreen.scss
+++ b/frontend/src/styles/recipe-fullscreen.scss
@@ -89,6 +89,21 @@
   filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.6));
 }
 
+/* Recipe Description */
+.recipe-description {
+  color: white;
+  font-size: 1.2em;
+  font-weight: 400;
+  margin: 0 auto;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  padding: 10px 20px;
+  display: block;
+  max-width: 800px;
+  line-height: 1.5;
+  text-align: center;
+  opacity: 0.9;
+}
+
 /* Recipe Timing Info */
 .recipe-timing-info {
   display: flex;


### PR DESCRIPTION
Add styling to make the recipe description text white in full screen view for improved readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-df8633c1-1a2b-483c-9682-9405fdf83d11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df8633c1-1a2b-483c-9682-9405fdf83d11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

