### PR TITLE
Fix recipe card width on small screens

### DIFF
--- a/frontend/src/styles/recipe-card.scss
+++ b/frontend/src/styles/recipe-card.scss
@@ -25,8 +25,28 @@
   }
   
   @media (max-width: 480px) {
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: $spacing-sm - 5px;
+  }
+  
+  @media (max-width: 400px) {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: $spacing-xs;
+  }
+  
+  @media (max-width: 360px) {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: $spacing-xs;
+  }
+  
+  @media (max-width: 320px) {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: $spacing-xs;
+  }
+  
+  @media (max-width: 280px) {
+    grid-template-columns: 1fr;
+    gap: $spacing-xs;
   }
 }
 
@@ -178,6 +198,118 @@
       }
     }
   }
+  
+  @media (max-width: 400px) {
+    padding: 0 4px 4px 4px !important;
+    
+    .recipe-card {
+      flex: 0 0 220px !important;
+      min-width: 220px !important;
+      max-width: 220px !important;
+      
+      &:first-child {
+        margin-left: 4px !important;
+      }
+      
+      &:last-child {
+        margin-right: 4px !important;
+      }
+      
+      .recipe-card-title {
+        font-size: 1.1em !important;
+        padding: 4px 8px 8px 8px !important;
+        line-height: 1.1 !important;
+      }
+      
+      .recipe-card-title-overlay {
+        padding: 0 8px !important;
+      }
+    }
+  }
+  
+  @media (max-width: 360px) {
+    padding: 0 3px 3px 3px !important;
+    
+    .recipe-card {
+      flex: 0 0 200px !important;
+      min-width: 200px !important;
+      max-width: 200px !important;
+      
+      &:first-child {
+        margin-left: 3px !important;
+      }
+      
+      &:last-child {
+        margin-right: 3px !important;
+      }
+      
+      .recipe-card-title {
+        font-size: 1em !important;
+        padding: 3px 6px 6px 6px !important;
+        line-height: 1.1 !important;
+      }
+      
+      .recipe-card-title-overlay {
+        padding: 0 6px !important;
+      }
+    }
+  }
+  
+  @media (max-width: 320px) {
+    padding: 0 2px 2px 2px !important;
+    
+    .recipe-card {
+      flex: 0 0 180px !important;
+      min-width: 180px !important;
+      max-width: 180px !important;
+      
+      &:first-child {
+        margin-left: 2px !important;
+      }
+      
+      &:last-child {
+        margin-right: 2px !important;
+      }
+      
+      .recipe-card-title {
+        font-size: 0.9em !important;
+        padding: 2px 5px 5px 5px !important;
+        line-height: 1.1 !important;
+      }
+      
+      .recipe-card-title-overlay {
+        padding: 0 5px !important;
+      }
+    }
+  }
+  
+  @media (max-width: 280px) {
+    padding: 0 1px 1px 1px !important;
+    
+    .recipe-card {
+      flex: 0 0 160px !important;
+      min-width: 160px !important;
+      max-width: 160px !important;
+      
+      &:first-child {
+        margin-left: 1px !important;
+      }
+      
+      &:last-child {
+        margin-right: 1px !important;
+      }
+      
+      .recipe-card-title {
+        font-size: 0.8em !important;
+        padding: 1px 4px 4px 4px !important;
+        line-height: 1.1 !important;
+      }
+      
+      .recipe-card-title-overlay {
+        padding: 0 4px !important;
+      }
+    }
+  }
 }
 
 /* Navigation Buttons */
@@ -213,6 +345,32 @@
     width: 24px;
     height: 24px;
     color: #2c3e50;
+    
+    /* Responsive adjustments for smaller screens */
+    @media (max-width: 480px) {
+      width: 22px;
+      height: 22px;
+    }
+    
+    @media (max-width: 400px) {
+      width: 20px;
+      height: 20px;
+    }
+    
+    @media (max-width: 360px) {
+      width: 18px;
+      height: 18px;
+    }
+    
+    @media (max-width: 320px) {
+      width: 16px;
+      height: 16px;
+    }
+    
+    @media (max-width: 280px) {
+      width: 14px;
+      height: 14px;
+    }
   }
 }
 
@@ -248,6 +406,127 @@
   /* Hide navigation buttons on mobile - use swipe instead */
   .carousel-nav {
     display: none;
+  }
+}
+
+/* Additional mobile breakpoints for better responsiveness */
+@media (max-width: 640px) {
+  .recipe-grid.carousel-layout {
+    padding: 0 8px 8px 8px !important;
+    
+    .recipe-card {
+      flex: 0 0 260px !important;
+      min-width: 260px !important;
+      max-width: 260px !important;
+      
+      &:first-child {
+        margin-left: 8px !important;
+      }
+      
+      &:last-child {
+        margin-right: 8px !important;
+      }
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .recipe-grid.carousel-layout {
+    padding: 0 6px 6px 6px !important;
+    
+    .recipe-card {
+      flex: 0 0 240px !important;
+      min-width: 240px !important;
+      max-width: 240px !important;
+      
+      &:first-child {
+        margin-left: 6px !important;
+      }
+      
+      &:last-child {
+        margin-right: 6px !important;
+      }
+    }
+  }
+}
+
+@media (max-width: 400px) {
+  .recipe-grid.carousel-layout {
+    padding: 0 4px 4px 4px !important;
+    
+    .recipe-card {
+      flex: 0 0 220px !important;
+      min-width: 220px !important;
+      max-width: 220px !important;
+      
+      &:first-child {
+        margin-left: 4px !important;
+      }
+      
+      &:last-child {
+        margin-right: 4px !important;
+      }
+    }
+  }
+}
+
+@media (max-width: 360px) {
+  .recipe-grid.carousel-layout {
+    padding: 0 3px 3px 3px !important;
+    
+    .recipe-card {
+      flex: 0 0 200px !important;
+      min-width: 200px !important;
+      max-width: 200px !important;
+      
+      &:first-child {
+        margin-left: 3px !important;
+      }
+      
+      &:last-child {
+        margin-right: 3px !important;
+      }
+    }
+  }
+}
+
+@media (max-width: 320px) {
+  .recipe-grid.carousel-layout {
+    padding: 0 2px 2px 2px !important;
+    
+    .recipe-card {
+      flex: 0 0 180px !important;
+      min-width: 180px !important;
+      max-width: 180px !important;
+      
+      &:first-child {
+        margin-left: 2px !important;
+      }
+      
+      &:last-child {
+        margin-right: 2px !important;
+      }
+    }
+  }
+}
+
+@media (max-width: 280px) {
+  .recipe-grid.carousel-layout {
+    padding: 0 1px 1px 1px !important;
+    
+    .recipe-card {
+      flex: 0 0 160px !important;
+      min-width: 160px !important;
+      max-width: 160px !important;
+      
+      &:first-child {
+        margin-left: 1px !important;
+      }
+      
+      &:last-child {
+        margin-right: 1px !important;
+      }
+    }
   }
 }
 
@@ -327,6 +606,78 @@
       
       &:last-child {
         margin-right: 6px !important;
+      }
+    }
+  }
+  
+  @media (max-width: 400px) {
+    padding: 0 4px 4px 4px !important;
+    
+    .recipe-card {
+      flex: 0 0 220px !important;
+      min-width: 220px !important;
+      max-width: 220px !important;
+      
+      &:first-child {
+        margin-left: 4px !important;
+      }
+      
+      &:last-child {
+        margin-right: 4px !important;
+      }
+    }
+  }
+  
+  @media (max-width: 360px) {
+    padding: 0 3px 3px 3px !important;
+    
+    .recipe-card {
+      flex: 0 0 200px !important;
+      min-width: 200px !important;
+      max-width: 200px !important;
+      
+      &:first-child {
+        margin-left: 3px !important;
+      }
+      
+      &:last-child {
+        margin-right: 3px !important;
+      }
+    }
+  }
+  
+  @media (max-width: 320px) {
+    padding: 0 2px 2px 2px !important;
+    
+    .recipe-card {
+      flex: 0 0 180px !important;
+      min-width: 180px !important;
+      max-width: 180px !important;
+      
+      &:first-child {
+        margin-left: 2px !important;
+      }
+      
+      &:last-child {
+        margin-right: 2px !important;
+      }
+    }
+  }
+  
+  @media (max-width: 280px) {
+    padding: 0 1px 1px 1px !important;
+    
+    .recipe-card {
+      flex: 0 0 160px !important;
+      min-width: 160px !important;
+      max-width: 160px !important;
+      
+      &:first-child {
+        margin-left: 1px !important;
+      }
+      
+      &:last-child {
+        margin-right: 1px !important;
       }
     }
   }
@@ -435,6 +786,27 @@
   border-radius: $border-radius-lg - 5px $border-radius-lg - 5px 0 0;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
   overflow: hidden;
+  
+  /* Responsive height adjustments for smaller screens */
+  @media (max-width: 480px) {
+    height: 220px;
+  }
+  
+  @media (max-width: 400px) {
+    height: 200px;
+  }
+  
+  @media (max-width: 360px) {
+    height: 180px;
+  }
+  
+  @media (max-width: 320px) {
+    height: 160px;
+  }
+  
+  @media (max-width: 280px) {
+    height: 140px;
+  }
 }
 
 .recipe-card-overlay {
@@ -478,6 +850,22 @@
   @media (max-width: 480px) {
     padding: 0 12px;
   }
+  
+  @media (max-width: 400px) {
+    padding: 0 10px;
+  }
+  
+  @media (max-width: 360px) {
+    padding: 0 8px;
+  }
+  
+  @media (max-width: 320px) {
+    padding: 0 6px;
+  }
+  
+  @media (max-width: 280px) {
+    padding: 0 5px;
+  }
 }
 
 .recipe-card:hover .recipe-card-overlay {
@@ -493,6 +881,37 @@
   opacity: 1;
   transition: opacity 0.3s ease;
   z-index: 20;
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    top: 12px;
+    right: 12px;
+    gap: 6px;
+  }
+  
+  @media (max-width: 400px) {
+    top: 10px;
+    right: 10px;
+    gap: 5px;
+  }
+  
+  @media (max-width: 360px) {
+    top: 8px;
+    right: 8px;
+    gap: 4px;
+  }
+  
+  @media (max-width: 320px) {
+    top: 6px;
+    right: 6px;
+    gap: 3px;
+  }
+  
+  @media (max-width: 280px) {
+    top: 5px;
+    right: 5px;
+    gap: 2px;
+  }
 }
 
 .recipe-card:hover .recipe-card-actions {
@@ -520,6 +939,42 @@
   justify-content: center;
   font-size: 1em;
   transition: all 0.3s ease;
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    width: 36px;
+    height: 28px;
+    border-radius: 14px;
+    font-size: 0.9em;
+  }
+  
+  @media (max-width: 400px) {
+    width: 32px;
+    height: 26px;
+    border-radius: 13px;
+    font-size: 0.85em;
+  }
+  
+  @media (max-width: 360px) {
+    width: 30px;
+    height: 24px;
+    border-radius: 12px;
+    font-size: 0.8em;
+  }
+  
+  @media (max-width: 320px) {
+    width: 28px;
+    height: 22px;
+    border-radius: 11px;
+    font-size: 0.75em;
+  }
+  
+  @media (max-width: 280px) {
+    width: 26px;
+    height: 20px;
+    border-radius: 10px;
+    font-size: 0.7em;
+  }
 }
 
 .recipe-card-actions .edit-btn:hover {
@@ -542,6 +997,27 @@
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border-top: 1px solid rgba(255, 255, 255, 0.1);
+  
+  /* Responsive padding for smaller screens */
+  @media (max-width: 480px) {
+    padding: 16px;
+  }
+  
+  @media (max-width: 400px) {
+    padding: 14px;
+  }
+  
+  @media (max-width: 360px) {
+    padding: 12px;
+  }
+  
+  @media (max-width: 320px) {
+    padding: 10px;
+  }
+  
+  @media (max-width: 280px) {
+    padding: 8px;
+  }
 }
 
 .recipe-card-title {
@@ -584,6 +1060,26 @@
     font-size: 1.4em;
     padding: 8px 12px 12px 12px;
   }
+  
+  @media (max-width: 400px) {
+    font-size: 1.2em;
+    padding: 6px 10px 10px 10px;
+  }
+  
+  @media (max-width: 360px) {
+    font-size: 1.1em;
+    padding: 5px 8px 8px 8px;
+  }
+  
+  @media (max-width: 320px) {
+    font-size: 1em;
+    padding: 4px 6px 6px 6px;
+  }
+  
+  @media (max-width: 280px) {
+    font-size: 0.9em;
+    padding: 3px 5px 5px 5px;
+  }
 }
 
 .recipe-card-description {
@@ -598,6 +1094,32 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    font-size: 0.85em;
+    margin: 0 0 12px 0;
+  }
+  
+  @media (max-width: 400px) {
+    font-size: 0.8em;
+    margin: 0 0 10px 0;
+  }
+  
+  @media (max-width: 360px) {
+    font-size: 0.75em;
+    margin: 0 0 8px 0;
+  }
+  
+  @media (max-width: 320px) {
+    font-size: 0.7em;
+    margin: 0 0 6px 0;
+  }
+  
+  @media (max-width: 280px) {
+    font-size: 0.65em;
+    margin: 0 0 5px 0;
+  }
 }
 
 .recipe-card-time {
@@ -610,6 +1132,32 @@
   justify-content: center;
   gap: 20px;
   text-shadow: 0 1px 1px rgba(255, 255, 255, 0.2);
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    font-size: 0.85em;
+    gap: 16px;
+  }
+  
+  @media (max-width: 400px) {
+    font-size: 0.8em;
+    gap: 14px;
+  }
+  
+  @media (max-width: 360px) {
+    font-size: 0.75em;
+    gap: 12px;
+  }
+  
+  @media (max-width: 320px) {
+    font-size: 0.7em;
+    gap: 10px;
+  }
+  
+  @media (max-width: 280px) {
+    font-size: 0.65em;
+    gap: 8px;
+  }
 }
 
 .recipe-card-time .time-item {
@@ -617,6 +1165,27 @@
   flex-direction: column;
   align-items: center;
   gap: 4px;
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    gap: 3px;
+  }
+  
+  @media (max-width: 400px) {
+    gap: 2px;
+  }
+  
+  @media (max-width: 360px) {
+    gap: 2px;
+  }
+  
+  @media (max-width: 320px) {
+    gap: 1px;
+  }
+  
+  @media (max-width: 280px) {
+    gap: 1px;
+  }
 }
 
 .recipe-card-time .time-label {
@@ -625,11 +1194,58 @@
   letter-spacing: 0.5px;
   opacity: 0.8;
   font-weight: 500;
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    font-size: 0.8em;
+    letter-spacing: 0.4px;
+  }
+  
+  @media (max-width: 400px) {
+    font-size: 0.75em;
+    letter-spacing: 0.3px;
+  }
+  
+  @media (max-width: 360px) {
+    font-size: 0.7em;
+    letter-spacing: 0.3px;
+  }
+  
+  @media (max-width: 320px) {
+    font-size: 0.65em;
+    letter-spacing: 0.2px;
+  }
+  
+  @media (max-width: 280px) {
+    font-size: 0.6em;
+    letter-spacing: 0.2px;
+  }
 }
 
 .recipe-card-time .time-value {
   font-size: 1.1em;
   font-weight: 600;
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    font-size: 1em;
+  }
+  
+  @media (max-width: 400px) {
+    font-size: 0.95em;
+  }
+  
+  @media (max-width: 360px) {
+    font-size: 0.9em;
+  }
+  
+  @media (max-width: 320px) {
+    font-size: 0.85em;
+  }
+  
+  @media (max-width: 280px) {
+    font-size: 0.8em;
+  }
 }
 
 .recipe-card-time .time-divider {
@@ -637,15 +1253,83 @@
   height: 30px;
   background: rgba(52, 73, 94, 0.2);
   margin: 0 5px;
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    height: 28px;
+    margin: 0 4px;
+  }
+  
+  @media (max-width: 400px) {
+    height: 26px;
+    margin: 0 3px;
+  }
+  
+  @media (max-width: 360px) {
+    height: 24px;
+    margin: 0 3px;
+  }
+  
+  @media (max-width: 320px) {
+    height: 22px;
+    margin: 0 2px;
+  }
+  
+  @media (max-width: 280px) {
+    height: 20px;
+    margin: 0 2px;
+  }
 }
 
 .recipe-card-time .time-icon {
   font-size: 1.1em;
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    font-size: 1em;
+  }
+  
+  @media (max-width: 400px) {
+    font-size: 0.95em;
+  }
+  
+  @media (max-width: 360px) {
+    font-size: 0.9em;
+  }
+  
+  @media (max-width: 320px) {
+    font-size: 0.85em;
+  }
+  
+  @media (max-width: 280px) {
+    font-size: 0.8em;
+  }
 }
 
 .recipe-card-time .no-time {
   font-weight: 500;
   color: #7f8c8d;
+  
+  /* Responsive adjustments for smaller screens */
+  @media (max-width: 480px) {
+    font-size: 0.9em;
+  }
+  
+  @media (max-width: 400px) {
+    font-size: 0.85em;
+  }
+  
+  @media (max-width: 360px) {
+    font-size: 0.8em;
+  }
+  
+  @media (max-width: 320px) {
+    font-size: 0.75em;
+  }
+  
+  @media (max-width: 280px) {
+    font-size: 0.7em;
+  }
 }
 
 /* Recipe Links */
@@ -878,6 +1562,42 @@
     flex: 0 0 240px !important; /* Even smaller on very small screens */
     min-width: 240px !important;
     max-width: 240px !important;
+  }
+}
+
+@media (max-width: 400px) {
+  .recipe-grid.mobile-carousel .recipe-card,
+  .recipe-grid:not(.mobile-carousel) .recipe-card {
+    flex: 0 0 220px !important;
+    min-width: 220px !important;
+    max-width: 220px !important;
+  }
+}
+
+@media (max-width: 360px) {
+  .recipe-grid.mobile-carousel .recipe-card,
+  .recipe-grid:not(.mobile-carousel) .recipe-card {
+    flex: 0 0 200px !important;
+    min-width: 200px !important;
+    max-width: 200px !important;
+  }
+}
+
+@media (max-width: 320px) {
+  .recipe-grid.mobile-carousel .recipe-card,
+  .recipe-grid:not(.mobile-carousel) .recipe-card {
+    flex: 0 0 180px !important;
+    min-width: 180px !important;
+    max-width: 180px !important;
+  }
+}
+
+@media (max-width: 280px) {
+  .recipe-grid.mobile-carousel .recipe-card,
+  .recipe-grid:not(.mobile-carousel) .recipe-card {
+    flex: 0 0 160px !important;
+    min-width: 160px !important;
+    max-width: 160px !important;
   }
 }
 


### PR DESCRIPTION
Adjust recipe card and carousel styling to prevent cards from becoming too narrow on smaller screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a863502-cf17-4fdd-af95-c57ee42b613f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a863502-cf17-4fdd-af95-c57ee42b613f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

