### PR TITLE
Add endpoint for AI recipe names by category

### DIFF
--- a/recipe-recommendation-worker/README.md
+++ b/recipe-recommendation-worker/README.md
@@ -7,6 +7,7 @@ A Cloudflare Worker that provides recipe recommendations based on location and d
 - 🌍 Location-based recommendations
 - 📅 Seasonal and date-aware suggestions
 - 🏷️ Returns categorized recipe tags
+- 🍳 **AI-generated recipe names by category with configurable limits**
 - 🤖 Powered by Cloudflare Workers AI (Llama 3.1 8B model)
 - 🔄 Fallback to curated mock data when AI is unavailable
 - 🔐 No API keys required - uses Cloudflare's AI binding
@@ -41,6 +42,51 @@ Get recipe recommendations based on location and date.
   "location": "San Francisco, CA",
   "date": "2024-07-15",
   "season": "Summer"
+}
+```
+
+### `POST /recipe-names`
+
+Get AI-generated recipe names by category with configurable limits.
+
+**Request Body:**
+```json
+{
+  "categories": ["Italian Cuisine", "Asian Fusion", "Desserts"],
+  "limit": 5  // Optional, defaults to 5, max 20
+}
+```
+
+**Response:**
+```json
+{
+  "recipeNames": {
+    "Italian Cuisine": [
+      "Margherita Pizza",
+      "Spaghetti Carbonara",
+      "Risotto ai Funghi",
+      "Osso Buco",
+      "Tiramisu"
+    ],
+    "Asian Fusion": [
+      "Thai Green Curry",
+      "Sushi Roll Combo",
+      "Korean BBQ Beef",
+      "Vietnamese Pho",
+      "Chinese Dumplings"
+    ],
+    "Desserts": [
+      "Chocolate Lava Cake",
+      "Apple Pie",
+      "Cheesecake",
+      "Chocolate Chip Cookies",
+      "Tiramisu"
+    ]
+  },
+  "requestId": "req_1642248600000_abc123def",
+  "processingTime": "245ms",
+  "recipesPerCategory": 5,
+  "categories": ["Italian Cuisine", "Asian Fusion", "Desserts"]
 }
 ```
 

--- a/recipe-recommendation-worker/curl-examples.md
+++ b/recipe-recommendation-worker/curl-examples.md
@@ -1,0 +1,106 @@
+# cURL Examples for Recipe Names Endpoint
+
+## Basic Usage
+
+### Get recipe names for Italian and Asian cuisine (default limit: 5)
+```bash
+curl -X POST http://localhost:8787/recipe-names \
+  -H "Content-Type: application/json" \
+  -d '{
+    "categories": ["Italian Cuisine", "Asian Fusion"]
+  }'
+```
+
+### Get recipe names with custom limit (3 per category)
+```bash
+curl -X POST http://localhost:8787/recipe-names \
+  -H "Content-Type: application/json" \
+  -d '{
+    "categories": ["Comfort Food", "Desserts"],
+    "limit": 3
+  }'
+```
+
+### Get recipe names for single category with high limit
+```bash
+curl -X POST http://localhost:8787/recipe-names \
+  -H "Content-Type: application/json" \
+  -d '{
+    "categories": ["Healthy Options"],
+    "limit": 10
+  }'
+```
+
+## Error Cases
+
+### Missing categories (should return 400)
+```bash
+curl -X POST http://localhost:8787/recipe-names \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+### Empty categories array (should return 400)
+```bash
+curl -X POST http://localhost:8787/recipe-names \
+  -H "Content-Type: application/json" \
+  -d '{
+    "categories": []
+  }'
+```
+
+### Wrong HTTP method (should return 405)
+```bash
+curl -X GET http://localhost:8787/recipe-names
+```
+
+## Production Examples
+
+### Using the deployed worker
+```bash
+curl -X POST https://recipe-recommendation-worker.nolanfoster.workers.dev/recipe-names \
+  -H "Content-Type: application/json" \
+  -d '{
+    "categories": ["Quick Meals", "Desserts"],
+    "limit": 4
+  }'
+```
+
+### Using staging environment
+```bash
+curl -X POST https://staging-recipe-recommendation-worker.nolanfoster.workers.dev/recipe-names \
+  -H "Content-Type: application/json" \
+  -d '{
+    "categories": ["Italian Cuisine"],
+    "limit": 6
+  }'
+```
+
+## Expected Response Format
+
+The endpoint returns a JSON response with this structure:
+
+```json
+{
+  "recipeNames": {
+    "Category Name": [
+      "Recipe Name 1",
+      "Recipe Name 2",
+      "Recipe Name 3"
+    ]
+  },
+  "requestId": "req_1234567890_abc123",
+  "processingTime": "245ms",
+  "recipesPerCategory": 3,
+  "categories": ["Category Name"]
+}
+```
+
+## Notes
+
+- **Categories**: Array of strings, required
+- **Limit**: Optional integer, defaults to 5, max 20
+- **Method**: POST only
+- **Content-Type**: application/json required
+- **AI Fallback**: Falls back to mock data if AI is unavailable
+- **Rate Limiting**: Subject to Cloudflare Workers AI rate limits

--- a/recipe-recommendation-worker/example-recipe-names.js
+++ b/recipe-recommendation-worker/example-recipe-names.js
@@ -1,0 +1,100 @@
+/**
+ * Example usage of the new /recipe-names endpoint
+ * This demonstrates how to get AI-generated recipe names by category with limits
+ */
+
+// Example function to call the recipe-names endpoint
+async function getRecipeNamesByCategory(categories, limit = 5) {
+  try {
+    const response = await fetch('http://localhost:8787/recipe-names', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        categories: categories,
+        limit: limit
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error calling recipe-names endpoint:', error);
+    throw error;
+  }
+}
+
+// Example usage scenarios
+async function demonstrateRecipeNames() {
+  console.log('🍳 Recipe Names Endpoint Examples\n');
+
+  try {
+    // Example 1: Get Italian and Asian cuisine recipes
+    console.log('1. Italian & Asian Cuisine Recipes:');
+    const italianAsian = await getRecipeNamesByCategory(['Italian Cuisine', 'Asian Fusion'], 4);
+    console.log(JSON.stringify(italianAsian, null, 2));
+    console.log('\n');
+
+    // Example 2: Get comfort food and desserts
+    console.log('2. Comfort Food & Desserts:');
+    const comfortDesserts = await getRecipeNamesByCategory(['Comfort Food', 'Desserts'], 3);
+    console.log(JSON.stringify(comfortDesserts, null, 2));
+    console.log('\n');
+
+    // Example 3: Get healthy options with higher limit
+    console.log('3. Healthy Options (8 recipes):');
+    const healthy = await getRecipeNamesByCategory(['Healthy Options'], 8);
+    console.log(JSON.stringify(healthy, null, 2));
+    console.log('\n');
+
+    // Example 4: Single category with default limit
+    console.log('4. Quick Meals (default limit):');
+    const quickMeals = await getRecipeNamesByCategory(['Quick Meals']);
+    console.log(JSON.stringify(quickMeals, null, 2));
+
+  } catch (error) {
+    console.error('Demo failed:', error.message);
+  }
+}
+
+// Example of the expected response structure
+console.log('📋 Expected Response Structure:');
+console.log(JSON.stringify({
+  recipeNames: {
+    "Italian Cuisine": [
+      "Margherita Pizza",
+      "Spaghetti Carbonara", 
+      "Risotto ai Funghi",
+      "Osso Buco",
+      "Tiramisu"
+    ],
+    "Asian Fusion": [
+      "Thai Green Curry",
+      "Sushi Roll Combo",
+      "Korean BBQ Beef",
+      "Vietnamese Pho"
+    ]
+  },
+  requestId: "req_1234567890_abc123",
+  processingTime: "245ms",
+  recipesPerCategory: 4,
+  categories: ["Italian Cuisine", "Asian Fusion"]
+}, null, 2));
+
+console.log('\n🚀 To run the examples, start the worker with:');
+console.log('   npm run dev');
+console.log('\nThen in another terminal, run:');
+console.log('   node example-recipe-names.js');
+
+// Export for use in other modules
+export { getRecipeNamesByCategory, demonstrateRecipeNames };
+
+// If running directly, show the demo
+if (import.meta.url === `file://${process.argv[1]}`) {
+  demonstrateRecipeNames();
+}


### PR DESCRIPTION
Add `POST /recipe-names` endpoint to explicitly get AI-generated recipe names by category with configurable limits.

---
<a href="https://cursor.com/background-agent?bcId=bc-385f1c63-b5f3-4581-b184-6cc436b7d359">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-385f1c63-b5f3-4581-b184-6cc436b7d359">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

