### PR TITLE
feat(recipe-app): Chef's Table generation UX

### DIFF
--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react'
 import RecipeCard, { parseDuration } from './RecipeCard.jsx'
+import GeneratingCard from './GeneratingCard.jsx'
 
 const SEARCH_DB_URL = import.meta.env.VITE_SEARCH_DB_URL
 const CLIPPER_API_URL = import.meta.env.VITE_CLIPPER_API_URL
@@ -33,6 +34,7 @@ export default function App() {
   const [showDropdown, setShowDropdown] = useState(false)
   const [recipe, setRecipe] = useState(null) // currently displayed recipe
   const [saveState, setSaveState] = useState('idle') // idle | saving | saved | error
+  const [generatingName, setGeneratingName] = useState('')
   const inputRef = useRef(null)
   const dropdownRef = useRef(null)
 
@@ -159,12 +161,15 @@ export default function App() {
 
   // --- Generate ---
   async function doGenerate(query, { elevate = false, baseRecipe = null } = {}) {
+    const dishName = elevate && baseRecipe ? baseRecipe.name : query
+    setGeneratingName(dishName)
+    setInput('')
     setStatus(elevate ? 'elevating' : 'generating')
     setShowDropdown(false)
     setSaveState('idle')
     try {
       const body = {
-        recipeName: elevate && baseRecipe ? baseRecipe.name : query,
+        recipeName: dishName,
         generateImage: true,
         elevate: elevate,
       }
@@ -194,8 +199,9 @@ export default function App() {
         ingredients: r.ingredients || [],
         instructions: r.instructions || [],
       })
-      if (!elevate) setInput('')
+      setGeneratingName('')
     } catch (e) {
+      setGeneratingName('')
       setErrorMsg(e.message)
       setStatus('error')
       return
@@ -262,6 +268,7 @@ export default function App() {
 
   function handleClose() {
     setRecipe(null)
+    setGeneratingName('')
     setErrorMsg('')
     setStatus('idle')
     setSaveState('idle')
@@ -347,13 +354,11 @@ export default function App() {
             </div>
           </div>
 
-          {/* Loading label */}
-          {busy && (
+          {/* Loading label — for search/clip only; generate/elevate use GeneratingCard */}
+          {busy && (status === 'searching' || status === 'clipping') && (
             <div className="status-label">
               {status === 'searching' && 'Searching…'}
               {status === 'clipping' && 'Clipping recipe…'}
-              {status === 'generating' && 'Generating recipe with AI…'}
-              {status === 'elevating' && 'Elevating recipe with AI…'}
             </div>
           )}
 
@@ -390,8 +395,13 @@ export default function App() {
           )}
         </div>
 
+        {/* GeneratingCard — shown while generate/elevate is in-flight */}
+        {(status === 'generating' || status === 'elevating') && generatingName && (
+          <GeneratingCard dishName={generatingName} />
+        )}
+
         {/* Recipe card */}
-        {recipe && (
+        {recipe && !(status === 'generating') && (
           <RecipeCard
             recipe={recipe}
             onClose={handleClose}

--- a/recipe-app/src/GeneratingCard.jsx
+++ b/recipe-app/src/GeneratingCard.jsx
@@ -1,0 +1,37 @@
+import React, { useState, useEffect } from 'react'
+
+const KITCHEN_PHRASES = [
+  'Selecting ingredients…',
+  'Balancing flavours…',
+  'Writing the method…',
+  'Seasoning to taste…',
+  'Plating up…',
+]
+
+export default function GeneratingCard({ dishName }) {
+  const [phraseIndex, setPhraseIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setPhraseIndex(i => (i + 1) % KITCHEN_PHRASES.length)
+    }, 3500)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <div className="generating-card">
+      <div className="generating-visual">
+        <span className="generating-bubble" />
+        <span className="generating-bubble" />
+        <span className="generating-bubble" />
+        <span className="generating-bubble" />
+        <span className="generating-bubble" />
+      </div>
+      <div className="generating-dish-name">{dishName}</div>
+      <p className="generating-phrase" key={phraseIndex}>
+        {KITCHEN_PHRASES[phraseIndex]}
+      </p>
+      <p className="generating-hint">AI recipes take about 15 seconds</p>
+    </div>
+  )
+}

--- a/recipe-app/src/__tests__/App.test.jsx
+++ b/recipe-app/src/__tests__/App.test.jsx
@@ -504,8 +504,9 @@ describe('Recipe card lifecycle', () => {
 
     await waitFor(() => screen.getByText(/Generation failed: 503/i));
 
-    // A new successful generation clears the error
+    // Re-type and start a new successful generation — the error should clear
     mockFetchOk(GENERATE_RESPONSE);
+    setInputValue('omelette');
     fireEvent.click(screen.getByText('Generate'));
 
     await waitFor(() => screen.getByRole('heading', { name: /AI Omelette/i }));

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -551,3 +551,77 @@ html, body {
   color: var(--text);
   margin-bottom: 6px;
 }
+
+/* ── GeneratingCard ── */
+.generating-card {
+  background: var(--surface);
+  border: 1px solid rgba(232,200,122,0.4);
+  border-radius: var(--radius);
+  overflow: hidden;
+  animation: slide-up 0.25s ease, gen-glow 2s ease-in-out infinite;
+  padding: 32px 20px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+@keyframes gen-glow {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(232,200,122,0.2), 0 0 16px rgba(232,200,122,0.06); }
+  50%       { box-shadow: 0 0 0 2px rgba(232,200,122,0.5), 0 0 36px rgba(232,200,122,0.16); }
+}
+
+.generating-visual {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 40px;
+}
+
+.generating-bubble {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--generate-color);
+  opacity: 0;
+  animation: bubble-rise 1.8s ease-in-out infinite alternate;
+}
+
+.generating-bubble:nth-child(1) { animation-delay: 0s; }
+.generating-bubble:nth-child(2) { animation-delay: 0.3s; }
+.generating-bubble:nth-child(3) { animation-delay: 0.6s; }
+.generating-bubble:nth-child(4) { animation-delay: 0.9s; }
+.generating-bubble:nth-child(5) { animation-delay: 1.2s; }
+
+@keyframes bubble-rise {
+  0%   { opacity: 0;   transform: translateY(0); }
+  30%  { opacity: 0.9; }
+  100% { opacity: 0.2; transform: translateY(-18px); }
+}
+
+.generating-dish-name {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.generating-phrase {
+  font-size: 0.9rem;
+  color: var(--generate-color);
+  font-style: italic;
+  animation: phrase-fade-in 0.4s ease;
+}
+
+@keyframes phrase-fade-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.generating-hint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  margin-top: -4px;
+}


### PR DESCRIPTION
## Summary

- Adds new `GeneratingCard` component that appears immediately when Generate is clicked, showing the dish name, animated saffron bubbles, and cycling kitchen phrases (\"Selecting ingredients…\", \"Balancing flavours…\", etc.)
- Captures and clears the input right away so the omnibox resets while generation is in-flight
- Replaces the generic \"Generating recipe with AI…\" status label for generate/elevate flows; search and clip still use the label
- Adds `gen-glow`, `bubble-rise`, and `phrase-fade-in` CSS keyframe animations with saffron (`#e8c87a`) accent throughout
- GeneratingCard dissolves and RecipeCard slides up on completion; errors revert to the omnibox error label as before
- Updates one test to re-type dish name before retrying after an error (input is now cleared at generation start)

## Test plan

- [ ] Type a dish name → click Generate: input clears instantly, GeneratingCard appears with dish name + bubbles + cycling phrase
- [ ] Wait for API response: GeneratingCard disappears, RecipeCard slides up with \"AI Generated\" badge
- [ ] Click Elevate on an existing card: GeneratingCard shows with recipe name while elevating
- [ ] Simulate generation error: error label shows below omnibox, GeneratingCard is gone
- [ ] All 53 existing tests pass (`npm test -- --watchAll=false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)