### PR TITLE
fix: close search dropdown before opening generated recipe fullscreen

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2030,13 +2030,14 @@ function App() {
           generationMethod: result.generationMethod
         };
 
+        // Clear search input BEFORE opening fullscreen to prevent the
+        // dropdown from briefly overlapping the generated recipe view
+        setSearchInput('');
+        setShowSearchResults(false);
+
         // Open the generated recipe directly in fullscreen view
         setSelectedRecipe(generatedRecipe);
         window.history.pushState({ recipeView: true }, '', window.location.href);
-        
-        // Clear search input
-        setSearchInput('');
-        setShowSearchResults(false);
         
         return true;
       } else {
@@ -2576,6 +2577,7 @@ function App() {
           isSearching={isSearching}
           onSearchBarClip={handleSearchBarClip}
           onSearchRecipes={searchRecipes}
+          onSearchResultsClear={() => { setShowSearchResults(false); setSearchResults([]); }}
           onRecipeSelect={openRecipeView}
           onClipDialogOpen={() => setIsClipping(true)}
           onGenerateAiRecipe={generateAiRecipeFromSearch}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -12,24 +12,25 @@ const Header = ({
   isSearching,
   onSearchBarClip,
   onSearchRecipes,
+  onSearchResultsClear,
   onRecipeSelect,
   onClipDialogOpen,
   onGenerateAiRecipe,
   isGeneratingAiRecipe
 }) => {
   const handleSearchInputChange = (e) => {
-    setSearchInput(e.target.value);
+    const value = e.target.value;
+    setSearchInput(value);
     
-    // Clear search results if it's a URL
-    if (isValidUrl(e.target.value)) {
-      // Clear search results if it's a URL
-      // This will be handled by the parent component
-    } else if (e.target.value.trim().length >= 2) {
+    if (isValidUrl(value)) {
+      // URL entered — clear any open search results
+      onSearchResultsClear();
+    } else if (value.trim().length >= 2) {
       // Trigger search for non-URL inputs
-      onSearchRecipes(e.target.value);
+      onSearchRecipes(value);
     } else {
-      // Clear results if query is too short
-      // This will be handled by the parent component
+      // Input cleared or too short — explicitly hide search results
+      onSearchResultsClear();
     }
   };
 
@@ -143,9 +144,8 @@ const Header = ({
                   key={recipe.id} 
                   className="search-result-item"
                   onClick={() => {
-                    // Open the recipe in fullscreen view
                     onRecipeSelect(recipe);
-                    // Clear search - this will be handled by parent
+                    onSearchResultsClear();
                   }}
                 >
                   <div className="search-result-title">{recipe.name}</div>


### PR DESCRIPTION
- Reorder state updates in generateAiRecipeFromSearch so search input and showSearchResults are cleared BEFORE setSelectedRecipe is called, preventing the dropdown from overlapping the recipe fullscreen view.

- Add onSearchResultsClear prop to Header component and call it in all cases where the dropdown should close: input cleared/too short, URL entered, and when a search result item is clicked.

- Wire up onSearchResultsClear in App.jsx to reset both showSearchResults and searchResults, preventing stale data on next open.