### PR TITLE
Verification email message-id error

### DIFF
--- a/auth-worker/src/services/email-service.ts
+++ b/auth-worker/src/services/email-service.ts
@@ -41,18 +41,20 @@ export class EmailService {
         };
       }
 
+      const messageId = this.generateMessageId();
       const rawMessage = this.buildRawMimeMessage({
         to,
         subject,
         htmlBody,
-        textBody
+        textBody,
+        messageId
       });
       const emailMessage = new EmailMessage(this.fromEmail, to, rawMessage);
       await this.sendEmailBinding.send(emailMessage);
 
       return {
         success: true,
-        messageId: this.generateMessageId()
+        messageId
       };
     } catch (error) {
       console.error('Error sending email:', error);
@@ -88,11 +90,23 @@ export class EmailService {
   }
 
   private generateMessageId(): string {
-    return `cf-email-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const fromDomain = this.getFromAddressDomain();
+    return `<cf-email-${Date.now()}-${Math.random().toString(36).slice(2, 10)}@${fromDomain}>`;
   }
 
-  private buildRawMimeMessage(options: EmailOptions): string {
-    const { to, subject, htmlBody, textBody } = options;
+  private getFromAddressDomain(): string {
+    const emailMatch = this.fromEmail.match(/<?([^\s<>@]+@[^\s<>@]+)>?/);
+    if (!emailMatch) {
+      return 'workers.dev';
+    }
+
+    const [, address] = emailMatch;
+    const domain = address.split('@')[1];
+    return domain || 'workers.dev';
+  }
+
+  private buildRawMimeMessage(options: EmailOptions & { messageId: string }): string {
+    const { to, subject, htmlBody, textBody, messageId } = options;
     const boundary = `cf-boundary-${Date.now()}-${Math.random().toString(16).slice(2)}`;
     const plainTextBody = this.normalizeLineEndings(textBody || this.stripHtml(htmlBody));
     const normalizedHtmlBody = this.normalizeLineEndings(htmlBody);
@@ -101,6 +115,7 @@ export class EmailService {
       `From: ${this.fromEmail}`,
       `To: ${to}`,
       `Subject: ${subject}`,
+      `Message-ID: ${messageId}`,
       'MIME-Version: 1.0',
       `Date: ${new Date().toUTCString()}`,
       `Content-Type: multipart/alternative; boundary="${boundary}"`,

--- a/auth-worker/tests/email-service.test.ts
+++ b/auth-worker/tests/email-service.test.ts
@@ -69,7 +69,7 @@ describe('EmailService', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.messageId).toMatch(/^cf-email-/);
+      expect(result.messageId).toMatch(/^<cf-email-.*@example\.com>$/);
       expect(mockEnv.send_email.send).toHaveBeenCalledTimes(1);
 
       const sentMessage = vi.mocked(mockEnv.send_email.send).mock.calls[0][0] as EmailMessage;
@@ -77,6 +77,7 @@ describe('EmailService', () => {
       expect((sentMessage as any).from).toBe('test@example.com');
       expect((sentMessage as any).to).toBe('test@example.com');
       expect((sentMessage as any).raw).toContain('Subject:');
+      expect((sentMessage as any).raw).toContain(`Message-ID: ${result.messageId}`);
       expect((sentMessage as any).raw).toContain('Test text');
       expect((sentMessage as any).raw).toContain('Test HTML');
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `Message-ID` header to verification emails to resolve "no message-id set" errors from Cloudflare.

<div><a href="https://cursor.com/agents/bc-b72a8813-e5a7-40a0-93e9-e5500e3c23e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b72a8813-e5a7-40a0-93e9-e5500e3c23e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->