### PR TITLE
Investigate background image readjustment on scroll

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -958,6 +958,12 @@ function App() {
     let scrollY = 0;
     
     const updateScrollEffects = () => {
+      // Skip scroll effects if we're in fullscreen mode
+      if (selectedRecipe) {
+        ticking = false;
+        return;
+      }
+      
       if (!recipeGridRef.current) {
         ticking = false;
         return;
@@ -1009,8 +1015,21 @@ function App() {
     window.addEventListener('scroll', handleScroll, { passive: true });
     handleScroll(); // Initial call
     
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [recipes]);
+    // Cleanup function to remove scroll effects
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      
+      // Reset any lingering reflection effects on recipe cards
+      if (recipeGridRef.current) {
+        const cards = recipeGridRef.current.querySelectorAll('.recipe-card');
+        cards.forEach((card) => {
+          card.style.removeProperty('--glass-intensity');
+          card.style.removeProperty('--reflection-offset');
+          card.style.removeProperty('--card-rotation');
+        });
+      }
+    };
+  }, [recipes, selectedRecipe]);
 
   // Scroll-based fade effect for recipe fullscreen title
   useEffect(() => {
@@ -2187,6 +2206,16 @@ function App() {
       // For AI cards that haven't been generated yet, generate the recipe first
       handleAiCardRecipeGeneration(recipe);
       return;
+    }
+
+    // Reset any lingering reflection effects before opening fullscreen
+    if (recipeGridRef.current) {
+      const cards = recipeGridRef.current.querySelectorAll('.recipe-card');
+      cards.forEach((card) => {
+        card.style.removeProperty('--glass-intensity');
+        card.style.removeProperty('--reflection-offset');
+        card.style.removeProperty('--card-rotation');
+      });
     }
 
     // For regular recipes or already generated AI recipes, open immediately

--- a/frontend/src/styles/recipe-fullscreen.scss
+++ b/frontend/src/styles/recipe-fullscreen.scss
@@ -546,6 +546,11 @@
   right: 0;
   bottom: 0;
   z-index: -1;
+  /* Ensure background container stays stable */
+  transform: none !important;
+  will-change: auto;
+  backface-visibility: visible;
+  -webkit-backface-visibility: visible;
 }
 
 .recipe-full-background::after {
@@ -564,6 +569,11 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  /* Ensure background image stays stable and doesn't get affected by transforms */
+  transform: none !important;
+  will-change: auto;
+  backface-visibility: visible;
+  -webkit-backface-visibility: visible;
 }
 
 .recipe-full-background-placeholder {

--- a/frontend/src/styles/recipe-fullscreen.scss
+++ b/frontend/src/styles/recipe-fullscreen.scss
@@ -11,10 +11,13 @@
   background: transparent;
   z-index: 3000;
   overflow-y: auto;
-  transition: background 0.3s ease;
+  overflow-x: hidden;
   color: white;
   display: flex;
   flex-direction: column;
+  /* Ensure stable rendering */
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
 }
 
 /* Recipe Top Header */
@@ -545,12 +548,27 @@
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: -1;
-  /* Ensure background container stays stable */
+  z-index: -2;
+  /* Ensure background container stays stable and isolated from scroll effects */
   transform: none !important;
   will-change: auto;
   backface-visibility: visible;
   -webkit-backface-visibility: visible;
+  /* Additional isolation properties */
+  isolation: isolate;
+  contain: layout style paint;
+  /* Prevent any scroll-related transforms */
+  transform-style: flat;
+  perspective: none;
+  /* Additional stability properties */
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  /* Ensure background is completely isolated */
+  mix-blend-mode: normal;
+  filter: none;
 }
 
 .recipe-full-background::after {
@@ -561,7 +579,7 @@
   right: 0;
   bottom: 0;
   background: rgba(0, 0, 0, 0.3);
-  z-index: 1;
+  z-index: -1;
   pointer-events: none;
 }
 
@@ -574,6 +592,15 @@
   will-change: auto;
   backface-visibility: visible;
   -webkit-backface-visibility: visible;
+  /* Additional isolation properties */
+  isolation: isolate;
+  contain: layout style paint;
+  /* Prevent any scroll-related transforms */
+  transform-style: flat;
+  perspective: none;
+  /* Ensure the image itself is stable */
+  image-rendering: auto;
+  image-orientation: from-image;
 }
 
 .recipe-full-background-placeholder {


### PR DESCRIPTION
Fix background image readjustment on scroll by disabling recipe card reflection effects in fullscreen mode and adding CSS stability.

The background image appeared to 'readjust' when scrolling due to a JavaScript-driven reflection effect on recipe cards that was inadvertently affecting the fullscreen background. This PR ensures these effects are disabled and cleaned up when a recipe is viewed in fullscreen, and adds CSS properties to further stabilize the background.

---
<a href="https://cursor.com/background-agent?bcId=bc-995eefd8-dd3b-49f9-8b4f-16917235ebac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-995eefd8-dd3b-49f9-8b4f-16917235ebac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

