### PR TITLE
feat: integrate embedding queue with recipe save worker

### DIFF
--- a/recipe-save-worker/src/index.js
+++ b/recipe-save-worker/src/index.js
@@ -283,6 +283,21 @@ export class RecipeSaver {
           log('info', 'Syncing with search database', { requestId, recipeId });
           await this.syncWithSearchDB(recipeRecord, 'create', requestId);
 
+          // Add recipe to embedding queue
+          log('info', 'Adding recipe to embedding queue', { requestId, recipeId });
+          try {
+            await this.env.EMBEDDING_QUEUE.sendBatch([{ body: recipeId }]);
+            log('info', 'Recipe added to embedding queue successfully', { requestId, recipeId });
+          } catch (queueError) {
+            log('warn', 'Failed to add recipe to embedding queue', { 
+              requestId, 
+              recipeId, 
+              error: queueError.message 
+            });
+            // Don't fail the save operation if queue fails
+            // The recipe can be queued for embedding later through other means
+          }
+
           // Store operation status
           const operationStatus = {
             status: 'completed',
@@ -442,6 +457,21 @@ export class RecipeSaver {
           // Sync with search database
           log('info', 'Syncing updated recipe with search database', { requestId, recipeId });
           await this.syncWithSearchDB(updatedRecipe, 'update', requestId);
+
+          // Add updated recipe to embedding queue for re-embedding
+          log('info', 'Adding updated recipe to embedding queue', { requestId, recipeId });
+          try {
+            await this.env.EMBEDDING_QUEUE.sendBatch([{ body: recipeId }]);
+            log('info', 'Updated recipe added to embedding queue successfully', { requestId, recipeId });
+          } catch (queueError) {
+            log('warn', 'Failed to add updated recipe to embedding queue', { 
+              requestId, 
+              recipeId, 
+              error: queueError.message 
+            });
+            // Don't fail the update operation if queue fails
+            // The recipe can be queued for embedding later through other means
+          }
 
           // Store operation status
           const operationStatus = {

--- a/recipe-save-worker/wrangler.toml
+++ b/recipe-save-worker/wrangler.toml
@@ -35,6 +35,10 @@ id = "3f8a3b17db9e4f8ea3eae83d864ad518"
 binding = "RECIPE_IMAGES"
 bucket_name = "recipe-images"
 
+[[env.staging.queues.producers]]
+queue = "recipe-embedding-queue"
+binding = "EMBEDDING_QUEUE"
+
 [[env.staging.durable_objects.bindings]]
 name = "RECIPE_SAVER"
 class_name = "RecipeSaver"
@@ -54,6 +58,10 @@ id = "dd001c20659a4d6982f6d650abcac880"
 [[env.production.r2_buckets]]
 binding = "RECIPE_IMAGES"
 bucket_name = "recipe-images"
+
+[[env.production.queues.producers]]
+queue = "recipe-embedding-queue"
+binding = "EMBEDDING_QUEUE"
 
 [[env.production.durable_objects.bindings]]
 name = "RECIPE_SAVER"
@@ -79,6 +87,11 @@ new_sqlite_classes = ["RecipeSaver"]
 [[r2_buckets]]
 binding = "RECIPE_IMAGES"
 bucket_name = "recipe-images"
+
+# Queue for recipe embedding
+[[queues.producers]]
+queue = "recipe-embedding-queue"
+binding = "EMBEDDING_QUEUE"
 
 # Optional: Analytics Engine (for monitoring)
 # [[analytics_engine_datasets]]


### PR DESCRIPTION
## Summary

This PR integrates the recipe embedding queue with the recipe save worker to automatically queue new and updated recipes for embedding after they are successfully saved to KV storage.

## Changes Made

### Configuration Updates
- Added  binding to all environments (staging, production, default) in 
- Configured queue producer for 

### Code Updates
- **Save Operation**: After successfully saving a new recipe to KV, the recipe ID is automatically added to the embedding queue
- **Update Operation**: After successfully updating a recipe in KV, the recipe ID is automatically added to the embedding queue for re-embedding
- **Error Handling**: Queue failures don't break save/update operations - they're logged as warnings and the operation continues
- **Logging**: Added comprehensive logging for queue operations with proper request context

## Technical Details

- Uses  to queue recipes
- Queue messages follow the expected format:  where  is a string
- Integration happens after successful KV save/update but before operation status storage
- Maintains atomic operations through the existing Durable Object transaction system

## Testing

✅ All existing tests pass (63/63)
✅ Pre-commit hooks pass
✅ No linting errors

## Impact

- **New recipes** will automatically be queued for embedding after save
- **Updated recipes** will automatically be re-queued for embedding after update
- **No breaking changes** - existing functionality preserved
- **Improved user experience** - recipes become searchable faster without manual intervention

## Related Issues

Closes: [Add issue number if applicable]

## Deployment Notes

- Requires the  to be available in all environments
- No database migrations required
- No breaking changes to existing APIs