### PR TITLE
Update recipe worker to use llama-4-scout

### DIFF
--- a/recipe-generation-worker/src/handlers/generate-handler.js
+++ b/recipe-generation-worker/src/handlers/generate-handler.js
@@ -247,7 +247,7 @@ async function generateRecipeWithAI(requestData, env) {
             { prompt: operationData.prompt },
             { response: operationData.llmResponse, structuredRecipe: generatedRecipe },
             {
-              model: 'llama-3-8b-instruct',
+              model: 'llama-4-scout-17b-16e-instruct',
               provider: 'cloudflare',
               metadata: {
                 similarRecipesCount: similarRecipes.length,
@@ -433,7 +433,7 @@ async function generateRecipeWithLLaMA(requestData, similarRecipes, aiBinding, o
   operationData.prompt = prompt;
 
   // Generate recipe using LLaMA
-  const response = await aiBinding.run('@cf/meta/llama-3.1-8b-instruct', {
+  const response = await aiBinding.run('llama-4-scout-17b-16e-instruct', {
     messages: [
       {
         role: 'system',

--- a/recipe-generation-worker/src/handlers/generate-handler.js
+++ b/recipe-generation-worker/src/handlers/generate-handler.js
@@ -247,7 +247,7 @@ async function generateRecipeWithAI(requestData, env) {
             { prompt: operationData.prompt },
             { response: operationData.llmResponse, structuredRecipe: generatedRecipe },
             {
-              model: 'llama-4-scout-17b-16e-instruct',
+              model: '@cf/meta/llama-4-scout-17b-16e-instruct',
               provider: 'cloudflare',
               metadata: {
                 similarRecipesCount: similarRecipes.length,
@@ -433,7 +433,7 @@ async function generateRecipeWithLLaMA(requestData, similarRecipes, aiBinding, o
   operationData.prompt = prompt;
 
   // Generate recipe using LLaMA
-  const response = await aiBinding.run('llama-4-scout-17b-16e-instruct', {
+  const response = await aiBinding.run('@cf/meta/llama-4-scout-17b-16e-instruct', {
     messages: [
       {
         role: 'system',

--- a/recipe-generation-worker/tests/unit/generate-handler.test.js
+++ b/recipe-generation-worker/tests/unit/generate-handler.test.js
@@ -38,7 +38,7 @@ describe('Generate Handler - Unit Tests', () => {
         return Promise.resolve({
           data: [[0.1, 0.2, 0.3, 0.4, 0.5]] // Mock embedding
         });
-      } else if (model === 'llama-4-scout-17b-16e-instruct') {
+      } else if (model === '@cf/meta/llama-4-scout-17b-16e-instruct') {
         return Promise.resolve({
           response: `Chicken Rice Bowl
 
@@ -113,7 +113,7 @@ Serves: 4`
 
       // Verify AI calls were made
       expect(mockAI.run).toHaveBeenCalledWith('@cf/baai/bge-small-en-v1.5', expect.any(Object));
-      expect(mockAI.run).toHaveBeenCalledWith('llama-4-scout-17b-16e-instruct', expect.any(Object));
+      expect(mockAI.run).toHaveBeenCalledWith('@cf/meta/llama-4-scout-17b-16e-instruct', expect.any(Object));
       expect(mockVectors.query).toHaveBeenCalled();
     });
 

--- a/recipe-generation-worker/tests/unit/generate-handler.test.js
+++ b/recipe-generation-worker/tests/unit/generate-handler.test.js
@@ -38,7 +38,7 @@ describe('Generate Handler - Unit Tests', () => {
         return Promise.resolve({
           data: [[0.1, 0.2, 0.3, 0.4, 0.5]] // Mock embedding
         });
-      } else if (model === '@cf/meta/llama-3.1-8b-instruct') {
+      } else if (model === 'llama-4-scout-17b-16e-instruct') {
         return Promise.resolve({
           response: `Chicken Rice Bowl
 
@@ -113,7 +113,7 @@ Serves: 4`
 
       // Verify AI calls were made
       expect(mockAI.run).toHaveBeenCalledWith('@cf/baai/bge-small-en-v1.5', expect.any(Object));
-      expect(mockAI.run).toHaveBeenCalledWith('@cf/meta/llama-3.1-8b-instruct', expect.any(Object));
+      expect(mockAI.run).toHaveBeenCalledWith('llama-4-scout-17b-16e-instruct', expect.any(Object));
       expect(mockVectors.query).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Update recipe generation worker to use `llama-4-scout-17b-16e-instruct` as the AI model.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2c997db-a737-4239-bc90-03f0029ff66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2c997db-a737-4239-bc90-03f0029ff66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

