### PR TITLE
feat(auth): add WebAuthn passkey support as alternative sign-in method

### DIFF
--- a/auth-worker/package-lock.json
+++ b/auth-worker/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@simplewebauthn/server": "^13.1.1",
         "hono": "^4.5.0",
         "jose": "^5.2.3"
       },
@@ -778,6 +779,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1316,6 +1323,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1352,6 +1365,174 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.8.0.tgz",
+      "integrity": "sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1693,6 +1874,25 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.1.tgz",
+      "integrity": "sha512-GV/oM/qeycWn8p42JZIMJBsXWQcNFg+nJFzeQTnMA4gN8mXg0+HZFWJerHg8ZN/zlveMS3iV1wzuFpOVWS/46w==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.0.2",
@@ -2229,6 +2429,20 @@
       "license": "MIT",
       "dependencies": {
         "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assertion-error": {
@@ -3887,6 +4101,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -3907,6 +4139,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4524,9 +4762,25 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/auth-worker/package.json
+++ b/auth-worker/package.json
@@ -48,6 +48,7 @@
     "wrangler": "^4.32.0"
   },
   "dependencies": {
+    "@simplewebauthn/server": "^13.1.1",
     "hono": "^4.5.0",
     "jose": "^5.2.3"
   }

--- a/auth-worker/src/index.ts
+++ b/auth-worker/src/index.ts
@@ -505,6 +505,135 @@ app.post('/email/send-verification', async (c) => {
   }
 });
 
+// Passkey Endpoints
+
+// Extract and verify Bearer JWT — returns payload or null
+async function getAuthPayload(authHeader: string | undefined, env: Env) {
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7);
+  const { JWTService } = await import('./services/jwt-service');
+  const result = await new JWTService(env).verifyToken(token);
+  return result.success && result.payload ? result.payload : null;
+}
+
+// Hash an email the same way OTP manager does (SHA-256 hex)
+async function hashEmailLocal(email: string): Promise<string> {
+  const { hashEmail } = await import('./utils/crypto');
+  return hashEmail(email);
+}
+
+// Begin passkey registration (requires valid JWT)
+app.post('/passkeys/register/begin', async (c) => {
+  try {
+    const payload = await getAuthPayload(c.req.header('Authorization'), c.env);
+    if (!payload) {
+      return c.json({ success: false, message: 'Authentication required' }, 401);
+    }
+
+    const { PasskeyService } = await import('./services/passkey-service');
+    const svc = new PasskeyService(c.env);
+    const result = await svc.beginRegistration(payload.sub, payload.email);
+
+    if (result.success) {
+      return c.json({ success: true, options: result.options });
+    } else {
+      return c.json({ success: false, message: result.error }, 400);
+    }
+  } catch (error) {
+    console.error('Error beginning passkey registration:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+// Complete passkey registration (requires valid JWT)
+app.post('/passkeys/register/complete', async (c) => {
+  try {
+    const payload = await getAuthPayload(c.req.header('Authorization'), c.env);
+    if (!payload) {
+      return c.json({ success: false, message: 'Authentication required' }, 401);
+    }
+
+    const body = await c.req.json();
+    const { response } = body;
+    if (!response) {
+      return c.json({ success: false, message: 'response is required' }, 400);
+    }
+
+    const { PasskeyService } = await import('./services/passkey-service');
+    const svc = new PasskeyService(c.env);
+    const result = await svc.completeRegistration(payload.sub, payload.email, response);
+
+    if (result.success) {
+      return c.json({ success: true, credential: result.credential });
+    } else {
+      return c.json({ success: false, message: result.error }, 400);
+    }
+  } catch (error) {
+    console.error('Error completing passkey registration:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+// Begin passkey authentication (no auth required)
+app.post('/passkeys/authenticate/begin', async (c) => {
+  try {
+    const body = await c.req.json().catch(() => ({})) as { email?: string };
+    const { email } = body;
+
+    let userId: string | null = null;
+    if (email && typeof email === 'string') {
+      userId = await hashEmailLocal(email);
+    }
+
+    const { PasskeyService } = await import('./services/passkey-service');
+    const svc = new PasskeyService(c.env);
+    const result = await svc.beginAuthentication(userId);
+
+    if (result.success) {
+      return c.json({ success: true, options: result.options, sessionToken: result.sessionToken });
+    } else {
+      const status = result.error === 'no_passkeys' ? 404 : 400;
+      return c.json({ success: false, message: result.error }, status);
+    }
+  } catch (error) {
+    console.error('Error beginning passkey authentication:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+// Complete passkey authentication (no auth required)
+app.post('/passkeys/authenticate/complete', async (c) => {
+  try {
+    const body = await c.req.json();
+    const { sessionToken, response } = body;
+
+    if (!sessionToken || typeof sessionToken !== 'string') {
+      return c.json({ success: false, message: 'sessionToken is required' }, 400);
+    }
+    if (!response) {
+      return c.json({ success: false, message: 'response is required' }, 400);
+    }
+
+    const { PasskeyService } = await import('./services/passkey-service');
+    const svc = new PasskeyService(c.env);
+    const result = await svc.completeAuthentication(sessionToken, response);
+
+    if (result.success) {
+      return c.json({
+        success: true,
+        token: result.jwtToken,
+        expiresIn: 604800,
+        user: result.user,
+      });
+    } else {
+      return c.json({ success: false, message: result.error }, 400);
+    }
+  } catch (error) {
+    console.error('Error completing passkey authentication:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
 // Root endpoint
 app.get('/', (c) => {
   return c.json({

--- a/auth-worker/src/services/passkey-service.ts
+++ b/auth-worker/src/services/passkey-service.ts
@@ -1,0 +1,310 @@
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  AuthenticatorTransportFuture,
+  WebAuthnCredential,
+} from '@simplewebauthn/server';
+import { Env } from '../types/env';
+import { generateSecureToken } from '../utils/crypto';
+
+const CHALLENGE_TTL = 300; // 5 minutes
+
+function uint8ArrayToBase64url(arr: Uint8Array): string {
+  return btoa(String.fromCharCode(...arr))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+function base64urlToUint8Array(str: string): Uint8Array<ArrayBuffer> {
+  const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (c) => c.charCodeAt(0)) as Uint8Array<ArrayBuffer>;
+}
+
+interface StoredRegChallenge {
+  challenge: string;
+  userId: string;
+  email: string;
+}
+
+interface StoredAuthChallenge {
+  challenge: string;
+  userId: string | null;
+}
+
+interface PasskeyCredentialRecord {
+  credential_id: string;
+  user_id: string;
+  public_key: string;
+  counter: number;
+  device_type: string;
+  backed_up: number;
+  transports: string | null;
+}
+
+export class PasskeyService {
+  constructor(private env: Env) {}
+
+  private get rpID() { return this.env.WEBAUTHN_RP_ID ?? 'localhost'; }
+  private get rpName() { return this.env.WEBAUTHN_RP_NAME ?? 'Seasoned'; }
+  private get origin() { return this.env.WEBAUTHN_ORIGIN ?? 'http://localhost:5173'; }
+  private get umURL() { return this.env.USER_MANAGEMENT_WORKER_URL; }
+
+  private async fetchCredentialsForUser(userId: string): Promise<PasskeyCredentialRecord[]> {
+    const res = await fetch(`${this.umURL}/passkey-credentials/user/${encodeURIComponent(userId)}`);
+    if (!res.ok) return [];
+    const json = await res.json() as { success: boolean; data?: PasskeyCredentialRecord[] };
+    return json.success && json.data ? json.data : [];
+  }
+
+  // --- Registration ---
+
+  async beginRegistration(userId: string, email: string): Promise<{
+    success: boolean;
+    options?: PublicKeyCredentialCreationOptionsJSON;
+    error?: string;
+  }> {
+    const existing = await this.fetchCredentialsForUser(userId);
+
+    const encoder = new TextEncoder();
+    const options = await generateRegistrationOptions({
+      rpName: this.rpName,
+      rpID: this.rpID,
+      userID: encoder.encode(userId) as Uint8Array<ArrayBuffer>,
+      userName: email,
+      userDisplayName: email,
+      attestationType: 'none',
+      excludeCredentials: existing.map((c) => ({
+        id: c.credential_id,
+        transports: (c.transports ? JSON.parse(c.transports) : []) as AuthenticatorTransportFuture[],
+      })),
+      authenticatorSelection: {
+        residentKey: 'preferred',
+        userVerification: 'preferred',
+      },
+    });
+
+    await this.env.OTP_KV.put(
+      `passkey:reg:${userId}`,
+      JSON.stringify({ challenge: options.challenge, userId, email } satisfies StoredRegChallenge),
+      { expirationTtl: CHALLENGE_TTL }
+    );
+
+    return { success: true, options };
+  }
+
+  async completeRegistration(userId: string, email: string, response: RegistrationResponseJSON): Promise<{
+    success: boolean;
+    credential?: { credentialId: string; deviceType: string; backedUp: boolean };
+    error?: string;
+  }> {
+    const raw = await this.env.OTP_KV.get(`passkey:reg:${userId}`);
+    if (!raw) {
+      return { success: false, error: 'Registration challenge expired or not found' };
+    }
+
+    const stored = JSON.parse(raw) as StoredRegChallenge;
+    await this.env.OTP_KV.delete(`passkey:reg:${userId}`);
+
+    let verification;
+    try {
+      verification = await verifyRegistrationResponse({
+        response,
+        expectedChallenge: stored.challenge,
+        expectedOrigin: this.origin,
+        expectedRPID: this.rpID,
+      });
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : 'Verification failed' };
+    }
+
+    if (!verification.verified || !verification.registrationInfo) {
+      return { success: false, error: 'Registration verification failed' };
+    }
+
+    const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+
+    const createRes = await fetch(`${this.umURL}/passkey-credentials`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        credential_id: credential.id,
+        user_id: userId,
+        public_key: uint8ArrayToBase64url(credential.publicKey),
+        counter: credential.counter,
+        device_type: credentialDeviceType,
+        backed_up: credentialBackedUp,
+        transports: credential.transports,
+      }),
+    });
+
+    if (!createRes.ok) {
+      return { success: false, error: 'Failed to store passkey credential' };
+    }
+
+    return {
+      success: true,
+      credential: {
+        credentialId: credential.id,
+        deviceType: credentialDeviceType,
+        backedUp: credentialBackedUp,
+      },
+    };
+  }
+
+  // --- Authentication ---
+
+  async beginAuthentication(userId: string | null): Promise<{
+    success: boolean;
+    options?: PublicKeyCredentialRequestOptionsJSON;
+    sessionToken?: string;
+    error?: string;
+  }> {
+    let allowCredentials: { id: string; transports?: AuthenticatorTransportFuture[] }[] = [];
+
+    if (userId) {
+      const creds = await this.fetchCredentialsForUser(userId);
+      if (creds.length === 0) {
+        return { success: false, error: 'no_passkeys' };
+      }
+      allowCredentials = creds.map((c) => ({
+        id: c.credential_id,
+        transports: (c.transports ? JSON.parse(c.transports) : undefined) as AuthenticatorTransportFuture[] | undefined,
+      }));
+    }
+
+    const options = await generateAuthenticationOptions({
+      rpID: this.rpID,
+      allowCredentials,
+      userVerification: 'preferred',
+    });
+
+    const sessionToken = generateSecureToken(16);
+
+    await this.env.OTP_KV.put(
+      `passkey:auth:${sessionToken}`,
+      JSON.stringify({ challenge: options.challenge, userId } satisfies StoredAuthChallenge),
+      { expirationTtl: CHALLENGE_TTL }
+    );
+
+    return { success: true, options, sessionToken };
+  }
+
+  async completeAuthentication(sessionToken: string, response: AuthenticationResponseJSON): Promise<{
+    success: boolean;
+    jwtToken?: string;
+    user?: { id: string; email: string };
+    error?: string;
+  }> {
+    const raw = await this.env.OTP_KV.get(`passkey:auth:${sessionToken}`);
+    if (!raw) {
+      return { success: false, error: 'Authentication challenge expired or not found' };
+    }
+
+    const stored = JSON.parse(raw) as StoredAuthChallenge;
+    await this.env.OTP_KV.delete(`passkey:auth:${sessionToken}`);
+
+    // Look up the credential
+    const credRes = await fetch(
+      `${this.umURL}/passkey-credentials/${encodeURIComponent(response.id)}`
+    );
+    if (!credRes.ok) {
+      return { success: false, error: 'Passkey credential not found' };
+    }
+    const credJson = await credRes.json() as { success: boolean; data?: PasskeyCredentialRecord };
+    if (!credJson.success || !credJson.data) {
+      return { success: false, error: 'Passkey credential not found' };
+    }
+    const storedCred = credJson.data;
+
+    // Verify the credential belongs to the expected user (if we targeted one)
+    if (stored.userId && storedCred.user_id !== stored.userId) {
+      return { success: false, error: 'Credential does not belong to expected user' };
+    }
+
+    const authenticatorCredential: WebAuthnCredential = {
+      id: storedCred.credential_id,
+      publicKey: base64urlToUint8Array(storedCred.public_key),
+      counter: storedCred.counter,
+      transports: storedCred.transports
+        ? (JSON.parse(storedCred.transports) as AuthenticatorTransportFuture[])
+        : undefined,
+    };
+
+    let verification;
+    try {
+      verification = await verifyAuthenticationResponse({
+        response,
+        expectedChallenge: stored.challenge,
+        expectedOrigin: this.origin,
+        expectedRPID: this.rpID,
+        credential: authenticatorCredential,
+        requireUserVerification: true,
+      });
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : 'Verification failed' };
+    }
+
+    if (!verification.verified) {
+      return { success: false, error: 'Authentication verification failed' };
+    }
+
+    const { newCounter } = verification.authenticationInfo;
+
+    // Replay attack detection: counter must advance if it was non-zero
+    if (storedCred.counter !== 0 && newCounter <= storedCred.counter) {
+      return { success: false, error: 'Counter regression detected — possible cloned authenticator' };
+    }
+
+    // Update counter
+    await fetch(`${this.umURL}/passkey-credentials/${encodeURIComponent(storedCred.credential_id)}/counter`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ counter: newCounter }),
+    });
+
+    const userId = storedCred.user_id;
+
+    // Resolve user email from user management worker
+    const userRes = await fetch(`${this.umURL}/users/${encodeURIComponent(userId)}`);
+    const userJson = userRes.ok
+      ? await userRes.json() as { success: boolean; data?: { email_encrypted?: string } }
+      : null;
+    const email = (userJson?.success && userJson.data?.email_encrypted) ? userJson.data.email_encrypted : '';
+
+    // Issue JWT
+    const { JWTService } = await import('./jwt-service');
+    const jwtService = new JWTService(this.env);
+    const tokenResult = await jwtService.createToken(userId, email, 604800);
+
+    if (!tokenResult.success || !tokenResult.token) {
+      return { success: false, error: 'Failed to issue JWT' };
+    }
+
+    // Record login history (best-effort)
+    fetch(`${this.umURL}/login-history`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        user_id: userId,
+        login_method: 'PASSKEY',
+        success: true,
+      }),
+    }).catch(() => {/* non-fatal */});
+
+    return {
+      success: true,
+      jwtToken: tokenResult.token,
+      user: { id: userId, email },
+    };
+  }
+}

--- a/auth-worker/src/types/env.ts
+++ b/auth-worker/src/types/env.ts
@@ -18,4 +18,9 @@ export interface Env {
   
   // JWT configuration
   JWT_SECRET: string;
+
+  // WebAuthn / Passkey configuration (required in production; set via wrangler.toml [vars])
+  WEBAUTHN_RP_ID?: string;
+  WEBAUTHN_RP_NAME?: string;
+  WEBAUTHN_ORIGIN?: string;
 }

--- a/auth-worker/src/utils/crypto.ts
+++ b/auth-worker/src/utils/crypto.ts
@@ -11,7 +11,7 @@
 export async function hashEmail(email: string): Promise<string> {
   const encoder = new TextEncoder();
   const data = encoder.encode(email.toLowerCase().trim());
-  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
 }
@@ -26,13 +26,13 @@ export async function hashOTP(otp: string, salt?: string): Promise<{hash: string
   if (!salt) {
     // Generate a random salt
     const saltArray = new Uint8Array(16);
-    globalThis.crypto.getRandomValues(saltArray);
+    crypto.getRandomValues(saltArray);
     salt = Array.from(saltArray).map(b => b.toString(16).padStart(2, '0')).join('');
   }
 
   const encoder = new TextEncoder();
   const otpData = encoder.encode(otp + salt);
-  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', otpData);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', otpData);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   const hash = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
   
@@ -75,7 +75,7 @@ export function generateOTP(length: number = 6): string {
  */
 export function generateSecureToken(length: number = 32): string {
   const tokenArray = new Uint8Array(length);
-  globalThis.crypto.getRandomValues(tokenArray);
+  crypto.getRandomValues(tokenArray);
   return Array.from(tokenArray).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 

--- a/auth-worker/src/utils/crypto.ts
+++ b/auth-worker/src/utils/crypto.ts
@@ -11,7 +11,7 @@
 export async function hashEmail(email: string): Promise<string> {
   const encoder = new TextEncoder();
   const data = encoder.encode(email.toLowerCase().trim());
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', data);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
 }
@@ -26,13 +26,13 @@ export async function hashOTP(otp: string, salt?: string): Promise<{hash: string
   if (!salt) {
     // Generate a random salt
     const saltArray = new Uint8Array(16);
-    crypto.getRandomValues(saltArray);
+    globalThis.crypto.getRandomValues(saltArray);
     salt = Array.from(saltArray).map(b => b.toString(16).padStart(2, '0')).join('');
   }
-  
+
   const encoder = new TextEncoder();
   const otpData = encoder.encode(otp + salt);
-  const hashBuffer = await crypto.subtle.digest('SHA-256', otpData);
+  const hashBuffer = await globalThis.crypto.subtle.digest('SHA-256', otpData);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
   const hash = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
   
@@ -75,7 +75,7 @@ export function generateOTP(length: number = 6): string {
  */
 export function generateSecureToken(length: number = 32): string {
   const tokenArray = new Uint8Array(length);
-  crypto.getRandomValues(tokenArray);
+  globalThis.crypto.getRandomValues(tokenArray);
   return Array.from(tokenArray).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 

--- a/auth-worker/tests/setup.ts
+++ b/auth-worker/tests/setup.ts
@@ -1,0 +1,14 @@
+// Ensure `crypto` is accessible as a bare top-level identifier in Node 18.
+// Node 18 exposes the Web Crypto API on globalThis.crypto (stable since 18.0.0)
+// but the bare `crypto` binding was not added until Node 19. This polyfill
+// materializes it so production code using `crypto.getRandomValues()` etc. works
+// in both Node 18 and Node 20+ test environments.
+const _g = globalThis as Record<string, unknown>;
+if (typeof crypto === 'undefined' && typeof _g['crypto'] !== 'undefined') {
+  Object.defineProperty(globalThis, 'crypto', {
+    value: _g['crypto'],
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+}

--- a/auth-worker/tests/unit/passkey-endpoints.test.ts
+++ b/auth-worker/tests/unit/passkey-endpoints.test.ts
@@ -1,0 +1,557 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import app from '../../src/index';
+import { JWTService } from '../../src/services/jwt-service';
+
+// --- Mocks ---
+
+vi.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: vi.fn().mockResolvedValue({
+    challenge: 'mock-challenge-base64url',
+    rp: { id: 'localhost', name: 'Seasoned' },
+    user: { id: 'dXNlcklk', name: 'test@example.com', displayName: 'test@example.com' },
+    pubKeyCredParams: [],
+    timeout: 60000,
+    excludeCredentials: [],
+    authenticatorSelection: {},
+    attestation: 'none',
+  }),
+  verifyRegistrationResponse: vi.fn().mockResolvedValue({
+    verified: true,
+    registrationInfo: {
+      credential: {
+        id: 'cred-id-base64url',
+        publicKey: new Uint8Array([1, 2, 3, 4]),
+        counter: 0,
+        transports: ['internal'],
+      },
+      credentialDeviceType: 'singleDevice',
+      credentialBackedUp: false,
+    },
+  }),
+  generateAuthenticationOptions: vi.fn().mockResolvedValue({
+    challenge: 'mock-auth-challenge-base64url',
+    rpId: 'localhost',
+    allowCredentials: [],
+    userVerification: 'preferred',
+    timeout: 60000,
+  }),
+  verifyAuthenticationResponse: vi.fn().mockResolvedValue({
+    verified: true,
+    authenticationInfo: {
+      credentialID: 'cred-id-base64url',
+      newCounter: 1,
+      userVerified: true,
+      credentialDeviceType: 'singleDevice',
+      credentialBackedUp: false,
+      origin: 'http://localhost:5173',
+      rpID: 'localhost',
+    },
+  }),
+}));
+
+// --- Shared fixtures ---
+
+const JWT_SECRET = 'test-secret-key-for-jwt-signing-32-chars-long';
+const UM_URL = 'http://localhost:8788';
+
+function makeEnv(kvOverrides = {}) {
+  return {
+    OTP_KV: {
+      get: vi.fn(),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      ...kvOverrides,
+    } as any,
+    USER_MANAGEMENT_WORKER_URL: UM_URL,
+    ENVIRONMENT: 'preview' as const,
+    JWT_SECRET,
+    FROM_EMAIL: 'test@example.com',
+    WEBAUTHN_RP_ID: 'localhost',
+    WEBAUTHN_RP_NAME: 'Seasoned',
+    WEBAUTHN_ORIGIN: 'http://localhost:5173',
+    send_email: { send: vi.fn().mockResolvedValue(undefined) },
+  };
+}
+
+async function makeValidToken(env: ReturnType<typeof makeEnv>) {
+  const svc = new JWTService(env);
+  const result = await svc.createToken('user-email-hash', 'user@example.com', 604800);
+  return result.token!;
+}
+
+function mockFetch(...responses: Array<{ ok: boolean; status?: number; body: unknown }>) {
+  let call = 0;
+  return vi.fn().mockImplementation(async () => {
+    const r = responses[Math.min(call++, responses.length - 1)];
+    return {
+      ok: r.ok,
+      status: r.status ?? (r.ok ? 200 : 500),
+      json: async () => r.body,
+    };
+  });
+}
+
+// Stored passkey credential returned by user-management-worker
+const STORED_CRED = {
+  credential_id: 'cred-id-base64url',
+  user_id: 'user-email-hash',
+  // base64url of Uint8Array([1,2,3,4])
+  public_key: 'AQID',
+  counter: 0,
+  device_type: 'singleDevice',
+  backed_up: 0,
+  transports: '["internal"]',
+};
+
+// -------------------------------------------------------------------
+// /passkeys/register/begin
+// -------------------------------------------------------------------
+
+describe('POST /passkeys/register/begin', () => {
+  it('returns 401 when no Authorization header', async () => {
+    const env = makeEnv();
+    const req = new Request('http://localhost/passkeys/register/begin', { method: 'POST' });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(401);
+    const body = await res.json() as any;
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 401 when token is invalid', async () => {
+    const env = makeEnv();
+    const req = new Request('http://localhost/passkeys/register/begin', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer bad.token.here' },
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with registration options when authenticated', async () => {
+    const env = makeEnv();
+    const token = await makeValidToken(env);
+
+    vi.stubGlobal('fetch', mockFetch(
+      // GET /passkey-credentials/user/:id → no existing creds
+      { ok: true, body: { success: true, data: [] } },
+    ));
+
+    const req = new Request('http://localhost/passkeys/register/begin', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.success).toBe(true);
+    expect(body.options).toBeDefined();
+    expect(env.OTP_KV.put).toHaveBeenCalledWith(
+      expect.stringContaining('passkey:reg:'),
+      expect.any(String),
+      { expirationTtl: 300 }
+    );
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// -------------------------------------------------------------------
+// /passkeys/register/complete
+// -------------------------------------------------------------------
+
+describe('POST /passkeys/register/complete', () => {
+  it('returns 401 with no auth', async () => {
+    const env = makeEnv();
+    const req = new Request('http://localhost/passkeys/register/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ response: {} }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when response body is missing', async () => {
+    const env = makeEnv();
+    const token = await makeValidToken(env);
+
+    const req = new Request('http://localhost/passkeys/register/complete', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({}),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when challenge not found in KV', async () => {
+    const env = makeEnv({ get: vi.fn().mockResolvedValue(null) });
+    const token = await makeValidToken(env);
+
+    const req = new Request('http://localhost/passkeys/register/complete', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ response: { id: 'x', rawId: 'x', type: 'public-key', response: {} } }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.success).toBe(false);
+    expect(body.message).toContain('expired');
+  });
+
+  it('returns 200 and stores credential on valid registration', async () => {
+    const storedChallenge = JSON.stringify({
+      challenge: 'mock-challenge-base64url',
+      userId: 'user-email-hash',
+      email: 'user@example.com',
+    });
+    const env = makeEnv({ get: vi.fn().mockResolvedValue(storedChallenge) });
+    const token = await makeValidToken(env);
+
+    vi.stubGlobal('fetch', mockFetch(
+      // POST /passkey-credentials
+      { ok: true, status: 201, body: { success: true, data: STORED_CRED } },
+    ));
+
+    const req = new Request('http://localhost/passkeys/register/complete', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        response: { id: 'cred-id', rawId: 'cred-id', type: 'public-key', response: {} },
+      }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.success).toBe(true);
+    expect(body.credential).toBeDefined();
+    expect(body.credential.credentialId).toBe('cred-id-base64url');
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// -------------------------------------------------------------------
+// /passkeys/authenticate/begin
+// -------------------------------------------------------------------
+
+describe('POST /passkeys/authenticate/begin', () => {
+  it('returns options without email (discoverable flow)', async () => {
+    const env = makeEnv();
+    const req = new Request('http://localhost/passkeys/authenticate/begin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.success).toBe(true);
+    expect(body.options).toBeDefined();
+    expect(body.sessionToken).toBeDefined();
+    expect(typeof body.sessionToken).toBe('string');
+  });
+
+  it('returns 404 when no passkeys registered for email', async () => {
+    const env = makeEnv();
+    vi.stubGlobal('fetch', mockFetch(
+      { ok: true, body: { success: true, data: [] } },
+    ));
+
+    const req = new Request('http://localhost/passkeys/authenticate/begin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'user@example.com' }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(404);
+    const body = await res.json() as any;
+    expect(body.success).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns options with allowCredentials when email has passkeys', async () => {
+    const env = makeEnv();
+    vi.stubGlobal('fetch', mockFetch(
+      { ok: true, body: { success: true, data: [STORED_CRED] } },
+    ));
+
+    const req = new Request('http://localhost/passkeys/authenticate/begin', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'user@example.com' }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.success).toBe(true);
+    expect(body.sessionToken).toBeDefined();
+    expect(env.OTP_KV.put).toHaveBeenCalledWith(
+      expect.stringContaining('passkey:auth:'),
+      expect.any(String),
+      { expirationTtl: 300 }
+    );
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// -------------------------------------------------------------------
+// /passkeys/authenticate/complete
+// -------------------------------------------------------------------
+
+describe('POST /passkeys/authenticate/complete', () => {
+  it('returns 400 when sessionToken is missing', async () => {
+    const env = makeEnv();
+    const req = new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ response: {} }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.success).toBe(false);
+    expect(body.message).toContain('sessionToken');
+  });
+
+  it('returns 400 when response is missing', async () => {
+    const env = makeEnv();
+    const req = new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionToken: 'abc123' }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when challenge not found in KV', async () => {
+    const env = makeEnv({ get: vi.fn().mockResolvedValue(null) });
+    const req = new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionToken: 'expired-token',
+        response: { id: 'cred-id-base64url', type: 'public-key', response: {} },
+      }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.success).toBe(false);
+  });
+
+  it('returns 400 when credential is not found', async () => {
+    const storedChallenge = JSON.stringify({
+      challenge: 'mock-auth-challenge-base64url',
+      userId: 'user-email-hash',
+    });
+    const env = makeEnv({ get: vi.fn().mockResolvedValue(storedChallenge) });
+
+    vi.stubGlobal('fetch', mockFetch(
+      // GET /passkey-credentials/:id → not found
+      { ok: false, status: 404, body: { success: false, message: 'Not found' } },
+    ));
+
+    const req = new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionToken: 'valid-session-token',
+        response: { id: 'cred-id-base64url', type: 'public-key', response: {} },
+      }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.success).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 200 with JWT on successful authentication', async () => {
+    const storedChallenge = JSON.stringify({
+      challenge: 'mock-auth-challenge-base64url',
+      userId: 'user-email-hash',
+    });
+    const env = makeEnv({ get: vi.fn().mockResolvedValue(storedChallenge) });
+
+    vi.stubGlobal('fetch', mockFetch(
+      // GET /passkey-credentials/:id
+      { ok: true, body: { success: true, data: STORED_CRED } },
+      // PATCH /passkey-credentials/:id/counter
+      { ok: true, body: { success: true, data: { ...STORED_CRED, counter: 1 } } },
+      // GET /users/:user_id
+      { ok: true, body: { success: true, data: { user_id: 'user-email-hash', email_encrypted: 'user@example.com' } } },
+      // POST /login-history (best-effort, fires and forgets)
+      { ok: true, body: { success: true } },
+    ));
+
+    const req = new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionToken: 'valid-session-token',
+        response: { id: 'cred-id-base64url', type: 'public-key', response: {} },
+      }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.success).toBe(true);
+    expect(body.token).toBeDefined();
+    expect(body.expiresIn).toBe(604800);
+    expect(body.user).toBeDefined();
+    expect(body.user.id).toBe('user-email-hash');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 400 when user_id mismatch detected', async () => {
+    const storedChallenge = JSON.stringify({
+      challenge: 'mock-auth-challenge-base64url',
+      userId: 'different-user-hash', // mismatch
+    });
+    const env = makeEnv({ get: vi.fn().mockResolvedValue(storedChallenge) });
+
+    vi.stubGlobal('fetch', mockFetch(
+      { ok: true, body: { success: true, data: STORED_CRED } }, // returns user-email-hash
+    ));
+
+    const req = new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionToken: 'valid-session-token',
+        response: { id: 'cred-id-base64url', type: 'public-key', response: {} },
+      }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.success).toBe(false);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 400 when WebAuthn verification fails', async () => {
+    const { verifyAuthenticationResponse } = await import('@simplewebauthn/server');
+    vi.mocked(verifyAuthenticationResponse).mockResolvedValueOnce({
+      verified: false,
+      authenticationInfo: {} as any,
+    });
+
+    const storedChallenge = JSON.stringify({
+      challenge: 'mock-auth-challenge-base64url',
+      userId: 'user-email-hash',
+    });
+    const env = makeEnv({ get: vi.fn().mockResolvedValue(storedChallenge) });
+
+    vi.stubGlobal('fetch', mockFetch(
+      { ok: true, body: { success: true, data: STORED_CRED } },
+    ));
+
+    const req = new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionToken: 'valid-session-token',
+        response: { id: 'cred-id-base64url', type: 'public-key', response: {} },
+      }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 400 when counter regression is detected', async () => {
+    const { verifyAuthenticationResponse } = await import('@simplewebauthn/server');
+    vi.mocked(verifyAuthenticationResponse).mockResolvedValueOnce({
+      verified: true,
+      authenticationInfo: {
+        credentialID: 'cred-id-base64url',
+        newCounter: 1, // equal to stored counter → regression
+        userVerified: true,
+        credentialDeviceType: 'singleDevice' as any,
+        credentialBackedUp: false,
+        origin: 'http://localhost:5173',
+        rpID: 'localhost',
+      },
+    });
+
+    const credWithCounter = { ...STORED_CRED, counter: 5 }; // stored > new
+    const storedChallenge = JSON.stringify({
+      challenge: 'mock-auth-challenge-base64url',
+      userId: 'user-email-hash',
+    });
+    const env = makeEnv({ get: vi.fn().mockResolvedValue(storedChallenge) });
+
+    vi.stubGlobal('fetch', mockFetch(
+      { ok: true, body: { success: true, data: credWithCounter } },
+    ));
+
+    const req = new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionToken: 'valid-session-token',
+        response: { id: 'cred-id-base64url', type: 'public-key', response: {} },
+      }),
+    });
+    const res = await app.fetch(req, env);
+    expect(res.status).toBe(400);
+    const body = await res.json() as any;
+    expect(body.message).toContain('Counter regression');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 200 with empty email when user lookup fails', async () => {
+    const storedChallenge = JSON.stringify({
+      challenge: 'mock-auth-challenge-base64url',
+      userId: null,
+    });
+    const env = makeEnv({ get: vi.fn().mockResolvedValue(storedChallenge) });
+
+    vi.stubGlobal('fetch', mockFetch(
+      // GET /passkey-credentials/:id → success
+      { ok: true, body: { success: true, data: STORED_CRED } },
+      // PATCH counter → success
+      { ok: true, body: { success: true, data: { ...STORED_CRED, counter: 1 } } },
+      // GET /users/:user_id → not found
+      { ok: false, status: 404, body: { success: false } },
+      // POST /login-history
+      { ok: true, body: { success: true } },
+    ));
+
+    const req = new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sessionToken: 'valid-session-token',
+        response: { id: 'cred-id-base64url', type: 'public-key', response: {} },
+      }),
+    });
+    const res = await app.fetch(req, env);
+    // Should still succeed — email falls back to empty string
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.success).toBe(true);
+    expect(body.token).toBeDefined();
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/auth-worker/vitest.config.ts
+++ b/auth-worker/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node', // Changed from 'miniflare' to fix timeout issues
+    setupFiles: ['./tests/setup.ts'],
     // environmentOptions: {
     //   wranglerConfigPath: './wrangler.toml',
     //   packagePath: true,

--- a/auth-worker/wrangler.toml
+++ b/auth-worker/wrangler.toml
@@ -11,6 +11,9 @@ id = "1fdebf1b59e249a691746f85a9eb5e62" # Will be replaced with actual ID after 
 [vars]
 FROM_EMAIL = "verify@seasonedapp.com"
 USER_MANAGEMENT_WORKER_URL = "https://user-management-worker.nolanfoster.workers.dev"
+WEBAUTHN_RP_NAME = "Seasoned"
+WEBAUTHN_RP_ID = "localhost"
+WEBAUTHN_ORIGIN = "http://localhost:5173"
 
 # Cloudflare Email Workers send_email binding
 [[send_email]]
@@ -32,6 +35,9 @@ name = "auth-worker-preview"
 [env.preview.vars]
 FROM_EMAIL = "verify@seasonedapp.com"
 USER_MANAGEMENT_WORKER_URL = "https://user-management-worker.nolanfoster.workers.dev"
+WEBAUTHN_RP_NAME = "Seasoned"
+WEBAUTHN_RP_ID = "localhost"
+WEBAUTHN_ORIGIN = "http://localhost:5173"
 
 [[env.preview.send_email]]
 name = "send_email"
@@ -50,6 +56,9 @@ name = "auth-worker-production"
 [env.production.vars]
 FROM_EMAIL = "verify@seasonedapp.com"
 USER_MANAGEMENT_WORKER_URL = "https://user-management-worker.nolanfoster.workers.dev"
+WEBAUTHN_RP_NAME = "Seasoned"
+WEBAUTHN_RP_ID = "seasonedapp.com"
+WEBAUTHN_ORIGIN = "https://seasonedapp.com"
 
 [[env.production.send_email]]
 name = "send_email"
@@ -68,6 +77,9 @@ name = "auth-worker-staging"
 [env.staging.vars]
 FROM_EMAIL = "verify@seasonedapp.com"
 USER_MANAGEMENT_WORKER_URL = "https://user-management-worker.nolanfoster.workers.dev"
+WEBAUTHN_RP_NAME = "Seasoned"
+WEBAUTHN_RP_ID = "seasonedapp.com"
+WEBAUTHN_ORIGIN = "https://seasonedapp.com"
 
 [[env.staging.send_email]]
 name = "send_email"

--- a/recipe-app/package-lock.json
+++ b/recipe-app/package-lock.json
@@ -11,6 +11,7 @@
         "@flaggly/sdk": "^0.2.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@mediapipe/tasks-vision": "^0.10.32",
+        "@simplewebauthn/browser": "^13.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -4229,6 +4230,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",

--- a/recipe-app/package.json
+++ b/recipe-app/package.json
@@ -17,6 +17,7 @@
     "@flaggly/sdk": "^0.2.0",
     "@hello-pangea/dnd": "^18.0.1",
     "@mediapipe/tasks-vision": "^0.10.32",
+    "@simplewebauthn/browser": "^13.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -56,9 +56,10 @@ function useDebounce(fn, delay) {
   }, [fn, delay])
 }
 
-function UserMenu({ user, onSignOut }) {
+function UserMenu({ user, onSignOut, onRegisterPasskey }) {
   const [open, setOpen] = useState(false)
   const [opacity, setOpacity] = useState(1)
+  const [passkeyStatus, setPasskeyStatus] = useState('idle') // idle | loading | done | error
   const menuRef = useRef(null)
 
   useEffect(() => {
@@ -101,6 +102,33 @@ function UserMenu({ user, onSignOut }) {
           <div className="user-menu-info">
             <div className="user-menu-email">{user?.email}</div>
           </div>
+          {onRegisterPasskey && (
+            <button
+              className="user-menu-item"
+              onClick={async () => {
+                setPasskeyStatus('loading')
+                try {
+                  await onRegisterPasskey()
+                  setPasskeyStatus('done')
+                  setTimeout(() => setPasskeyStatus('idle'), 2000)
+                } catch {
+                  setPasskeyStatus('error')
+                  setTimeout(() => setPasskeyStatus('idle'), 2500)
+                }
+              }}
+              disabled={passkeyStatus === 'loading'}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" width="16" height="16">
+                <circle cx="12" cy="8" r="3"/>
+                <path d="M6 21v-1a6 6 0 0112 0v1"/>
+                <path d="M18 15l2 2 4-4"/>
+              </svg>
+              {passkeyStatus === 'loading' ? 'Registering…'
+                : passkeyStatus === 'done' ? 'Passkey added!'
+                : passkeyStatus === 'error' ? 'Failed — try again'
+                : 'Add passkey'}
+            </button>
+          )}
           <button className="user-menu-item" onClick={() => { setOpen(false); onSignOut() }}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4M16 17l5-5-5-5M21 12H9"/>
@@ -258,7 +286,7 @@ export default function App() {
   }
 
   if (!auth.isAuthenticated) {
-    return <AuthScreen onRequestOTP={auth.requestOTP} onVerifyOTP={auth.verifyOTP} />
+    return <AuthScreen onRequestOTP={auth.requestOTP} onVerifyOTP={auth.verifyOTP} onSignInWithPasskey={auth.signInWithPasskey} />
   }
 
   function handleInputChange(e) {
@@ -477,7 +505,7 @@ export default function App() {
           onClose={() => setIsDrawerOpen(false)}
         />
       )}
-      <UserMenu user={auth.user} onSignOut={auth.signOut} />
+      <UserMenu user={auth.user} onSignOut={auth.signOut} onRegisterPasskey={auth.registerPasskey} />
       <div className="omnibox-wrapper">
         <div className="brand">
           <div className="brand-header">

--- a/recipe-app/src/AuthScreen.jsx
+++ b/recipe-app/src/AuthScreen.jsx
@@ -2,19 +2,25 @@ import React, { useState, useRef, useEffect } from 'react'
 
 const OTP_LENGTH = 6
 
-export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
+export default function AuthScreen({ onRequestOTP, onVerifyOTP, onSignInWithPasskey }) {
   const [step, setStep] = useState('email') // 'email' | 'otp'
   const [email, setEmail] = useState('')
   const [otp, setOtp] = useState(Array(OTP_LENGTH).fill(''))
   const [status, setStatus] = useState('idle') // idle | loading | error | success
   const [errorMsg, setErrorMsg] = useState('')
   const [resendCooldown, setResendCooldown] = useState(0)
+  const [passkeySupported, setPasskeySupported] = useState(false)
 
   const emailInputRef = useRef(null)
   const otpRefs = useRef([])
 
   useEffect(() => {
     emailInputRef.current?.focus()
+    if (window.PublicKeyCredential?.isUserVerifyingPlatformAuthenticatorAvailable) {
+      window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
+        .then(setPasskeySupported)
+        .catch(() => {/* not supported */})
+    }
   }, [])
 
   useEffect(() => {
@@ -120,6 +126,17 @@ export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
     setTimeout(() => emailInputRef.current?.focus(), 50)
   }
 
+  async function handlePasskeySignIn() {
+    setStatus('loading')
+    setErrorMsg('')
+    try {
+      await onSignInWithPasskey(email || undefined)
+    } catch (err) {
+      setErrorMsg(err.message || 'Passkey sign-in failed')
+      setStatus('error')
+    }
+  }
+
   const isLoading = status === 'loading'
 
   return (
@@ -178,6 +195,25 @@ export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
                   </span>
                 ) : 'Continue'}
               </button>
+
+              {passkeySupported && onSignInWithPasskey && (
+                <>
+                  <div className="auth-divider"><span>or</span></div>
+                  <button
+                    className="auth-passkey-btn"
+                    type="button"
+                    onClick={handlePasskeySignIn}
+                    disabled={isLoading}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" width="18" height="18">
+                      <circle cx="12" cy="8" r="3"/>
+                      <path d="M6 21v-1a6 6 0 0112 0v1"/>
+                      <path d="M18 15l2 2 4-4"/>
+                    </svg>
+                    Sign in with passkey
+                  </button>
+                </>
+              )}
             </form>
           </>
         ) : (

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -1607,6 +1607,51 @@ html, body {
   cursor: not-allowed;
 }
 
+/* Passkey sign-in option */
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  margin: 4px 0;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.auth-passkey-btn {
+  width: 100%;
+  padding: 11px 16px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.auth-passkey-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: rgba(200, 169, 110, 0.06);
+}
+
+.auth-passkey-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* User menu in app header */
 .user-menu {
   position: fixed;

--- a/recipe-app/src/useAuth.js
+++ b/recipe-app/src/useAuth.js
@@ -119,6 +119,79 @@ export function useAuth() {
     setUser(null)
   }, [])
 
+  async function signInWithPasskey(email) {
+    const { startAuthentication } = await import('@simplewebauthn/browser')
+    const beginRes = await fetch(`${AUTH_WORKER_URL}/passkeys/authenticate/begin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(email ? { email } : {}),
+    })
+    const beginData = await beginRes.json()
+    if (!beginRes.ok || !beginData.success) {
+      throw new Error(beginData.message || 'Failed to begin passkey authentication')
+    }
+
+    let authResponse
+    try {
+      authResponse = await startAuthentication({ optionsJSON: beginData.options })
+    } catch (err) {
+      throw new Error(err.message || 'Passkey authentication cancelled')
+    }
+
+    const completeRes = await fetch(`${AUTH_WORKER_URL}/passkeys/authenticate/complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionToken: beginData.sessionToken, response: authResponse }),
+    })
+    const completeData = await completeRes.json()
+    if (!completeRes.ok || !completeData.success) {
+      throw new Error(completeData.message || 'Passkey authentication failed')
+    }
+
+    if (completeData.token && completeData.user) {
+      storeAuth(completeData.token, completeData.user)
+      setToken(completeData.token)
+      setUser(completeData.user)
+    }
+    return completeData
+  }
+
+  async function registerPasskey() {
+    const { startRegistration } = await import('@simplewebauthn/browser')
+    const beginRes = await fetch(`${AUTH_WORKER_URL}/passkeys/register/begin`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+    })
+    const beginData = await beginRes.json()
+    if (!beginRes.ok || !beginData.success) {
+      throw new Error(beginData.message || 'Failed to begin passkey registration')
+    }
+
+    let regResponse
+    try {
+      regResponse = await startRegistration({ optionsJSON: beginData.options })
+    } catch (err) {
+      throw new Error(err.message || 'Passkey registration cancelled')
+    }
+
+    const completeRes = await fetch(`${AUTH_WORKER_URL}/passkeys/register/complete`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ response: regResponse }),
+    })
+    const completeData = await completeRes.json()
+    if (!completeRes.ok || !completeData.success) {
+      throw new Error(completeData.message || 'Passkey registration failed')
+    }
+    return completeData
+  }
+
   return {
     user,
     token,
@@ -127,5 +200,7 @@ export function useAuth() {
     requestOTP,
     verifyOTP,
     signOut,
+    signInWithPasskey,
+    registerPasskey,
   }
 }

--- a/user-management-worker/migrations/001_add_passkeys.sql
+++ b/user-management-worker/migrations/001_add_passkeys.sql
@@ -1,0 +1,21 @@
+-- Migration 001: Add passkey credential storage
+-- Run against each environment:
+--   wrangler d1 execute user-db --env preview  --file migrations/001_add_passkeys.sql
+--   wrangler d1 execute user-db --env staging  --file migrations/001_add_passkeys.sql
+--   wrangler d1 execute user-db --env production --file migrations/001_add_passkeys.sql
+
+CREATE TABLE IF NOT EXISTS passkey_credentials (
+    credential_id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    public_key TEXT NOT NULL,
+    counter INTEGER NOT NULL DEFAULT 0,
+    device_type TEXT NOT NULL CHECK (device_type IN ('singleDevice', 'multiDevice')),
+    backed_up INTEGER NOT NULL DEFAULT 0,
+    transports TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_passkeys_user_id ON passkey_credentials(user_id);
+CREATE INDEX IF NOT EXISTS idx_passkeys_created_at ON passkey_credentials(created_at);

--- a/user-management-worker/schema.sql
+++ b/user-management-worker/schema.sql
@@ -3,6 +3,7 @@
 
 -- Drop existing tables if they exist (for migrations)
 DROP TABLE IF EXISTS user_login_history;
+DROP TABLE IF EXISTS passkey_credentials;
 DROP TABLE IF EXISTS users;
 
 -- Users table - core user information
@@ -33,11 +34,25 @@ CREATE TABLE IF NOT EXISTS user_login_history (
     latitude REAL,
     longitude REAL,
     timezone TEXT,
-    login_method TEXT NOT NULL CHECK (login_method IN ('OTP', 'MAGIC_LINK')) DEFAULT 'OTP',
+    login_method TEXT NOT NULL CHECK (login_method IN ('OTP', 'MAGIC_LINK', 'PASSKEY')) DEFAULT 'OTP',
     success BOOLEAN NOT NULL,
     failure_reason TEXT, -- NULL if successful
     device_fingerprint TEXT, -- For device recognition
     risk_score INTEGER DEFAULT 0, -- 0-100 risk assessment
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+-- Passkey credentials table
+CREATE TABLE IF NOT EXISTS passkey_credentials (
+    credential_id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    public_key TEXT NOT NULL,
+    counter INTEGER NOT NULL DEFAULT 0,
+    device_type TEXT NOT NULL CHECK (device_type IN ('singleDevice', 'multiDevice')),
+    backed_up INTEGER NOT NULL DEFAULT 0,
+    transports TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME,
     FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
 
@@ -49,6 +64,10 @@ CREATE INDEX IF NOT EXISTS idx_users_status ON users(status);
 CREATE INDEX IF NOT EXISTS idx_users_account_type ON users(account_type);
 CREATE INDEX IF NOT EXISTS idx_users_created_at ON users(created_at);
 CREATE INDEX IF NOT EXISTS idx_users_last_activity ON users(last_activity_at);
+
+-- Passkey credential indexes
+CREATE INDEX IF NOT EXISTS idx_passkeys_user_id ON passkey_credentials(user_id);
+CREATE INDEX IF NOT EXISTS idx_passkeys_created_at ON passkey_credentials(created_at);
 
 -- User login history indexes
 CREATE INDEX IF NOT EXISTS idx_login_history_user_id ON user_login_history(user_id);

--- a/user-management-worker/src/index.ts
+++ b/user-management-worker/src/index.ts
@@ -345,7 +345,7 @@ app.post('/login-history', async (c) => {
       }, 400);
     }
 
-    if (!['OTP', 'MAGIC_LINK'].includes(login_method)) {
+    if (!['OTP', 'MAGIC_LINK', 'PASSKEY'].includes(login_method)) {
       return c.json({
         success: false,
         message: 'Invalid login method'
@@ -451,6 +451,104 @@ app.get('/users/:user_id/statistics', async (c) => {
       success: false,
       message: 'Internal server error'
     }, 500);
+  }
+});
+
+// Passkey Credential Endpoints
+
+// Create passkey credential
+app.post('/passkey-credentials', async (c) => {
+  try {
+    const body = await c.req.json();
+    const { credential_id, user_id, public_key, counter, device_type, backed_up, transports } = body;
+
+    if (!credential_id || !user_id || !public_key || counter === undefined || !device_type) {
+      return c.json({
+        success: false,
+        message: 'credential_id, user_id, public_key, counter, and device_type are required'
+      }, 400);
+    }
+
+    const userDB = new UserDatabaseService(c.env.USER_DB);
+    const result = await userDB.createPasskeyCredential({
+      credential_id,
+      user_id,
+      public_key,
+      counter,
+      device_type,
+      backed_up: !!backed_up,
+      transports
+    });
+
+    if (result.success) {
+      return c.json({ success: true, data: result.data }, 201);
+    } else {
+      return c.json({ success: false, message: result.error }, 400);
+    }
+  } catch (error) {
+    console.error('Error creating passkey credential:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+// Get passkey credentials by user ID
+app.get('/passkey-credentials/user/:user_id', async (c) => {
+  try {
+    const user_id = c.req.param('user_id');
+    const userDB = new UserDatabaseService(c.env.USER_DB);
+    const result = await userDB.getPasskeyCredentialsByUserId(user_id);
+
+    if (result.success) {
+      return c.json({ success: true, data: result.data });
+    } else {
+      return c.json({ success: false, message: result.error }, 404);
+    }
+  } catch (error) {
+    console.error('Error getting passkey credentials:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+// Get passkey credential by credential ID
+app.get('/passkey-credentials/:credential_id', async (c) => {
+  try {
+    const credential_id = c.req.param('credential_id');
+    const userDB = new UserDatabaseService(c.env.USER_DB);
+    const result = await userDB.getPasskeyCredentialById(credential_id);
+
+    if (result.success) {
+      return c.json({ success: true, data: result.data });
+    } else {
+      return c.json({ success: false, message: result.error }, 404);
+    }
+  } catch (error) {
+    console.error('Error getting passkey credential:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+// Update passkey counter
+app.patch('/passkey-credentials/:credential_id/counter', async (c) => {
+  try {
+    const credential_id = c.req.param('credential_id');
+    const body = await c.req.json();
+    const { counter } = body;
+
+    if (counter === undefined || typeof counter !== 'number') {
+      return c.json({ success: false, message: 'counter is required and must be a number' }, 400);
+    }
+
+    const userDB = new UserDatabaseService(c.env.USER_DB);
+    const result = await userDB.updatePasskeyCounter({ credential_id, counter });
+
+    if (result.success) {
+      return c.json({ success: true, data: result.data });
+    } else {
+      return c.json({ success: false, message: result.error }, 404);
+    }
+  } catch (error) {
+    console.error('Error updating passkey counter:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
   }
 });
 

--- a/user-management-worker/src/services/user-database.ts
+++ b/user-management-worker/src/services/user-database.ts
@@ -8,7 +8,10 @@ import {
   DatabaseResult,
   PaginatedResult,
   RecentLoginActivity,
-  UserStatistics
+  UserStatistics,
+  PasskeyCredential,
+  CreatePasskeyCredentialInput,
+  UpdatePasskeyCounterInput,
 } from '../types/database';
 
 export class UserDatabaseService {
@@ -275,6 +278,87 @@ export class UserDatabaseService {
       return { success: true, data: result.results };
     } catch (error) {
       console.error('Error searching users:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  // Passkey Credential Methods
+
+  async createPasskeyCredential(input: CreatePasskeyCredentialInput): Promise<DatabaseResult<PasskeyCredential>> {
+    try {
+      const transports = input.transports ? JSON.stringify(input.transports) : null;
+      const result = await this.db.prepare(`
+        INSERT INTO passkey_credentials (
+          credential_id, user_id, public_key, counter, device_type, backed_up, transports
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        RETURNING *
+      `).bind(
+        input.credential_id,
+        input.user_id,
+        input.public_key,
+        input.counter,
+        input.device_type,
+        input.backed_up ? 1 : 0,
+        transports
+      ).first<PasskeyCredential>();
+
+      if (!result) {
+        return { success: false, error: 'Failed to create passkey credential' };
+      }
+
+      return { success: true, data: result };
+    } catch (error) {
+      console.error('Error creating passkey credential:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async getPasskeyCredentialsByUserId(user_id: string): Promise<DatabaseResult<PasskeyCredential[]>> {
+    try {
+      const result = await this.db.prepare(`
+        SELECT * FROM passkey_credentials WHERE user_id = ? ORDER BY created_at DESC
+      `).bind(user_id).all<PasskeyCredential>();
+
+      return { success: true, data: result.results };
+    } catch (error) {
+      console.error('Error getting passkey credentials by user ID:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async getPasskeyCredentialById(credential_id: string): Promise<DatabaseResult<PasskeyCredential>> {
+    try {
+      const result = await this.db.prepare(`
+        SELECT * FROM passkey_credentials WHERE credential_id = ?
+      `).bind(credential_id).first<PasskeyCredential>();
+
+      if (!result) {
+        return { success: false, error: 'Passkey credential not found' };
+      }
+
+      return { success: true, data: result };
+    } catch (error) {
+      console.error('Error getting passkey credential by ID:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async updatePasskeyCounter(input: UpdatePasskeyCounterInput): Promise<DatabaseResult<PasskeyCredential>> {
+    try {
+      const result = await this.db.prepare(`
+        UPDATE passkey_credentials
+        SET counter = ?, last_used_at = CURRENT_TIMESTAMP
+        WHERE credential_id = ?
+        RETURNING *
+      `).bind(input.counter, input.credential_id).first<PasskeyCredential>();
+
+      if (!result) {
+        return { success: false, error: 'Passkey credential not found' };
+      }
+
+      return { success: true, data: result };
+    } catch (error) {
+      console.error('Error updating passkey counter:', error);
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
     }
   }

--- a/user-management-worker/src/types/database.ts
+++ b/user-management-worker/src/types/database.ts
@@ -27,7 +27,7 @@ export interface UserLoginHistory {
   latitude?: number;
   longitude?: number;
   timezone?: string;
-  login_method: 'OTP' | 'MAGIC_LINK';
+  login_method: 'OTP' | 'MAGIC_LINK' | 'PASSKEY';
   success: boolean;
   failure_reason?: string;
   device_fingerprint?: string;
@@ -54,7 +54,7 @@ export interface RecentLoginActivity {
   ip_address?: string;
   country?: string;
   city?: string;
-  login_method: 'OTP' | 'MAGIC_LINK';
+  login_method: 'OTP' | 'MAGIC_LINK' | 'PASSKEY';
   success: boolean;
   risk_score: number;
 }
@@ -95,11 +95,38 @@ export interface CreateLoginHistoryInput {
   latitude?: number;
   longitude?: number;
   timezone?: string;
-  login_method: 'OTP' | 'MAGIC_LINK';
+  login_method: 'OTP' | 'MAGIC_LINK' | 'PASSKEY';
   success: boolean;
   failure_reason?: string;
   device_fingerprint?: string;
   risk_score?: number;
+}
+
+export interface PasskeyCredential {
+  credential_id: string;
+  user_id: string;
+  public_key: string;
+  counter: number;
+  device_type: 'singleDevice' | 'multiDevice';
+  backed_up: number;
+  transports: string | null;
+  created_at: string;
+  last_used_at: string | null;
+}
+
+export interface CreatePasskeyCredentialInput {
+  credential_id: string;
+  user_id: string;
+  public_key: string;
+  counter: number;
+  device_type: 'singleDevice' | 'multiDevice';
+  backed_up: boolean;
+  transports?: string[];
+}
+
+export interface UpdatePasskeyCounterInput {
+  credential_id: string;
+  counter: number;
 }
 
 // Update types


### PR DESCRIPTION
Users who have previously signed in via OTP can register a passkey (Face
ID, Touch ID, Windows Hello) from the account menu, then use it on future
logins instead of waiting for an email code.

- user-management-worker: new passkey_credentials D1 table + 4 CRUD
  endpoints; migration at migrations/001_add_passkeys.sql; login_method
  updated to accept 'PASSKEY'
- auth-worker: 4 new endpoints (/passkeys/register/begin|complete,
  /passkeys/authenticate/begin|complete) backed by PasskeyService using
  @simplewebauthn/server v13; challenges stored in OTP_KV with 5-min TTL;
  WEBAUTHN_RP_ID/RP_NAME/ORIGIN vars added to wrangler.toml per environment
- recipe-app: signInWithPasskey + registerPasskey in useAuth; "Sign in
  with passkey" button on AuthScreen (hidden if platform authenticator
  unavailable); "Add passkey" item in UserMenu; @simplewebauthn/browser
  added as dependency

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GZR3zGHJJsMVVCA7aUUqBk