### PR TITLE
feat(recipe-app): make recipe search keyboard accessible

### DIFF
--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react'
+import React, { useState, useRef, useEffect, useCallback, useId } from 'react'
 import RecipeCard, { parseDuration } from './RecipeCard.jsx'
 import GeneratingCard from './GeneratingCard.jsx'
 import AuthScreen from './AuthScreen.jsx'
@@ -49,11 +49,24 @@ function isYouTubeUrl(str) {
 // Debounce helper — cancels pending timer on unmount to prevent leaks
 function useDebounce(fn, delay) {
   const timer = useRef(null)
-  useEffect(() => () => clearTimeout(timer.current), [])
-  return useCallback((...args) => {
+  const fnRef = useRef(fn)
+
+  useEffect(() => {
+    fnRef.current = fn
+  }, [fn])
+
+  const cancel = useCallback(() => {
     clearTimeout(timer.current)
-    timer.current = setTimeout(() => fn(...args), delay)
-  }, [fn, delay])
+    timer.current = null
+  }, [])
+
+  const schedule = useCallback((...args) => {
+    cancel()
+    timer.current = setTimeout(() => fnRef.current(...args), delay)
+  }, [cancel, delay])
+
+  useEffect(() => cancel, [cancel])
+  return [schedule, cancel]
 }
 
 function UserMenu({ user, onSignOut }) {
@@ -129,12 +142,16 @@ export default function App() {
   const [searchResults, setSearchResults] = useState([])
   const [lastSearchQuery, setLastSearchQuery] = useState('')
   const [showDropdown, setShowDropdown] = useState(false)
+  const [activeOptionKey, setActiveOptionKey] = useState(null)
   const [saveState, setSaveState] = useState('idle') // idle | saving | saved | error
   const [savedRecipeId, setSavedRecipeId] = useState(null) // persisted KV id for share URL
   const [generatingName, setGeneratingName] = useState('')
   const [clippingFromYouTube, setClippingFromYouTube] = useState(false)
   const inputRef = useRef(null)
   const dropdownRef = useRef(null)
+  const listboxId = useId()
+  const latestInputRef = useRef('')
+  const searchRequestIdRef = useRef(0)
   const [recentRecipes, addRecentRecipe, clearRecentRecipes] = useRecentRecipes()
 
   const isUrl = isValidUrl(input.trim())
@@ -149,15 +166,20 @@ export default function App() {
 
   // --- Search ---
   async function doSearch(query) {
-    if (!query || query.trim().length < 2) {
+    const normalizedQuery = query?.trim() || ''
+    const requestId = ++searchRequestIdRef.current
+
+    if (normalizedQuery.length < 2 || isValidUrl(normalizedQuery)) {
       setSearchResults([])
       setShowDropdown(false)
+      setActiveOptionKey(null)
       return
     }
     setStatus('searching')
     setShowDropdown(true)
+    setActiveOptionKey(null)
     try {
-      const res = await fetch(`${SEARCH_DB_URL}/api/search?q=${encodeURIComponent(query)}&type=recipe&limit=10`)
+      const res = await fetch(`${SEARCH_DB_URL}/api/search?q=${encodeURIComponent(normalizedQuery)}&type=recipe&limit=10`)
       if (!res.ok) throw new Error(`Search failed: ${res.status}`)
       const data = await res.json()
 
@@ -186,29 +208,46 @@ export default function App() {
           }
         })
       )
+      if (
+        requestId !== searchRequestIdRef.current ||
+        latestInputRef.current.trim() !== normalizedQuery
+      ) return
+
       setSearchResults(results.filter(Boolean))
-      setLastSearchQuery(query)
+      setLastSearchQuery(normalizedQuery)
     } catch (e) {
+      if (requestId !== searchRequestIdRef.current) return
+      setSearchResults([])
+      setShowDropdown(false)
+      setActiveOptionKey(null)
       setErrorMsg(e.message)
       setStatus('error')
       return
     }
-    setStatus('idle')
+    if (requestId === searchRequestIdRef.current) setStatus('idle')
   }
 
-  const debouncedSearch = useDebounce(doSearch, 300)
+  const [debouncedSearch, cancelDebouncedSearch] = useDebounce(doSearch, 300)
+
+  function invalidateSearch() {
+    cancelDebouncedSearch()
+    searchRequestIdRef.current += 1
+    setStatus((current) => current === 'searching' ? 'idle' : current)
+  }
 
   // Close dropdown on outside click
   useEffect(() => {
     function handleClick(e) {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target) &&
           inputRef.current && !inputRef.current.contains(e.target)) {
+        invalidateSearch()
         setShowDropdown(false)
+        setActiveOptionKey(null)
       }
     }
     document.addEventListener('mousedown', handleClick)
     return () => document.removeEventListener('mousedown', handleClick)
-  }, [])
+  }, [cancelDebouncedSearch])
 
   const busy = status === 'searching' || status === 'clipping' || status === 'generating' || status === 'elevating'
   const inputBusy = status === 'clipping' || status === 'generating' || status === 'elevating'
@@ -234,6 +273,43 @@ export default function App() {
   useEffect(() => {
     if (!mealPlannerEnabled) setIsDrawerOpen(false)
   }, [mealPlannerEnabled])
+
+  const isSearchView = hasText
+  const searchResultsMatchInput = isSearchView && lastSearchQuery === input.trim()
+  const isBrowseView = input.trim().length === 0
+  const visibleOptions = (searchResultsMatchInput
+    ? searchResults.map((recipe, index) => ({
+        key: `search-${recipe.id || index}-${index}`,
+        kind: 'search',
+        recipe,
+      }))
+    : isBrowseView
+      ? [
+        ...recentRecipes.map((recipe, index) => ({
+          key: `recent-${recipe.id || index}-${index}`,
+          kind: 'recent',
+          recipe,
+        })),
+        ...searchResults.map((recipe, index) => ({
+          key: `last-search-${recipe.id || index}-${index}`,
+          kind: 'search',
+          recipe,
+        })),
+      ]
+      : []
+  ).map((option, index) => ({ ...option, domId: `${listboxId}-option-${index}` }))
+
+  const activeOption = visibleOptions.find((option) => option.key === activeOptionKey)
+  const activeOptionDomId = activeOption?.domId
+
+  useEffect(() => {
+    if (!activeOptionDomId) return
+    document.getElementById(activeOptionDomId)?.scrollIntoView?.({ block: 'nearest' })
+  }, [activeOptionDomId])
+
+  useEffect(() => () => {
+    searchRequestIdRef.current += 1
+  }, [])
 
   // --- Auth gates (after all hooks) ---
 
@@ -263,11 +339,17 @@ export default function App() {
 
   function handleInputChange(e) {
     const val = e.target.value
+    latestInputRef.current = val
     setInput(val)
     setErrorMsg('')
+    setActiveOptionKey(null)
+    searchRequestIdRef.current += 1
     if (!isValidUrl(val.trim()) && val.trim().length >= 2) {
+      if (val.trim() !== lastSearchQuery) setShowDropdown(false)
       debouncedSearch(val.trim())
     } else {
+      cancelDebouncedSearch()
+      if (status === 'searching') setStatus('idle')
       // Don't re-open the dropdown if a generation/clip/elevate is in
       // flight — clearing the input during those flows would otherwise
       // cause the dropdown to pop back up over the recipe/generating card
@@ -278,6 +360,8 @@ export default function App() {
 
   // --- Clip ---
   async function doClip(url) {
+    invalidateSearch()
+    latestInputRef.current = ''
     setStatus('clipping')
     setClippingFromYouTube(isYouTubeUrl(url))
     setShowDropdown(false)
@@ -321,6 +405,8 @@ export default function App() {
 
   // --- Generate ---
   async function doGenerate(query, { elevate = false, baseRecipe = null } = {}) {
+    invalidateSearch()
+    latestInputRef.current = ''
     const dishName = elevate && baseRecipe ? baseRecipe.name : query
     setGeneratingName(dishName)
     setInput('')
@@ -375,30 +461,72 @@ export default function App() {
   function handleSubmit() {
     const action = getPrimaryAction()
     if (action === 'clip') doClip(input.trim())
-    else if (action === 'search') doSearch(input.trim())
+    else if (action === 'search') {
+      cancelDebouncedSearch()
+      doSearch(input.trim())
+    }
+  }
+
+  function selectOption(option) {
+    if (option.kind === 'recent') handleRecentSelect(option.recipe)
+    else handleResultSelect(option.recipe)
   }
 
   function handleKeyDown(e) {
-    if (e.key === 'Enter') handleSubmit()
+    if (e.nativeEvent?.isComposing) return
+
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      if (status === 'searching' || visibleOptions.length === 0) return
+      e.preventDefault()
+      setShowDropdown(true)
+      setActiveOptionKey((currentKey) => {
+        const currentIndex = visibleOptions.findIndex((option) => option.key === currentKey)
+        if (e.key === 'ArrowDown') {
+          return visibleOptions[(currentIndex + 1) % visibleOptions.length].key
+        }
+        const previousIndex = currentIndex <= 0 ? visibleOptions.length - 1 : currentIndex - 1
+        return visibleOptions[previousIndex].key
+      })
+      return
+    }
+
+    if (e.key === 'Enter') {
+      if (showDropdown && activeOption) {
+        e.preventDefault()
+        selectOption(activeOption)
+      } else {
+        handleSubmit()
+      }
+      return
+    }
+
     if (e.key === 'Escape') {
+      e.preventDefault()
       setShowDropdown(false)
+      setActiveOptionKey(null)
       setSearchResults([])
       setLastSearchQuery('')
     }
   }
 
   function handleResultSelect(result) {
+    invalidateSearch()
+    latestInputRef.current = ''
     setActiveRecipe(result)
     addRecentRecipe(result)
     setSaveState('saved')
     setSavedRecipeId(result.id)
     setShowDropdown(false)
+    setActiveOptionKey(null)
     setInput('')
   }
 
   function handleRecentSelect(r) {
+    invalidateSearch()
+    latestInputRef.current = ''
     setActiveRecipe(r)
     setShowDropdown(false)
+    setActiveOptionKey(null)
     setInput('')
     // Only mark as saved for real DB recipes (not temporary clip-* / ai-* ids)
     if (r.id && !r.id.startsWith('clip-') && !r.id.startsWith('ai-')) {
@@ -410,7 +538,41 @@ export default function App() {
   }
 
   function handleInputFocus() {
+    setActiveOptionKey(null)
     if (!input.trim() && (recentRecipes.length > 0 || searchResults.length > 0)) setShowDropdown(true)
+  }
+
+  function handleClearRecentRecipes() {
+    clearRecentRecipes()
+    setActiveOptionKey(null)
+    if (searchResults.length === 0) setShowDropdown(false)
+    inputRef.current?.focus()
+  }
+
+  function renderOption(option) {
+    const isActive = option.key === activeOptionKey
+    const r = option.recipe
+    return (
+      <button
+        key={option.key}
+        id={option.domId}
+        type="button"
+        role="option"
+        aria-selected={isActive}
+        tabIndex={-1}
+        className="dropdown-item"
+        onMouseDown={(e) => e.preventDefault()}
+        onMouseEnter={() => setActiveOptionKey(option.key)}
+        onClick={() => selectOption(option)}
+      >
+        <span className="dropdown-name">{r.name}</span>
+        <span className="dropdown-meta">
+          {r.prep_time && <span className="dropdown-pill">Prep: {parseDuration(r.prep_time)}</span>}
+          {r.cook_time && <span className="dropdown-pill">Cook: {parseDuration(r.cook_time)}</span>}
+          {r.recipe_yield && <span className="dropdown-pill">Serves: {r.recipe_yield}</span>}
+        </span>
+      </button>
+    )
   }
 
   // --- Save ---
@@ -493,16 +655,31 @@ export default function App() {
 
         <div className="omnibox">
           <div className={`omnibox-inner ${busy ? 'busy' : ''} ${status === 'error' ? 'has-error' : ''}`}>
+            <label className="sr-only" htmlFor="recipe-omnibox-input">
+              Search, clip, or generate a recipe
+            </label>
+            <span id="omnibox-instructions" className="sr-only">
+              Use the up and down arrow keys to review recipe suggestions, then press Enter to open one.
+            </span>
             <input
+              id="recipe-omnibox-input"
               ref={inputRef}
               className="omnibox-input"
               type="text"
+              role="combobox"
               placeholder="Search recipes, paste a URL, or describe a dish…"
               value={input}
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
               onFocus={handleInputFocus}
               disabled={inputBusy}
+              aria-autocomplete="list"
+              aria-haspopup="listbox"
+              aria-expanded={showDropdown}
+              aria-controls={showDropdown ? listboxId : undefined}
+              aria-activedescendant={showDropdown && activeOption ? activeOption.domId : undefined}
+              aria-busy={status === 'searching'}
+              aria-describedby={`omnibox-instructions${status === 'error' && errorMsg ? ' omnibox-error' : ''}`}
               autoFocus
               autoComplete="off"
               spellCheck="false"
@@ -552,7 +729,7 @@ export default function App() {
 
           {/* Loading label — for search/clip only; generate/elevate use GeneratingCard */}
           {busy && (status === 'searching' || status === 'clipping') && (
-            <div className="status-label">
+            <div className="status-label" role="status" aria-live="polite">
               {status === 'searching' && 'Searching…'}
               {status === 'clipping' && (clippingFromYouTube ? 'Clipping recipe from YouTube…' : 'Clipping recipe…')}
             </div>
@@ -560,72 +737,85 @@ export default function App() {
 
           {/* Error */}
           {status === 'error' && errorMsg && (
-            <div className="error-label">{errorMsg}</div>
+            <div id="omnibox-error" className="error-label" role="alert">{errorMsg}</div>
           )}
 
           {/* Search dropdown */}
           {showDropdown && (
             <div className="dropdown" ref={dropdownRef}>
-              {status === 'searching' ? (
-                [0, 1, 2].map((i) => (
-                  <div key={i} className="skeleton-item">
-                    <div className="skeleton-line title" />
-                    <div className="skeleton-line meta" />
+              {!isSearchView && recentRecipes.length > 0 && (
+                <div className="dropdown-section-label">
+                  <span id="recent-recipes-label">Recently Viewed</span>
+                  <button
+                    type="button"
+                    className="dropdown-clear-btn"
+                    aria-label="Clear recently viewed recipes"
+                    onClick={handleClearRecentRecipes}
+                  >
+                    Clear
+                  </button>
+                </div>
+              )}
+
+              <div
+                id={listboxId}
+                role="listbox"
+                aria-label="Recipe suggestions"
+                aria-busy={status === 'searching'}
+              >
+                {status !== 'searching' && searchResultsMatchInput && visibleOptions.length > 0 && (
+                  <div role="group" aria-label="Search results">
+                    {visibleOptions.map(renderOption)}
                   </div>
-                ))
-              ) : input.trim().length >= 2 ? (
-                searchResults.length > 0 ? (
-                  searchResults.map((r) => (
-                    <button key={r.id} className="dropdown-item" onClick={() => handleResultSelect(r)}>
-                      <span className="dropdown-name">{r.name}</span>
-                      <span className="dropdown-meta">
-                        {r.prep_time && <span className="dropdown-pill">Prep: {parseDuration(r.prep_time)}</span>}
-                        {r.cook_time && <span className="dropdown-pill">Cook: {parseDuration(r.cook_time)}</span>}
-                        {r.recipe_yield && <span className="dropdown-pill">Serves: {r.recipe_yield}</span>}
-                      </span>
-                    </button>
-                  ))
-                ) : (
-                  <div className="dropdown-empty">No recipes found for "{input}"</div>
-                )
-              ) : (
-                <>
-                  {recentRecipes.length > 0 && (
-                    <>
-                      <div className="dropdown-section-label">
-                        <span>Recently Viewed</span>
-                        <button className="dropdown-clear-btn" onClick={clearRecentRecipes}>Clear</button>
+                )}
+                {status !== 'searching' && isBrowseView && (
+                  <>
+                    {recentRecipes.length > 0 && (
+                      <div role="group" aria-labelledby="recent-recipes-label">
+                        {visibleOptions
+                          .filter((option) => option.kind === 'recent')
+                          .map(renderOption)}
                       </div>
-                      {recentRecipes.map((r) => (
-                        <button key={r.id} className="dropdown-item" onClick={() => handleRecentSelect(r)}>
-                          <span className="dropdown-name">{r.name}</span>
-                          <span className="dropdown-meta">
-                            {r.prep_time && <span className="dropdown-pill">Prep: {parseDuration(r.prep_time)}</span>}
-                            {r.cook_time && <span className="dropdown-pill">Cook: {parseDuration(r.cook_time)}</span>}
-                            {r.recipe_yield && <span className="dropdown-pill">Serves: {r.recipe_yield}</span>}
-                          </span>
-                        </button>
-                      ))}
-                    </>
-                  )}
-                  {searchResults.length > 0 && (
-                    <>
-                      <div className="dropdown-section-label">
-                        <span>Last Search{lastSearchQuery ? `: "${lastSearchQuery}"` : ''}</span>
+                    )}
+                    {searchResults.length > 0 && (
+                      <div
+                        role="group"
+                        aria-label={lastSearchQuery ? `Last search: ${lastSearchQuery}` : 'Last search'}
+                        className="dropdown-option-group dropdown-option-group--labeled"
+                        data-label={lastSearchQuery ? `Last Search: “${lastSearchQuery}”` : 'Last Search'}
+                      >
+                        {visibleOptions
+                          .filter((option) => option.kind === 'search')
+                          .map(renderOption)}
                       </div>
-                      {searchResults.map((r) => (
-                        <button key={r.id} className="dropdown-item" onClick={() => handleResultSelect(r)}>
-                          <span className="dropdown-name">{r.name}</span>
-                          <span className="dropdown-meta">
-                            {r.prep_time && <span className="dropdown-pill">Prep: {parseDuration(r.prep_time)}</span>}
-                            {r.cook_time && <span className="dropdown-pill">Cook: {parseDuration(r.cook_time)}</span>}
-                            {r.recipe_yield && <span className="dropdown-pill">Serves: {r.recipe_yield}</span>}
-                          </span>
-                        </button>
-                      ))}
-                    </>
-                  )}
-                </>
+                    )}
+                  </>
+                )}
+              </div>
+
+              {status === 'searching' && (
+                <div aria-hidden="true">
+                  {[0, 1, 2].map((i) => (
+                    <div key={i} className="skeleton-item">
+                      <div className="skeleton-line title" />
+                      <div className="skeleton-line meta" />
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {status !== 'searching' && searchResultsMatchInput && visibleOptions.length === 0 && (
+                <div className="dropdown-empty" role="status">
+                  No recipes found for "{input}"
+                </div>
+              )}
+
+              {status !== 'searching' && visibleOptions.length > 0 && (
+                <div className="dropdown-shortcuts" aria-hidden="true">
+                  <span><kbd>↑</kbd><kbd>↓</kbd> Navigate</span>
+                  <span><kbd>Enter</kbd> Open</span>
+                  <span><kbd>Esc</kbd> Close</span>
+                </div>
               )}
             </div>
           )}

--- a/recipe-app/src/__tests__/App.test.jsx
+++ b/recipe-app/src/__tests__/App.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from '../App';
 import { MealPlanProvider } from '../MealPlanContext.jsx';
@@ -48,11 +48,11 @@ function mockFetchFail(status = 500) {
 // Sets the input to a value via a single change event (avoids per-character
 // debounce fires that would consume mockOnce responses prematurely).
 function setInputValue(value) {
-  fireEvent.change(screen.getByRole('textbox'), { target: { value } });
+  fireEvent.change(screen.getByRole('combobox'), { target: { value } });
 }
 
 function pressEnter() {
-  fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+  fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Enter' });
 }
 
 const SEARCH_RESPONSE = {
@@ -210,7 +210,7 @@ describe('Search behaviour', () => {
     await waitFor(() => screen.getByText('Chocolate Cake'));
     fireEvent.click(screen.getByText('Chocolate Cake'));
 
-    expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByRole('combobox')).toHaveValue('');
   });
 
   test('Escape key closes the dropdown', async () => {
@@ -222,7 +222,7 @@ describe('Search behaviour', () => {
     pressEnter();
 
     await waitFor(() => screen.getByText('Chocolate Cake'));
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape' });
+    fireEvent.keyDown(screen.getByRole('combobox'), { key: 'Escape' });
 
     expect(screen.queryByText('Chocolate Cake')).not.toBeInTheDocument();
   });
@@ -252,6 +252,205 @@ describe('Search behaviour', () => {
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining('/api/recipes/abc123')
     );
+  });
+});
+
+describe('Omnibox accessibility and keyboard navigation', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('exposes an accessible combobox linked to its listbox', async () => {
+    mockFetchOk(SEARCH_RESPONSE);
+    mockFetchOk(FULL_RECIPE_RESPONSE);
+
+    renderApp();
+    const input = screen.getByRole('combobox', {
+      name: /search, clip, or generate a recipe/i,
+    });
+
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+
+    setInputValue('cake');
+    pressEnter();
+
+    await waitFor(() => expect(screen.getByRole('option', { name: /Chocolate Cake/i })).toBeInTheDocument());
+
+    const listbox = screen.getByRole('listbox', { name: /recipe suggestions/i });
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    expect(input).toHaveAttribute('aria-controls', listbox.id);
+  });
+
+  test('navigates suggestions with arrow keys and opens the active recipe with Enter', async () => {
+    mockFetchOk(SEARCH_RESPONSE);
+    mockFetchOk(FULL_RECIPE_RESPONSE);
+
+    renderApp();
+    setInputValue('cake');
+    pressEnter();
+
+    const option = await screen.findByRole('option', { name: /Chocolate Cake/i });
+    const input = screen.getByRole('combobox');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(input).toHaveFocus();
+    expect(option).toHaveAttribute('aria-selected', 'true');
+    expect(input).toHaveAttribute('aria-activedescendant', option.id);
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByRole('heading', { name: /Chocolate Cake/i })).toBeInTheDocument();
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('ArrowUp wraps to the last recently viewed recipe', () => {
+    seedLocalStorage([
+      { id: 'r1', name: 'Recipe One', ingredients: [], instructions: [] },
+      { id: 'r2', name: 'Recipe Two', ingredients: [], instructions: [] },
+    ]);
+
+    renderApp();
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    const lastOption = screen.getByRole('option', { name: /Recipe Two/i });
+    expect(lastOption).toHaveAttribute('aria-selected', 'true');
+    expect(input).toHaveAttribute('aria-activedescendant', lastOption.id);
+  });
+
+  test('Escape closes suggestions and clears the active descendant', async () => {
+    seedLocalStorage([{ id: 'r1', name: 'Recipe One', ingredients: [], instructions: [] }]);
+
+    renderApp();
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(input).toHaveAttribute('aria-activedescendant');
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('Enter cancels the pending debounced duplicate search', async () => {
+    mockFetchOk(SEARCH_RESPONSE);
+    mockFetchOk(FULL_RECIPE_RESPONSE);
+
+    renderApp();
+    setInputValue('cake');
+    pressEnter();
+
+    await screen.findByRole('option', { name: /Chocolate Cake/i });
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    const searchCalls = global.fetch.mock.calls.filter(([url]) =>
+      url.includes('/api/search?q=cake')
+    );
+    expect(searchCalls).toHaveLength(1);
+  });
+
+  test('hides previous results immediately when the text query changes', async () => {
+    mockFetchOk(SEARCH_RESPONSE);
+    mockFetchOk(FULL_RECIPE_RESPONSE);
+
+    renderApp();
+    setInputValue('cake');
+    pressEnter();
+    await screen.findByRole('option', { name: /Chocolate Cake/i });
+
+    setInputValue('soup');
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(screen.queryByRole('option', { name: /Chocolate Cake/i })).not.toBeInTheDocument();
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+
+    mockFetchOk({ results: [] });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/search?q=soup')
+      )
+    );
+  });
+
+  test('does not expose stale search options after switching to a URL', async () => {
+    mockFetchOk(SEARCH_RESPONSE);
+    mockFetchOk(FULL_RECIPE_RESPONSE);
+
+    renderApp();
+    setInputValue('cake');
+    pressEnter();
+    await screen.findByRole('option', { name: /Chocolate Cake/i });
+
+    setInputValue('https://example.com/soup');
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+
+    mockFetchOk(CLIP_RESPONSE);
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(await screen.findByRole('heading', { name: /Clipped Soup/i })).toBeInTheDocument();
+  });
+
+  test('ignores a slower response from an outdated query', async () => {
+    let resolveFirstSearch;
+    let resolveSecondSearch;
+    const response = (body) => ({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(body),
+    });
+
+    global.fetch.mockImplementation((url) => {
+      if (url.includes('/api/search?q=first')) {
+        return new Promise((resolve) => { resolveFirstSearch = resolve; });
+      }
+      if (url.includes('/api/search?q=second')) {
+        return new Promise((resolve) => { resolveSecondSearch = resolve; });
+      }
+      if (url.includes('/api/recipes/second-id')) {
+        return Promise.resolve(response({
+          data: { ...FULL_RECIPE_RESPONSE.data, name: 'Second Recipe' },
+        }));
+      }
+      if (url.includes('/api/recipes/first-id')) {
+        return Promise.resolve(response({
+          data: { ...FULL_RECIPE_RESPONSE.data, name: 'First Recipe' },
+        }));
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    renderApp();
+    setInputValue('first');
+    pressEnter();
+    await waitFor(() => expect(resolveFirstSearch).toBeDefined());
+
+    setInputValue('second');
+    pressEnter();
+    await waitFor(() => expect(resolveSecondSearch).toBeDefined());
+
+    await act(async () => {
+      resolveSecondSearch(response({ results: [{ id: 'second-id' }] }));
+    });
+    expect(await screen.findByRole('option', { name: /Second Recipe/i })).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFirstSearch(response({ results: [{ id: 'first-id' }] }));
+    });
+
+    expect(screen.queryByRole('option', { name: /First Recipe/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Second Recipe/i })).toBeInTheDocument();
   });
 });
 
@@ -322,7 +521,7 @@ describe('Clip behaviour', () => {
     pressEnter();
 
     await waitFor(() => screen.getByRole('heading', { name: /Clipped Soup/i }));
-    expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByRole('combobox')).toHaveValue('');
   });
 
   test('shows error when clip fetch fails', async () => {
@@ -455,7 +654,7 @@ describe('Generate behaviour', () => {
     fireEvent.click(screen.getByText('Generate'));
 
     await waitFor(() => screen.getByRole('heading', { name: /AI Omelette/i }));
-    expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByRole('combobox')).toHaveValue('');
   });
 
   test('shows error when generation fetch fails', async () => {
@@ -669,7 +868,7 @@ describe('Recently viewed recipes', () => {
     seedLocalStorage([{ id: 'abc123', name: 'Chocolate Cake', description: '', image: '', prep_time: null, cook_time: null, recipe_yield: null, ingredients: [], instructions: [] }]);
 
     renderApp();
-    fireEvent.focus(screen.getByRole('textbox'));
+    fireEvent.focus(screen.getByRole('combobox'));
 
     expect(screen.getByText('Recently Viewed')).toBeInTheDocument();
     expect(screen.getByText('Chocolate Cake')).toBeInTheDocument();
@@ -688,11 +887,11 @@ describe('Recently viewed recipes', () => {
 
     // Clear the input — dropdown should now show both sections
     setInputValue('');
-    fireEvent.focus(screen.getByRole('textbox'));
+    fireEvent.focus(screen.getByRole('combobox'));
 
     expect(screen.getByText('Recently Viewed')).toBeInTheDocument();
     expect(screen.getByText('Saved Pasta')).toBeInTheDocument();
-    expect(screen.getByText(/Last Search/i)).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /Last search: cake/i })).toBeInTheDocument();
     expect(screen.getAllByText('Chocolate Cake').length).toBeGreaterThan(0);
   });
 
@@ -725,7 +924,7 @@ describe('Recently viewed recipes', () => {
     seedLocalStorage([recentRecipe]);
 
     renderApp();
-    fireEvent.focus(screen.getByRole('textbox'));
+    fireEvent.focus(screen.getByRole('combobox'));
 
     await waitFor(() => screen.getByText('Chocolate Cake'));
     fireEvent.click(screen.getByText('Chocolate Cake'));
@@ -809,7 +1008,7 @@ describe('Recently viewed recipes', () => {
     seedLocalStorage([recipe2, recipe1]); // recipe2 is more recent
 
     renderApp();
-    fireEvent.focus(screen.getByRole('textbox'));
+    fireEvent.focus(screen.getByRole('combobox'));
 
     // Re-open the older recipe from recent
     await waitFor(() => screen.getByText('Recipe One'));
@@ -827,7 +1026,7 @@ describe('Recently viewed recipes', () => {
     seedLocalStorage([{ id: 'abc123', name: 'Chocolate Cake', description: '', image: '', prep_time: null, cook_time: null, recipe_yield: null, ingredients: [], instructions: [] }]);
 
     renderApp();
-    fireEvent.focus(screen.getByRole('textbox'));
+    fireEvent.focus(screen.getByRole('combobox'));
 
     await waitFor(() => screen.getByText('Recently Viewed'));
     fireEvent.click(screen.getByText('Clear'));

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -35,6 +35,18 @@ html, body {
   height: 100%;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .app {
   min-height: 100vh;
   display: flex;
@@ -178,10 +190,10 @@ html, body {
 
 .primary-btn {
   background: linear-gradient(135deg, var(--accent), var(--accent-hover));
-  color: #fff;
+  color: var(--bg);
 }
 .primary-btn:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--accent-hover), #9a7838);
+  background: linear-gradient(135deg, var(--accent-hover), #9f7d3d);
 }
 .primary-btn.clip {
   background: var(--clip-color);
@@ -265,9 +277,14 @@ html, body {
   border-left: 2px solid transparent;
 }
 .dropdown-item:last-child { border-bottom: none; }
-.dropdown-item:hover {
+.dropdown-item:hover,
+.dropdown-item[aria-selected="true"] {
   background: var(--surface2);
   border-left-color: var(--accent);
+}
+
+.dropdown-item[aria-selected="true"] {
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 .dropdown-name {
@@ -316,9 +333,70 @@ html, body {
   cursor: pointer;
   font-size: 0.7rem;
   color: var(--text-muted);
-  padding: 0;
+  min-width: 40px;
+  min-height: 24px;
+  padding: 2px 6px;
 }
 .dropdown-clear-btn:hover { color: var(--accent); }
+.dropdown-clear-btn:focus-visible {
+  color: var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 2px;
+}
+
+.dropdown-option-group--labeled::before {
+  content: attr(data-label);
+  display: block;
+  padding: 0.5rem 1rem 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dropdown-shortcuts {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 14px;
+  border-top: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.7rem;
+}
+
+.dropdown-shortcuts span {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.dropdown-shortcuts kbd {
+  min-width: 20px;
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  border-bottom-color: var(--text-muted);
+  border-radius: 4px;
+  background: var(--surface2);
+  color: var(--text);
+  font: inherit;
+  line-height: 1.35;
+  text-align: center;
+}
+
+@media (max-width: 560px) {
+  .dropdown-shortcuts {
+    display: none;
+  }
+}
+
+@media (forced-colors: active) {
+  .dropdown-item[aria-selected="true"] {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}
 
 /* ── Skeleton loading items ── */
 .skeleton-item {
@@ -2078,4 +2156,13 @@ html, body {
 }
 .planner-feedback-dismiss:hover {
   opacity: 1;
+}
+
+/* Respect motion preferences after all component animation declarations. */
+@media (prefers-reduced-motion: reduce) {
+  .dropdown,
+  .omnibox-inner.busy,
+  .skeleton-line {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## Summary
- turn the primary recipe omnibox into a standards-based ARIA combobox/listbox
- add Arrow Up/Down navigation, active-option scrolling, Enter selection, Escape dismissal, and visible keyboard hints
- prevent stale or duplicate search results with cancellable debounce and latest-request guards
- improve reduced-motion behavior, focus visibility, touch target sizing, and primary-action contrast
- add regression coverage for keyboard selection, query changes, URL mode, duplicate debounce calls, and out-of-order responses

## Why
The omnibox is Seasoned’s primary workflow, but recipe suggestions were only selectable with a pointer. This change makes search and recent recipes keyboard- and screen-reader-operable while also eliminating stale-result race conditions that could open the wrong recipe.

## Validation
- `npm test -- --runInBand` — 14 suites, 339 tests passed
- `npm run build` — production Vite/PWA build passed
- `git diff --check` — passed

## Notes
- No dependencies or backend APIs changed.
- Existing non-failing React `act(...)` warnings remain in unrelated asynchronous test paths.