### PR TITLE
feat: Add passkey authentication support

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: recipe-app/package-lock.json
     
@@ -197,7 +197,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
     
     - name: Build Frontend
       working-directory: ./recipe-app

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [ main, staging ]
     paths:
-      - 'frontend/**'
+      - 'recipe-app/**'
       - '.github/workflows/frontend-tests.yml'
       - 'package.json'
       - 'package-lock.json'
   pull_request:
     branches: [ main, staging ]
     paths:
-      - 'frontend/**'
+      - 'recipe-app/**'
       - '.github/workflows/frontend-tests.yml'
       - 'package.json'
       - 'package-lock.json'
@@ -26,7 +26,6 @@ jobs:
   test-frontend:
     name: Frontend Tests and Coverage
     runs-on: ubuntu-latest
-    continue-on-error: true  # Continue even if tests fail to get coverage data
     outputs:
       diff_coverage_available: ${{ steps.diff-coverage.outputs.diff_coverage_available }}
       diff_coverage_below_threshold: ${{ steps.diff-coverage.outputs.diff_coverage_below_threshold }}
@@ -47,24 +46,22 @@ jobs:
       with:
         node-version: '18'
         cache: 'npm'
-        cache-dependency-path: frontend/package-lock.json
+        cache-dependency-path: recipe-app/package-lock.json
     
     - name: Install Frontend Dependencies
-      working-directory: ./frontend
+      working-directory: ./recipe-app
       run: npm ci
     
     - name: Run Frontend Tests with Coverage
-      working-directory: ./frontend
+      working-directory: ./recipe-app
       run: |
         echo "Running tests with coverage..."
         # Run tests with coverage, but don't fail the workflow if tests fail
         # Coverage will still be generated even with test failures
-        npm run test:coverage -- --passWithNoTests --ci --watchAll=false --coverageReporters=json-summary --coverageReporters=lcov || {
-          echo "Tests completed with coverage generation (some tests may have failed)"
-        }
+        npm run test:coverage -- --passWithNoTests --ci --watchAll=false --coverageReporters=json-summary --coverageReporters=lcov
     
     - name: Check Coverage Thresholds
-      working-directory: ./frontend
+      working-directory: ./recipe-app
       run: |
         echo "### Frontend Coverage Results" >> $GITHUB_STEP_SUMMARY
         # The coverage threshold check is handled by Jest config
@@ -109,14 +106,14 @@ jobs:
     - name: Upload Frontend Coverage Reports
       uses: actions/upload-artifact@v4
       with:
-        name: frontend-coverage
-        path: frontend/coverage/
+        name: recipe-app-coverage
+        path: recipe-app/coverage/
       if: always()  # Always upload coverage even if tests fail
     
     - name: Generate Diff Coverage Report (PR only)
       if: github.event_name == 'pull_request'
       id: diff-coverage
-      working-directory: ./frontend
+      working-directory: ./recipe-app
       run: |
         # Install diff-cover for differential coverage
         pip install diff-cover
@@ -202,11 +199,11 @@ jobs:
       with:
         node-version: '18'
     
-    - name: Lint Frontend
-      working-directory: ./frontend
+    - name: Build Frontend
+      working-directory: ./recipe-app
       run: |
         npm ci
-        npm run lint || echo "Linting completed with warnings"
+        npm run build
 
   coverage-report:
     name: Frontend Coverage Report
@@ -220,8 +217,8 @@ jobs:
     - name: Download Frontend Coverage
       uses: actions/download-artifact@v4
       with:
-        name: frontend-coverage
-        path: ./coverage-reports/frontend
+        name: recipe-app-coverage
+        path: ./coverage-reports/recipe-app
       continue-on-error: true
     
     - name: Coverage Summary
@@ -231,7 +228,7 @@ jobs:
         echo "" >> $GITHUB_STEP_SUMMARY
         
         # Validate that we have coverage data
-        if [ ! -d ./coverage-reports/frontend ] || [ ! -f ./coverage-reports/frontend/coverage-summary.json ]; then
+        if [ ! -d ./coverage-reports/recipe-app ] || [ ! -f ./coverage-reports/recipe-app/coverage-summary.json ]; then
           echo "⚠️ **No valid coverage data available**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "This may happen if:" >> $GITHUB_STEP_SUMMARY
@@ -243,11 +240,11 @@ jobs:
           exit 0
         fi
         
-        if [ -d ./coverage-reports/frontend ]; then
+        if [ -d ./coverage-reports/recipe-app ]; then
           echo "✅ Frontend coverage reports available" >> $GITHUB_STEP_SUMMARY
           
           # Extract and display coverage percentages from JSON summary
-          if [ -f ./coverage-reports/frontend/coverage-summary.json ]; then
+          if [ -f ./coverage-reports/recipe-app/coverage-summary.json ]; then
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "### Coverage Metrics:" >> $GITHUB_STEP_SUMMARY
             echo "| Metric | Coverage |" >> $GITHUB_STEP_SUMMARY
@@ -257,10 +254,10 @@ jobs:
             sudo apt-get install -y jq
             
             # Extract coverage values with error handling
-            lines=$(jq -r '.total.lines.pct // "N/A"' ./coverage-reports/frontend/coverage-summary.json)
-            statements=$(jq -r '.total.statements.pct // "N/A"' ./coverage-reports/frontend/coverage-summary.json)
-            functions=$(jq -r '.total.functions.pct // "N/A"' ./coverage-reports/frontend/coverage-summary.json)
-            branches=$(jq -r '.total.branches.pct // "N/A"' ./coverage-reports/frontend/coverage-summary.json)
+            lines=$(jq -r '.total.lines.pct // "N/A"' ./coverage-reports/recipe-app/coverage-summary.json)
+            statements=$(jq -r '.total.statements.pct // "N/A"' ./coverage-reports/recipe-app/coverage-summary.json)
+            functions=$(jq -r '.total.functions.pct // "N/A"' ./coverage-reports/recipe-app/coverage-summary.json)
+            branches=$(jq -r '.total.branches.pct // "N/A"' ./coverage-reports/recipe-app/coverage-summary.json)
             
             # Validate that we got numeric values and they are reasonable
             if [[ "$lines" =~ ^[0-9]+\.?[0-9]*$ ]] && [[ "$statements" =~ ^[0-9]+\.?[0-9]*$ ]] && \
@@ -296,7 +293,7 @@ jobs:
             else
               echo "⚠️ Invalid coverage data format detected" >> $GITHUB_STEP_SUMMARY
               echo "Raw coverage data:" >> $GITHUB_STEP_SUMMARY
-              cat ./coverage-reports/frontend/coverage-summary.json >> $GITHUB_STEP_SUMMARY
+              cat ./coverage-reports/recipe-app/coverage-summary.json >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "**Coverage data validation failed**" >> $GITHUB_STEP_SUMMARY
               echo "This may indicate:" >> $GITHUB_STEP_SUMMARY
@@ -308,7 +305,7 @@ jobs:
             
 
                       else
-              echo "⚠️ coverage-summary.json not found in frontend coverage reports" >> $GITHUB_STEP_SUMMARY
+              echo "⚠️ coverage-summary.json not found in recipe-app coverage reports" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "**Coverage files missing**" >> $GITHUB_STEP_SUMMARY
               echo "This may indicate:" >> $GITHUB_STEP_SUMMARY
@@ -318,7 +315,7 @@ jobs:
               echo "coverage_available=false" >> $GITHUB_OUTPUT
             fi
         else
-          echo "⚠️ No frontend coverage reports found" >> $GITHUB_STEP_SUMMARY
+          echo "⚠️ No recipe-app coverage reports found" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**No coverage artifacts available**" >> $GITHUB_STEP_SUMMARY
           echo "This may indicate:" >> $GITHUB_STEP_SUMMARY
@@ -488,7 +485,7 @@ jobs:
             
             console.log('Frontend coverage comment posted successfully');
           } catch (error) {
-            console.error('Failed to post frontend coverage comment:', error);
+            console.error('Failed to post recipe-app coverage comment:', error);
             console.log('This may be due to permissions. The coverage report is still available in the workflow summary.');
             
             // Still add to summary even if comment fails

--- a/.github/workflows/test-and-staging.yml
+++ b/.github/workflows/test-and-staging.yml
@@ -18,12 +18,11 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: '18'
-        cache: 'npm'
-    
+
     - name: Test Frontend
       if: contains(github.event.head_commit.message, 'frontend') || github.event_name == 'pull_request'
       run: |
-        cd frontend
+        cd recipe-app
         if [ -f "package.json" ]; then
           npm ci
           npm test
@@ -32,6 +31,16 @@ jobs:
     - name: Test Workers
       if: contains(github.event.head_commit.message, 'worker') || github.event_name == 'pull_request'
       run: |
+        # Test authentication and user-management workers for passkey support
+        for worker_dir in auth-worker user-management-worker; do
+          if [ -d "$worker_dir" ] && [ -f "$worker_dir/package.json" ]; then
+            cd "$worker_dir"
+            npm ci
+            npm test -- --run
+            cd ..
+          fi
+        done
+
         # Test recipe-save-worker
         if [ -d "recipe-save-worker" ] && [ -f "recipe-save-worker/package.json" ]; then
           cd recipe-save-worker
@@ -48,9 +57,9 @@ jobs:
           cd ..
         fi
         
-        # Test recipe-clipper
-        if [ -d "recipe-clipper" ] && [ -f "recipe-clipper/package.json" ]; then
-          cd recipe-clipper
+        # Test clipper
+        if [ -d "clipper" ] && [ -f "clipper/package.json" ]; then
+          cd clipper
           npm ci
           npm test
           cd ..
@@ -60,14 +69,14 @@ jobs:
     - name: Run Linting
       run: |
         # Run linting for frontend
-        if [ -d "frontend" ] && [ -f "frontend/package.json" ]; then
-          cd frontend
+        if [ -d "recipe-app" ] && [ -f "recipe-app/package.json" ]; then
+          cd recipe-app
           npm run lint || echo "No lint script found"
           cd ..
         fi
         
         # Run linting for workers
-        for worker_dir in recipe-save-worker recipe-search-db recipe-clipper; do
+        for worker_dir in auth-worker user-management-worker recipe-save-worker recipe-search-db clipper; do
           if [ -d "$worker_dir" ] && [ -f "$worker_dir/package.json" ]; then
             cd "$worker_dir"
             npm run lint || echo "No lint script found in $worker_dir"

--- a/auth-worker/README.md
+++ b/auth-worker/README.md
@@ -278,3 +278,14 @@ wrangler tail --env=preview
 ## License
 
 This project follows the same license as the main recipe-app repository.
+### Passkeys (WebAuthn)
+
+In addition to OTP recovery, the worker supports native browser passkeys:
+
+- `POST /passkeys/register/begin` and `/passkeys/register/complete` (Bearer JWT required)
+- `POST /passkeys/authenticate/begin` and `/passkeys/authenticate/complete` (email-first sign-in)
+
+Registration challenges are claimed atomically by the `PasskeyChallengeObject` Durable Object.
+Set `WEBAUTHN_RP_ID`, `WEBAUTHN_RP_NAME`, and the exact HTTPS `WEBAUTHN_ORIGIN` for each
+non-development environment. Set the same `PASSKEY_SERVICE_TOKEN` secret on this worker and
+`user-management-worker` before enabling passkeys.

--- a/auth-worker/package-lock.json
+++ b/auth-worker/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@simplewebauthn/server": "^9.0.3",
+        "@simplewebauthn/types": "^9.0.1",
         "hono": "^4.5.0",
         "jose": "^5.2.3"
       },
@@ -778,6 +780,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1316,6 +1324,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1352,6 +1366,73 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.8.0.tgz",
+      "integrity": "sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1693,6 +1774,33 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-9.0.3.tgz",
+      "integrity": "sha512-FMZieoBosrVLFxCnxPFD9Enhd1U7D8nidVDT4MsHc6l4fdVcjoeHjDueeXCloO1k5O/fZg1fsSXXPKbY2XTzDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.3.10",
+        "@peculiar/asn1-ecc": "^2.3.8",
+        "@peculiar/asn1-rsa": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-x509": "^2.3.8",
+        "@simplewebauthn/types": "^9.0.1",
+        "cross-fetch": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@simplewebauthn/types": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/types/-/types-9.0.1.tgz",
+      "integrity": "sha512-tGSRP1QvsAvsJmnOlRQyw/mvK9gnPtjEc5fg2+m8n+QUa+D7rvrKkOYyfpy42GTs90X3RDOnqJgfHt+qO67/+w==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "7.0.2",
@@ -2231,6 +2339,20 @@
         "printable-characters": "^1.0.42"
       }
     },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2414,6 +2536,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -3643,6 +3774,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -3885,6 +4036,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/queue-microtask": {
@@ -4507,6 +4676,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -4524,9 +4699,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4825,6 +4998,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/auth-worker/package.json
+++ b/auth-worker/package.json
@@ -48,6 +48,8 @@
     "wrangler": "^4.32.0"
   },
   "dependencies": {
+    "@simplewebauthn/server": "^9.0.3",
+    "@simplewebauthn/types": "^9.0.1",
     "hono": "^4.5.0",
     "jose": "^5.2.3"
   }

--- a/auth-worker/src/index.ts
+++ b/auth-worker/src/index.ts
@@ -1,15 +1,67 @@
 import { Hono } from 'hono';
+import type { Context } from 'hono';
 import { cors } from 'hono/cors';
 import { logger } from 'hono/logger';
 import { Env } from './types/env';
 import { storeOTP, verifyOTPForEmail, hasOTP, deleteOTP, getOTPStats } from './utils/otp-manager';
 import { EmailService } from './services/email-service';
+import { JWTService } from './services/jwt-service';
+import { PasskeyService, isAuthenticationResponse, isRegistrationResponse } from './services/passkey-service';
 
 const app = new Hono<{ Bindings: Env }>();
+type AuthContext = Context<{ Bindings: Env }>;
+
+function userManagementHeaders(env: Env, contentType = false): HeadersInit {
+  const headers: Record<string, string> = {};
+  if (contentType) headers['Content-Type'] = 'application/json';
+  if (env.PASSKEY_SERVICE_TOKEN) headers['X-Internal-Auth'] = env.PASSKEY_SERVICE_TOKEN;
+  return headers;
+}
+
+function hasInternalAuth(c: AuthContext): boolean {
+  if (c.env.ENVIRONMENT === 'development') return true;
+  const token = c.env.PASSKEY_SERVICE_TOKEN;
+  return typeof token === 'string' && token.length > 0 && c.req.header('X-Internal-Auth') === token;
+}
+
+async function getActiveUser(env: Env, userId: string): Promise<boolean> {
+  const response = await fetch(`${env.USER_MANAGEMENT_WORKER_URL}/users/${encodeURIComponent(userId)}`, {
+    headers: userManagementHeaders(env),
+  });
+  if (!response.ok) return false;
+  const body = await response.json() as { success?: boolean; data?: { status?: string } };
+  return body.success === true && body.data?.status === 'ACTIVE';
+}
+
+async function ensureUserForOTP(env: Env, userId: string): Promise<boolean> {
+  const response = await fetch(`${env.USER_MANAGEMENT_WORKER_URL}/users/${encodeURIComponent(userId)}`, {
+    headers: userManagementHeaders(env),
+  });
+  if (response.status === 404) {
+    const createResponse = await fetch(`${env.USER_MANAGEMENT_WORKER_URL}/users`, {
+      method: 'POST',
+      headers: userManagementHeaders(env, true),
+      body: JSON.stringify({ email_hash: userId, account_type: 'FREE' }),
+    });
+    if (!createResponse.ok) return false;
+    const created = await createResponse.json() as { success?: boolean; data?: { status?: string } };
+    return created.success === true && created.data?.status === 'ACTIVE';
+  }
+  if (!response.ok) return false;
+  const body = await response.json() as { success?: boolean; data?: { status?: string } };
+  return body.success === true && body.data?.status === 'ACTIVE';
+}
 
 // Middleware
 app.use('*', logger());
-app.use('*', cors());
+app.use('*', cors({
+  origin: (origin, c) => {
+    if (!origin) return '';
+    return c.env.WEBAUTHN_ORIGIN === origin ? origin : '';
+  },
+  allowHeaders: ['Content-Type', 'Authorization'],
+  allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+}));
 
 // Health check endpoint
 app.get('/health', async (c) => {
@@ -27,7 +79,7 @@ app.get('/health', async (c) => {
 
   try {
     // Test OTP_KV access
-    const testKey = '__health_check_otp__';
+    const testKey = `${env.OTP_KV_PREFIX || 'default'}:__health_check_otp__`;
     await env.OTP_KV.put(testKey, new Date().toISOString(), {
       expirationTtl: 60 // Expire after 1 minute
     });
@@ -98,7 +150,7 @@ app.post('/otp/generate', async (c) => {
     }
 
     // Check if OTP already exists
-    const existingOTP = await hasOTP(c.env.OTP_KV, email);
+    const existingOTP = await hasOTP(c.env.OTP_KV, email, c.env.OTP_KV_PREFIX);
     if (existingOTP) {
       return c.json({
         success: false,
@@ -106,7 +158,7 @@ app.post('/otp/generate', async (c) => {
       }, 409);
     }
 
-    const result = await storeOTP(c.env.OTP_KV, email);
+    const result = await storeOTP(c.env.OTP_KV, email, undefined, undefined, c.env.OTP_KV_PREFIX);
     
     if (result.success) {
       // Always send verification email (security best practice)
@@ -169,77 +221,55 @@ app.post('/otp/verify', async (c) => {
       }, 400);
     }
 
-    const result = await verifyOTPForEmail(c.env.OTP_KV, email, otp);
+    const result = await verifyOTPForEmail(c.env.OTP_KV, email, otp, c.env.OTP_KV_PREFIX);
     
     if (result.success) {
-      // Generate JWT token for successful authentication (always do this first)
+      const emailHash = result.user_id;
+      if (!emailHash) {
+        return c.json({ success: false, message: 'Authentication failed' }, 500);
+      }
+
+      // A valid OTP is not enough to bypass an account suspension/deletion.
+      // User creation is allowed only for a genuinely new email hash.
+      let activeUser = false;
+      try {
+        activeUser = await ensureUserForOTP(c.env, emailHash);
+      } catch (userError) {
+        console.error('Error checking user status:', userError);
+      }
+      if (!activeUser) {
+        return c.json({ success: false, message: 'Authentication service unavailable' }, 503);
+      }
+
       let jwtToken = null;
       try {
-        if (result.user_id) {
-          const { JWTService } = await import('./services/jwt-service');
-          const jwtService = new JWTService(c.env);
-          
-          // Create token with 7 day expiration
-          const tokenResult = await jwtService.createToken(result.user_id, email, 604800);
-          
-          if (tokenResult.success && tokenResult.token) {
-            jwtToken = tokenResult.token;
-          } else {
-            console.error('Failed to generate JWT token:', tokenResult.error);
-          }
+        const jwtService = new JWTService(c.env);
+        const tokenResult = await jwtService.createToken(emailHash, email, 604800);
+        if (tokenResult.success && tokenResult.token) {
+          jwtToken = tokenResult.token;
         } else {
-          console.error('No user_id returned from OTP verification');
+          console.error('Failed to generate JWT token:', tokenResult.error);
         }
       } catch (jwtError) {
         console.error('Error generating JWT token:', jwtError);
       }
 
-      // Try to manage user data (optional, don't block JWT generation)
+      // Record successful login (best effort after account status is confirmed).
       try {
-        const emailHash = result.user_id; // This should be the email hash from OTP verification
-        
-        if (!emailHash) {
-          console.error('No user_id returned from OTP verification');
-        } else {
-          // Check if user exists
-          const userResponse = await fetch(`${c.env.USER_MANAGEMENT_WORKER_URL}/users/email/${emailHash}`);
-          
-          if (!userResponse.ok) {
-            // User doesn't exist, create new user
-            const createUserResponse = await fetch(`${c.env.USER_MANAGEMENT_WORKER_URL}/users`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                email_hash: emailHash,
-                account_type: 'FREE'
-              })
-            });
-            
-            if (!createUserResponse.ok) {
-              console.error('Failed to create user in User Management Worker');
-            }
-          }
-          
-          // Record successful login
-          const loginResponse = await fetch(`${c.env.USER_MANAGEMENT_WORKER_URL}/login-history`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              user_id: emailHash,
-              login_method: 'OTP',
-              success: true,
-              ip_address: c.req.header('CF-Connecting-IP'),
-              user_agent: c.req.header('User-Agent')
-            })
-          });
-          
-          if (!loginResponse.ok) {
-            console.error('Failed to record login history');
-          }
-        }
+        const loginResponse = await fetch(`${c.env.USER_MANAGEMENT_WORKER_URL}/login-history`, {
+          method: 'POST',
+          headers: userManagementHeaders(c.env, true),
+          body: JSON.stringify({
+            user_id: emailHash,
+            login_method: 'OTP',
+            success: true,
+            ip_address: c.req.header('CF-Connecting-IP'),
+            user_agent: c.req.header('User-Agent')
+          })
+        });
+        if (!loginResponse.ok) console.error('Failed to record login history');
       } catch (userError) {
-        console.error('Error managing user data:', userError);
-        // Don't fail the OTP verification if user management fails
+        console.error('Error recording login history:', userError);
       }
 
       // Return success response with JWT token if available
@@ -306,6 +336,10 @@ app.post('/auth/refresh', async (c) => {
         }, 400);
       }
 
+      if (!(await getActiveUser(c.env, verifyResult.payload.sub))) {
+        return c.json({ success: false, message: 'Authentication failed' }, 401);
+      }
+
       // Create a new token with extended expiration (sliding window — refresh any valid token)
       const newTokenResult = await jwtService.createToken(
         verifyResult.payload.sub,
@@ -366,6 +400,10 @@ app.post('/auth/validate', async (c) => {
       const result = await jwtService.verifyToken(token);
       
       if (result.success && result.payload) {
+        const active = await getActiveUser(c.env, result.payload.sub);
+        if (!active) {
+          return c.json({ success: false, valid: false, message: 'Authentication failed' });
+        }
         return c.json({
           success: true,
           valid: true,
@@ -402,6 +440,7 @@ app.post('/auth/validate', async (c) => {
 
 // Check OTP status
 app.get('/otp/status/:email', async (c) => {
+  if (!hasInternalAuth(c)) return c.json({ success: false, message: 'Unauthorized' }, 401);
   try {
     const email = c.req.param('email');
 
@@ -412,7 +451,7 @@ app.get('/otp/status/:email', async (c) => {
       }, 400);
     }
 
-    const stats = await getOTPStats(c.env.OTP_KV, email);
+    const stats = await getOTPStats(c.env.OTP_KV, email, c.env.OTP_KV_PREFIX);
     
     return c.json({
       success: true,
@@ -431,6 +470,7 @@ app.get('/otp/status/:email', async (c) => {
 
 // Delete OTP (admin/cleanup endpoint)
 app.delete('/otp/:email', async (c) => {
+  if (!hasInternalAuth(c)) return c.json({ success: false, message: 'Unauthorized' }, 401);
   try {
     const email = c.req.param('email');
 
@@ -441,7 +481,7 @@ app.delete('/otp/:email', async (c) => {
       }, 400);
     }
 
-    const deleted = await deleteOTP(c.env.OTP_KV, email);
+    const deleted = await deleteOTP(c.env.OTP_KV, email, c.env.OTP_KV_PREFIX);
     
     return c.json({
       success: deleted,
@@ -458,11 +498,12 @@ app.delete('/otp/:email', async (c) => {
 
 // Send verification email manually
 app.post('/email/send-verification', async (c) => {
+  if (!hasInternalAuth(c)) return c.json({ success: false, message: 'Unauthorized' }, 401);
   try {
     const body = await c.req.json();
     const { email, otp, expiryMinutes = 10 } = body;
 
-    console.log('📧 Email verification request:', { email, otp, expiryMinutes });
+    console.log('📧 Email verification request:', { email, expiryMinutes });
 
     if (!email || typeof email !== 'string') {
       return c.json({
@@ -505,6 +546,124 @@ app.post('/email/send-verification', async (c) => {
   }
 });
 
+// Passkey endpoints
+function normalizePasskeyEmail(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const email = value.trim().toLowerCase();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : null;
+}
+
+async function getAuthPayload(c: AuthContext) {
+  const header = c.req.header('Authorization');
+  if (!header?.startsWith('Bearer ')) return null;
+  const token = header.slice('Bearer '.length).trim();
+  if (!token || token.length > 4096) return null;
+
+  const result = await new JWTService(c.env).verifyToken(token);
+  return result.success && result.payload ? result.payload : null;
+}
+
+async function readJsonBody(c: AuthContext): Promise<Record<string, unknown>> {
+  const body = await c.req.json();
+  return body && typeof body === 'object' ? body as Record<string, unknown> : {};
+}
+
+async function beginPasskeyRegistration(c: AuthContext) {
+  try {
+    const payload = await getAuthPayload(c);
+    if (!payload?.sub || !payload.email) {
+      return c.json({ success: false, message: 'Authentication required' }, 401);
+    }
+    if (!(await getActiveUser(c.env, payload.sub))) {
+      return c.json({ success: false, message: 'Authentication required' }, 401);
+    }
+
+    const result = await new PasskeyService(c.env).beginRegistration(payload.sub, payload.email);
+    return result.success
+      ? c.json({ success: true, state: result.state, options: result.options })
+      : c.json({ success: false, message: result.error || 'Unable to begin passkey registration' }, 400);
+  } catch (error) {
+    console.error('Error beginning passkey registration:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+}
+
+async function completePasskeyRegistration(c: AuthContext) {
+  try {
+    const payload = await getAuthPayload(c);
+    if (!payload?.sub) {
+      return c.json({ success: false, message: 'Authentication required' }, 401);
+    }
+    if (!(await getActiveUser(c.env, payload.sub))) {
+      return c.json({ success: false, message: 'Authentication required' }, 401);
+    }
+
+    const body = await readJsonBody(c);
+    const state = typeof body.state === 'string' ? body.state : body.sessionToken;
+    if (typeof state !== 'string' || !isRegistrationResponse(body.response)) {
+      return c.json({ success: false, message: 'state and a valid passkey response are required' }, 400);
+    }
+
+    const result = await new PasskeyService(c.env).completeRegistration(payload.sub, state, body.response);
+    return result.success
+      ? c.json({ success: true, credentialId: result.credentialId })
+      : c.json({ success: false, message: result.error || 'Passkey registration failed' }, 400);
+  } catch (error) {
+    console.error('Error completing passkey registration:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+}
+
+async function beginPasskeyAuthentication(c: AuthContext) {
+  try {
+    const body = await readJsonBody(c);
+    const email = normalizePasskeyEmail(body.email);
+    if (!email) {
+      return c.json({ success: false, message: 'A valid email is required' }, 400);
+    }
+
+    const result = await new PasskeyService(c.env).beginAuthentication(email);
+    return result.success
+      ? c.json({ success: true, state: result.state, options: result.options })
+      : c.json({ success: false, message: 'No passkey is registered for this email' }, 404);
+  } catch (error) {
+    console.error('Error beginning passkey authentication:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+}
+
+async function completePasskeyAuthentication(c: AuthContext) {
+  try {
+    const body = await readJsonBody(c);
+    const email = normalizePasskeyEmail(body.email);
+    const state = typeof body.state === 'string' ? body.state : body.sessionToken;
+    if (!email || typeof state !== 'string' || !isAuthenticationResponse(body.response)) {
+      return c.json({ success: false, message: 'email, state, and a valid passkey response are required' }, 400);
+    }
+
+    const result = await new PasskeyService(c.env).completeAuthentication(email, state, body.response);
+    if (!result.success || !result.jwtToken || !result.user) {
+      return c.json({ success: false, message: result.error || 'Passkey authentication failed' }, 400);
+    }
+
+    return c.json({
+      success: true,
+      message: 'Passkey authenticated successfully',
+      token: result.jwtToken,
+      expiresIn: 604800,
+      user: result.user,
+    });
+  } catch (error) {
+    console.error('Error completing passkey authentication:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+}
+
+app.post('/passkeys/register/begin', beginPasskeyRegistration);
+app.post('/passkeys/register/complete', completePasskeyRegistration);
+app.post('/passkeys/authenticate/begin', beginPasskeyAuthentication);
+app.post('/passkeys/authenticate/complete', completePasskeyAuthentication);
+
 // Root endpoint
 app.get('/', (c) => {
   return c.json({
@@ -543,6 +702,28 @@ app.get('/', (c) => {
         method: 'POST',
         description: 'Send verification email manually',
         body: { email: 'string', otp: 'string', expiryMinutes: 'number (optional)' }
+      },
+      {
+        path: '/passkeys/register/begin',
+        method: 'POST',
+        description: 'Create WebAuthn registration options (Bearer JWT required)'
+      },
+      {
+        path: '/passkeys/register/complete',
+        method: 'POST',
+        description: 'Verify and save a WebAuthn registration (Bearer JWT required)'
+      },
+      {
+        path: '/passkeys/authenticate/begin',
+        method: 'POST',
+        description: 'Create WebAuthn authentication options',
+        body: { email: 'string' }
+      },
+      {
+        path: '/passkeys/authenticate/complete',
+        method: 'POST',
+        description: 'Verify a WebAuthn authentication response',
+        body: { email: 'string', state: 'string', response: 'object' }
       }
     ]
   });
@@ -566,3 +747,4 @@ app.onError((err, c) => {
 });
 
 export default app;
+export { PasskeyChallengeObject } from './passkey-challenge-do';

--- a/auth-worker/src/passkey-challenge-do.ts
+++ b/auth-worker/src/passkey-challenge-do.ts
@@ -1,0 +1,50 @@
+interface StoredChallenge {
+  challenge: string;
+  flow: 'registration' | 'authentication';
+  userId: string;
+  expiresAt: number;
+}
+
+/**
+ * Durable Objects serialize requests for a single state id. Keeping the
+ * challenge in object storage makes the read-and-delete claim one-time even
+ * when two completion requests arrive concurrently.
+ */
+export class PasskeyChallengeObject {
+  private claimInProgress = false;
+
+  constructor(private readonly state: DurableObjectState) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === 'POST' && url.pathname === '/store') {
+      const challenge = await request.json() as StoredChallenge;
+      if (!challenge || typeof challenge.challenge !== 'string' ||
+          !['registration', 'authentication'].includes(challenge.flow) ||
+          typeof challenge.userId !== 'string' || !Number.isFinite(challenge.expiresAt)) {
+        return Response.json({ success: false }, { status: 400 });
+      }
+      await this.state.storage.put('challenge', challenge);
+      return Response.json({ success: true });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/claim') {
+      if (this.claimInProgress) return Response.json({ success: false }, { status: 404 });
+      this.claimInProgress = true;
+      try {
+        const challenge = await this.state.storage.get<StoredChallenge>('challenge');
+        if (!challenge || challenge.expiresAt <= Date.now()) {
+          await this.state.storage.delete('challenge');
+          return Response.json({ success: false }, { status: 404 });
+        }
+        await this.state.storage.delete('challenge');
+        return Response.json({ success: true, data: challenge });
+      } finally {
+        this.claimInProgress = false;
+      }
+    }
+
+    return Response.json({ success: false }, { status: 404 });
+  }
+}

--- a/auth-worker/src/services/jwt-service.ts
+++ b/auth-worker/src/services/jwt-service.ts
@@ -32,6 +32,9 @@ export class JWTService {
     if (!env.JWT_SECRET) {
       throw new Error('JWT_SECRET not configured');
     }
+    if ((env.ENVIRONMENT === 'staging' || env.ENVIRONMENT === 'production') && env.JWT_SECRET.length < 32) {
+      throw new Error('JWT_SECRET must be at least 32 characters outside development and preview');
+    }
 
     // Convert secret to Uint8Array for jose library
     this.secret = new TextEncoder().encode(env.JWT_SECRET);

--- a/auth-worker/src/services/passkey-service.ts
+++ b/auth-worker/src/services/passkey-service.ts
@@ -1,0 +1,405 @@
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+} from '@simplewebauthn/server';
+import type {
+  AuthenticatorDevice,
+  AuthenticatorTransportFuture,
+  AuthenticationResponseJSON,
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+} from '@simplewebauthn/types';
+import { Env } from '../types/env';
+import { generateSecureToken, hashEmail } from '../utils/crypto';
+
+const CHALLENGE_TTL_SECONDS = 300;
+const PASSKEY_TOKEN_TTL_SECONDS = 604800;
+const DEFAULT_RP_ID = 'localhost';
+const DEFAULT_RP_NAME = 'Seasoned';
+const DEFAULT_ORIGIN = 'http://localhost:5173';
+
+interface StoredChallenge {
+  challenge: string;
+  flow: 'registration' | 'authentication';
+  userId: string;
+  expiresAt?: number;
+}
+
+interface PasskeyCredentialRecord {
+  credential_id: string;
+  user_id: string;
+  public_key: string;
+  counter: number;
+  device_type: 'singleDevice' | 'multiDevice';
+  backed_up: number | boolean;
+  transports?: string | null;
+}
+
+interface UserRecord {
+  status?: 'ACTIVE' | 'SUSPENDED' | 'DELETED';
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error('Invalid base64url value');
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - value.length % 4) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+  return bytes;
+}
+
+function parseTransports(value: string | null | undefined): AuthenticatorTransportFuture[] | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) && parsed.every((item) => typeof item === 'string')
+      ? parsed as AuthenticatorTransportFuture[]
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function isRegistrationResponse(value: unknown): value is RegistrationResponseJSON {
+  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.rawId !== 'string' || typeof value.type !== 'string') {
+    return false;
+  }
+  const response = value.response;
+  return isRecord(response) && typeof response.clientDataJSON === 'string' && typeof response.attestationObject === 'string';
+}
+
+export function isAuthenticationResponse(value: unknown): value is AuthenticationResponseJSON {
+  if (!isRecord(value) || typeof value.id !== 'string' || typeof value.rawId !== 'string' || typeof value.type !== 'string') {
+    return false;
+  }
+  const response = value.response;
+  return isRecord(response) && typeof response.clientDataJSON === 'string' &&
+    typeof response.authenticatorData === 'string' && typeof response.signature === 'string';
+}
+
+export class PasskeyService {
+  constructor(private readonly env: Env) {
+    if (env.ENVIRONMENT !== 'development') {
+      if (!env.WEBAUTHN_RP_ID || !env.WEBAUTHN_ORIGIN || !env.PASSKEY_SERVICE_TOKEN || !env.PASSKEY_CHALLENGE_DO) {
+        throw new Error('WebAuthn RP, service-token, and challenge storage configuration are required outside development');
+      }
+      const userManagementUrl = new URL(env.USER_MANAGEMENT_WORKER_URL);
+      if (userManagementUrl.protocol !== 'https:') {
+        throw new Error('User management URL must use HTTPS outside development');
+      }
+      const origin = new URL(env.WEBAUTHN_ORIGIN);
+      if (origin.protocol !== 'https:' || env.WEBAUTHN_RP_ID === 'localhost') {
+        throw new Error('WebAuthn production configuration must use HTTPS and a non-localhost RP ID');
+      }
+      if (origin.hostname !== env.WEBAUTHN_RP_ID && !origin.hostname.endsWith(`.${env.WEBAUTHN_RP_ID}`)) {
+        throw new Error('WebAuthn RP ID must match the configured origin');
+      }
+    }
+  }
+
+  private get rpId(): string {
+    return this.env.WEBAUTHN_RP_ID || DEFAULT_RP_ID;
+  }
+
+  private get rpName(): string {
+    return this.env.WEBAUTHN_RP_NAME || DEFAULT_RP_NAME;
+  }
+
+  private get origin(): string {
+    return this.env.WEBAUTHN_ORIGIN || DEFAULT_ORIGIN;
+  }
+
+  private serviceHeaders(contentType = false): HeadersInit {
+    const headers: Record<string, string> = {};
+    if (contentType) headers['Content-Type'] = 'application/json';
+    if (this.env.PASSKEY_SERVICE_TOKEN) headers['X-Internal-Auth'] = this.env.PASSKEY_SERVICE_TOKEN;
+    return headers;
+  }
+
+  private async userManagement(path: string, init: RequestInit = {}): Promise<Response> {
+    const headers = new Headers(init.headers);
+    const serviceHeaders = this.serviceHeaders(init.body !== undefined);
+    Object.entries(serviceHeaders).forEach(([name, value]) => headers.set(name, value));
+    return fetch(`${this.env.USER_MANAGEMENT_WORKER_URL}${path}`, { ...init, headers });
+  }
+
+  private async getCredentials(userId: string): Promise<PasskeyCredentialRecord[]> {
+    const response = await this.userManagement(`/passkey-credentials/user/${encodeURIComponent(userId)}`);
+    if (!response.ok) return [];
+    const body = await response.json() as { success?: boolean; data?: PasskeyCredentialRecord[] };
+    return body.success && Array.isArray(body.data) ? body.data : [];
+  }
+
+  private async storeChallenge(state: string, challenge: StoredChallenge): Promise<void> {
+    if (this.env.PASSKEY_CHALLENGE_DO) {
+      const objectId = this.env.PASSKEY_CHALLENGE_DO.idFromName(state);
+      const response = await this.env.PASSKEY_CHALLENGE_DO.get(objectId).fetch('https://passkey-challenge/store', {
+        method: 'POST',
+        body: JSON.stringify({ ...challenge, expiresAt: Date.now() + CHALLENGE_TTL_SECONDS * 1000 }),
+      });
+      if (!response.ok) throw new Error('Unable to store passkey challenge');
+      return;
+    }
+
+    // KV is retained only for local development, where a Durable Object is not
+    // normally provisioned. Production and deployed preview/staging must use
+    // the atomic Durable Object claim path.
+    if (this.env.ENVIRONMENT !== 'development') throw new Error('Passkey challenge storage is not configured');
+    await this.env.OTP_KV.put(`passkey:challenge:${state}`, JSON.stringify({ ...challenge, expiresAt: Date.now() + CHALLENGE_TTL_SECONDS * 1000 }), { expirationTtl: CHALLENGE_TTL_SECONDS });
+  }
+
+  private async consumeChallenge(state: string, flow: StoredChallenge['flow']): Promise<StoredChallenge | null> {
+    if (!/^[a-f0-9]{64}$/.test(state)) return null;
+
+    if (this.env.PASSKEY_CHALLENGE_DO) {
+      const objectId = this.env.PASSKEY_CHALLENGE_DO.idFromName(state);
+      const response = await this.env.PASSKEY_CHALLENGE_DO.get(objectId).fetch('https://passkey-challenge/claim', { method: 'POST' });
+      if (!response.ok) return null;
+      const body = await response.json() as { success?: boolean; data?: StoredChallenge };
+      const stored = body.success ? body.data : undefined;
+      return stored && stored.flow === flow && typeof stored.challenge === 'string' && typeof stored.userId === 'string' &&
+        (!stored.expiresAt || stored.expiresAt > Date.now())
+        ? stored
+        : null;
+    }
+
+    if (this.env.ENVIRONMENT !== 'development') return null;
+    const key = `passkey:challenge:${state}`;
+    const raw = await this.env.OTP_KV.get(key);
+    // Local KV fallback only; deployed environments require the atomic DO path.
+    await this.env.OTP_KV.delete(key);
+    if (!raw) return null;
+
+    try {
+      const stored = JSON.parse(raw) as StoredChallenge;
+      if (stored.flow !== flow || typeof stored.challenge !== 'string' || typeof stored.userId !== 'string') return null;
+      return stored;
+    } catch {
+      return null;
+    }
+  }
+
+  async beginRegistration(userId: string, email: string): Promise<{
+    success: boolean;
+    state?: string;
+    options?: PublicKeyCredentialCreationOptionsJSON;
+    error?: string;
+  }> {
+    const existing = await this.getCredentials(userId);
+    const options = await generateRegistrationOptions({
+      rpName: this.rpName,
+      rpID: this.rpId,
+      userID: encodeBase64Url(new TextEncoder().encode(userId)),
+      userName: email,
+      userDisplayName: email,
+      attestationType: 'none',
+      excludeCredentials: existing.map((credential) => ({
+        id: decodeBase64Url(credential.credential_id),
+        type: 'public-key',
+        transports: parseTransports(credential.transports),
+      })),
+      authenticatorSelection: {
+        residentKey: 'preferred',
+        userVerification: 'required',
+      },
+    });
+
+    const state = generateSecureToken(32);
+    await this.storeChallenge(state, { challenge: options.challenge, flow: 'registration', userId });
+
+    return { success: true, state, options };
+  }
+
+  async completeRegistration(userId: string, state: string, response: RegistrationResponseJSON): Promise<{
+    success: boolean;
+    credentialId?: string;
+    error?: string;
+  }> {
+    const challenge = await this.consumeChallenge(state, 'registration');
+    if (!challenge || challenge.userId !== userId) {
+      return { success: false, error: 'Registration challenge expired or invalid' };
+    }
+
+    let verification;
+    try {
+      verification = await verifyRegistrationResponse({
+        response,
+        expectedChallenge: challenge.challenge,
+        expectedOrigin: this.origin,
+        expectedRPID: this.rpId,
+        expectedType: 'webauthn.create',
+        requireUserVerification: true,
+      });
+    } catch (error) {
+      console.warn('Passkey registration verification failed:', error);
+      return { success: false, error: 'Passkey registration failed' };
+    }
+
+    if (!verification.verified || !verification.registrationInfo) {
+      return { success: false, error: 'Passkey registration failed' };
+    }
+
+    const info = verification.registrationInfo;
+    const credentialId = encodeBase64Url(info.credentialID);
+    const responseTransports = response.response.transports;
+    const createResponse = await this.userManagement('/passkey-credentials', {
+      method: 'POST',
+      headers: this.serviceHeaders(true),
+      body: JSON.stringify({
+        credential_id: credentialId,
+        user_id: userId,
+        public_key: encodeBase64Url(info.credentialPublicKey),
+        counter: info.counter,
+        device_type: info.credentialDeviceType,
+        backed_up: info.credentialBackedUp,
+        transports: responseTransports,
+      }),
+    });
+
+    if (!createResponse.ok) {
+      return { success: false, error: 'Unable to save passkey' };
+    }
+
+    return { success: true, credentialId };
+  }
+
+  async beginAuthentication(email: string): Promise<{
+    success: boolean;
+    state?: string;
+    options?: PublicKeyCredentialRequestOptionsJSON;
+    error?: string;
+  }> {
+    const userId = await hashEmail(email);
+    const credentials = await this.getCredentials(userId);
+    if (credentials.length === 0) {
+      return { success: false, error: 'No passkey is registered for this email' };
+    }
+
+    const options = await generateAuthenticationOptions({
+      rpID: this.rpId,
+      allowCredentials: credentials.map((credential) => ({
+        id: decodeBase64Url(credential.credential_id),
+        type: 'public-key',
+        transports: parseTransports(credential.transports),
+      })),
+      userVerification: 'required',
+    });
+    const state = generateSecureToken(32);
+    await this.storeChallenge(state, { challenge: options.challenge, flow: 'authentication', userId });
+
+    return { success: true, state, options };
+  }
+
+  async completeAuthentication(email: string, state: string, response: AuthenticationResponseJSON): Promise<{
+    success: boolean;
+    jwtToken?: string;
+    user?: { id: string; email: string };
+    error?: string;
+  }> {
+    const userId = await hashEmail(email);
+    const challenge = await this.consumeChallenge(state, 'authentication');
+    if (!challenge || challenge.userId !== userId) {
+      return { success: false, error: 'Authentication challenge expired or invalid' };
+    }
+
+    let credential: PasskeyCredentialRecord | undefined;
+    try {
+      const credentialResponse = await this.userManagement(`/passkey-credentials/${encodeURIComponent(response.id)}`);
+      if (credentialResponse.ok) {
+        const body = await credentialResponse.json() as { success?: boolean; data?: PasskeyCredentialRecord };
+        credential = body.success ? body.data : undefined;
+      }
+    } catch (error) {
+      console.error('Error loading passkey credential:', error);
+    }
+
+    if (!credential || credential.user_id !== userId) {
+      return { success: false, error: 'Passkey authentication failed' };
+    }
+
+    let verification;
+    try {
+      const authenticator: AuthenticatorDevice = {
+        credentialID: decodeBase64Url(credential.credential_id),
+        credentialPublicKey: decodeBase64Url(credential.public_key),
+        counter: credential.counter,
+        transports: parseTransports(credential.transports),
+      };
+      verification = await verifyAuthenticationResponse({
+        response,
+        expectedChallenge: challenge.challenge,
+        expectedOrigin: this.origin,
+        expectedRPID: this.rpId,
+        expectedType: 'webauthn.get',
+        authenticator,
+        requireUserVerification: true,
+      });
+    } catch (error) {
+      console.warn('Passkey authentication verification failed:', error);
+      return { success: false, error: 'Passkey authentication failed' };
+    }
+
+    if (!verification.verified) {
+      return { success: false, error: 'Passkey authentication failed' };
+    }
+
+    const { newCounter } = verification.authenticationInfo;
+    if (credential.counter > 0 && newCounter <= credential.counter) {
+      return { success: false, error: 'Passkey authentication failed' };
+    }
+
+    // User deletion cascades credentials. Fail closed if account status cannot be
+    // positively established before mutating the authenticator counter.
+    const userResponse = await this.userManagement(`/users/${encodeURIComponent(userId)}`);
+    if (!userResponse.ok) {
+      return { success: false, error: 'Passkey authentication failed' };
+    }
+    const userBody = await userResponse.json() as { success?: boolean; data?: UserRecord };
+    if (!userBody.success || userBody.data?.status !== 'ACTIVE') {
+      return { success: false, error: 'Passkey authentication failed' };
+    }
+
+    const counterResponse = await this.userManagement(
+      `/passkey-credentials/${encodeURIComponent(credential.credential_id)}/counter`,
+      {
+        method: 'PATCH',
+        headers: this.serviceHeaders(true),
+        body: JSON.stringify({ previous_counter: credential.counter, counter: newCounter }),
+      },
+    );
+    if (!counterResponse.ok) {
+      return { success: false, error: 'Passkey authentication failed' };
+    }
+
+    const { JWTService } = await import('./jwt-service');
+    const tokenResult = await new JWTService(this.env).createToken(userId, email, PASSKEY_TOKEN_TTL_SECONDS);
+    if (!tokenResult.success || !tokenResult.token) {
+      return { success: false, error: 'Passkey authentication failed' };
+    }
+
+    await this.userManagement('/login-history', {
+      method: 'POST',
+      headers: this.serviceHeaders(true),
+      body: JSON.stringify({ user_id: userId, login_method: 'PASSKEY', success: true }),
+    }).catch((error) => console.error('Unable to record passkey login:', error));
+
+    return {
+      success: true,
+      jwtToken: tokenResult.token,
+      user: { id: userId, email },
+    };
+  }
+}

--- a/auth-worker/src/types/env.ts
+++ b/auth-worker/src/types/env.ts
@@ -7,6 +7,8 @@ export interface SendEmailBinding {
 export interface Env {
   // KV Namespace binding
   OTP_KV: KVNamespace;
+  OTP_KV_PREFIX?: string;
+  PASSKEY_CHALLENGE_DO?: DurableObjectNamespace;
   
   // Environment variables
   ENVIRONMENT: 'development' | 'preview' | 'staging' | 'production';
@@ -18,4 +20,10 @@ export interface Env {
   
   // JWT configuration
   JWT_SECRET: string;
+
+  // WebAuthn relying-party configuration. Defaults are for local development only.
+  WEBAUTHN_RP_ID?: string;
+  WEBAUTHN_RP_NAME?: string;
+  WEBAUTHN_ORIGIN?: string;
+  PASSKEY_SERVICE_TOKEN?: string;
 }

--- a/auth-worker/src/utils/otp-manager.ts
+++ b/auth-worker/src/utils/otp-manager.ts
@@ -28,6 +28,10 @@ export interface OTPVerificationResult {
 const MAX_ATTEMPTS = 3;
 const OTP_EXPIRY_MINUTES = 5;
 
+function otpKey(emailHash: string, prefix = ''): string {
+  return prefix ? `${prefix}:${emailHash}` : emailHash;
+}
+
 /**
  * Store an OTP for an email address
  * @param otpKV - The OTP KV namespace
@@ -40,7 +44,8 @@ export async function storeOTP(
   otpKV: KVNamespace,
   email: string,
   otp?: string,
-  expiryMinutes: number = OTP_EXPIRY_MINUTES
+  expiryMinutes: number = OTP_EXPIRY_MINUTES,
+  keyPrefix = ''
 ): Promise<OTPResult> {
   try {
     if (!otp) {
@@ -61,7 +66,7 @@ export async function storeOTP(
 
     // Store with TTL slightly longer than expiry to handle clock skew
     const ttlSeconds = Math.ceil(expiryMinutes * 60 * 1.1);
-    await otpKV.put(emailHash, JSON.stringify(otpRecord), {
+    await otpKV.put(otpKey(emailHash, keyPrefix), JSON.stringify(otpRecord), {
       expirationTtl: ttlSeconds
     });
 
@@ -89,11 +94,13 @@ export async function storeOTP(
 export async function verifyOTPForEmail(
   otpKV: KVNamespace,
   email: string,
-  otp: string
+  otp: string,
+  keyPrefix = ''
 ): Promise<OTPVerificationResult> {
   try {
     const emailHash = await hashEmail(email);
-    const recordData = await otpKV.get(emailHash);
+    const key = otpKey(emailHash, keyPrefix);
+    const recordData = await otpKV.get(key);
 
     if (!recordData) {
       return {
@@ -106,7 +113,7 @@ export async function verifyOTPForEmail(
 
     // Check if expired
     if (isExpired(record.expiresAt)) {
-      await otpKV.delete(emailHash);
+      await otpKV.delete(key);
       return {
         success: false,
         message: 'OTP has expired'
@@ -115,7 +122,7 @@ export async function verifyOTPForEmail(
 
     // Check attempts
     if (record.attempts >= MAX_ATTEMPTS) {
-      await otpKV.delete(emailHash);
+      await otpKV.delete(key);
       return {
         success: false,
         message: 'Maximum verification attempts exceeded'
@@ -127,7 +134,7 @@ export async function verifyOTPForEmail(
 
     if (isValid) {
       // OTP is valid, delete it
-      await otpKV.delete(emailHash);
+      await otpKV.delete(key);
       return {
         success: true,
         message: 'OTP verified successfully',
@@ -142,7 +149,7 @@ export async function verifyOTPForEmail(
         // Update record with incremented attempts
         const ttlSeconds = Math.ceil((record.expiresAt - Date.now()) / 1000);
         if (ttlSeconds > 0) {
-          await otpKV.put(emailHash, JSON.stringify(record), {
+          await otpKV.put(key, JSON.stringify(record), {
             expirationTtl: ttlSeconds
           });
         }
@@ -154,7 +161,7 @@ export async function verifyOTPForEmail(
         };
       } else {
         // Max attempts reached, delete record
-        await otpKV.delete(emailHash);
+        await otpKV.delete(otpKey(emailHash, keyPrefix));
         return {
           success: false,
           message: 'Invalid OTP. Maximum attempts exceeded.'
@@ -176,10 +183,10 @@ export async function verifyOTPForEmail(
  * @param email - The email address
  * @returns Promise<boolean>
  */
-export async function hasOTP(otpKV: KVNamespace, email: string): Promise<boolean> {
+export async function hasOTP(otpKV: KVNamespace, email: string, keyPrefix = ''): Promise<boolean> {
   try {
     const emailHash = await hashEmail(email);
-    const recordData = await otpKV.get(emailHash);
+    const recordData = await otpKV.get(otpKey(emailHash, keyPrefix));
     
     if (!recordData) {
       return false;
@@ -199,10 +206,10 @@ export async function hasOTP(otpKV: KVNamespace, email: string): Promise<boolean
  * @param email - The email address
  * @returns Promise<boolean> - True if deleted successfully
  */
-export async function deleteOTP(otpKV: KVNamespace, email: string): Promise<boolean> {
+export async function deleteOTP(otpKV: KVNamespace, email: string, keyPrefix = ''): Promise<boolean> {
   try {
     const emailHash = await hashEmail(email);
-    await otpKV.delete(emailHash);
+    await otpKV.delete(otpKey(emailHash, keyPrefix));
     return true;
   } catch (error) {
     console.error('Error deleting OTP:', error);
@@ -218,11 +225,12 @@ export async function deleteOTP(otpKV: KVNamespace, email: string): Promise<bool
  */
 export async function getOTPStats(
   otpKV: KVNamespace,
-  email: string
+  email: string,
+  keyPrefix = ''
 ): Promise<{exists: boolean, attempts?: number, expiresAt?: number}> {
   try {
     const emailHash = await hashEmail(email);
-    const recordData = await otpKV.get(emailHash);
+    const recordData = await otpKV.get(otpKey(emailHash, keyPrefix));
     
     if (!recordData) {
       return { exists: false };

--- a/auth-worker/tests/unit/jwt-endpoints.test.ts
+++ b/auth-worker/tests/unit/jwt-endpoints.test.ts
@@ -20,6 +20,11 @@ const mockEnv = {
 describe('JWT Endpoints', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, data: { status: 'ACTIVE' } }),
+    }));
   });
 
   describe('POST /auth/validate', () => {

--- a/auth-worker/tests/unit/jwt-endpoints.test.ts
+++ b/auth-worker/tests/unit/jwt-endpoints.test.ts
@@ -102,6 +102,27 @@ describe('JWT Endpoints', () => {
       expect(result.message).toBeDefined();
     });
 
+    it('should reject valid tokens for suspended users', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ success: true, data: { status: 'SUSPENDED' } }),
+      }));
+      const { JWTService } = await import('../../src/services/jwt-service');
+      const tokenResult = await new JWTService(mockEnv).createToken('test-user-id', 'test@example.com');
+
+      const response = await app.fetch(new Request('http://localhost/auth/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: tokenResult.token }),
+      }), mockEnv);
+      const result = await response.json() as any;
+
+      expect(response.status).toBe(200);
+      expect(result.success).toBe(false);
+      expect(result.valid).toBe(false);
+    });
+
     it('should reject expired JWT tokens', async () => {
       // Create a token that expires in 1 second
       const { JWTService } = await import('../../src/services/jwt-service');
@@ -230,6 +251,26 @@ describe('JWT Endpoints', () => {
       expect(result.token).toBeDefined();
       expect(result.token).not.toBe(token);
       expect(result.expiresIn).toBe(604800);
+    });
+
+    it('should not refresh tokens for suspended users', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ success: true, data: { status: 'SUSPENDED' } }),
+      }));
+      const { JWTService } = await import('../../src/services/jwt-service');
+      const tokenResult = await new JWTService(mockEnv).createToken('test-user-id', 'test@example.com');
+
+      const response = await app.fetch(new Request('http://localhost/auth/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: tokenResult.token }),
+      }), mockEnv);
+      const result = await response.json() as any;
+
+      expect(response.status).toBe(401);
+      expect(result.success).toBe(false);
     });
 
     it('should reject expired tokens', async () => {

--- a/auth-worker/tests/unit/otp-endpoints.test.ts
+++ b/auth-worker/tests/unit/otp-endpoints.test.ts
@@ -31,7 +31,7 @@ describe('OTP Endpoints', () => {
         getWithMetadata: vi.fn()
       } as unknown as KVNamespace,
       USER_MANAGEMENT_WORKER_URL: 'https://user-management-worker-preview.your-domain.workers.dev',
-      ENVIRONMENT: 'preview',
+      ENVIRONMENT: 'development',
       JWT_SECRET: 'test-jwt-secret',
       FROM_EMAIL: 'verify@seasonedapp.com',
       send_email: {
@@ -43,7 +43,7 @@ describe('OTP Endpoints', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
-      json: () => Promise.resolve({ success: true })
+      json: () => Promise.resolve({ success: true, data: { status: 'ACTIVE' } })
     } as Response));
 
     // Mock OTP_KV operations to simulate actual KV behavior

--- a/auth-worker/tests/unit/passkey-challenge-do.test.ts
+++ b/auth-worker/tests/unit/passkey-challenge-do.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { PasskeyChallengeObject } from '@/passkey-challenge-do';
+
+function createObject() {
+  const values = new Map<string, unknown>();
+  const state = {
+    storage: {
+      put: async (key: string, value: unknown) => { values.set(key, value); },
+      get: async <T>(key: string) => values.get(key) as T | undefined,
+      delete: async (key: string) => values.delete(key),
+    },
+  } as unknown as DurableObjectState;
+  return new PasskeyChallengeObject(state);
+}
+
+const challenge = {
+  challenge: 'Y2hhbGxlbmdl',
+  flow: 'authentication',
+  userId: 'user-id',
+  expiresAt: Date.now() + 60_000,
+};
+
+describe('PasskeyChallengeObject', () => {
+  it('stores and atomically claims a challenge once', async () => {
+    const object = createObject();
+    const store = await object.fetch(new Request('https://challenge/store', {
+      method: 'POST', body: JSON.stringify(challenge),
+    }));
+    expect(store.status).toBe(200);
+
+    const [first, second] = await Promise.all([
+      object.fetch(new Request('https://challenge/claim', { method: 'POST' })),
+      object.fetch(new Request('https://challenge/claim', { method: 'POST' })),
+    ]);
+    expect([first.status, second.status].sort()).toEqual([200, 404]);
+  });
+
+  it('rejects malformed and expired challenge records', async () => {
+    const object = createObject();
+    const malformed = await object.fetch(new Request('https://challenge/store', {
+      method: 'POST', body: JSON.stringify({ flow: 'authentication' }),
+    }));
+    expect(malformed.status).toBe(400);
+
+    const expired = await object.fetch(new Request('https://challenge/store', {
+      method: 'POST', body: JSON.stringify({ ...challenge, expiresAt: Date.now() - 1 }),
+    }));
+    expect(expired.status).toBe(200);
+    const claim = await object.fetch(new Request('https://challenge/claim', { method: 'POST' }));
+    expect(claim.status).toBe(404);
+  });
+
+  it('returns not found for unsupported operations', async () => {
+    const object = createObject();
+    const response = await object.fetch(new Request('https://challenge/nope'));
+    expect(response.status).toBe(404);
+  });
+});

--- a/auth-worker/tests/unit/passkey-endpoints.test.ts
+++ b/auth-worker/tests/unit/passkey-endpoints.test.ts
@@ -95,6 +95,16 @@ describe('Passkey endpoints', () => {
     vi.stubGlobal('fetch', fetchMock);
   });
 
+  it('returns unauthorized when the registration user is no longer active', async () => {
+    const token = await new JWTService(mockEnv).createToken(userId, email);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: { status: 'SUSPENDED' } }));
+    const response = await app.fetch(new Request('http://localhost/passkeys/register/begin', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token.token}` },
+    }), mockEnv);
+    expect(response.status).toBe(401);
+  });
+
   it('requires a JWT to begin registration', async () => {
     const response = await app.fetch(new Request('http://localhost/passkeys/register/begin', { method: 'POST' }), mockEnv);
     expect(response.status).toBe(401);
@@ -119,6 +129,16 @@ describe('Passkey endpoints', () => {
     }));
   });
 
+  it('returns an internal error for malformed registration JSON', async () => {
+    const token = await new JWTService(mockEnv).createToken(userId, email);
+    const response = await app.fetch(new Request('http://localhost/passkeys/register/complete', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token.token}`, 'Content-Type': 'application/json' },
+      body: '{',
+    }), mockEnv);
+    expect(response.status).toBe(500);
+  });
+
   it('rejects malformed registration responses before consuming a challenge', async () => {
     const token = await new JWTService(mockEnv).createToken(userId, email);
     const response = await app.fetch(new Request('http://localhost/passkeys/register/complete', {
@@ -128,6 +148,17 @@ describe('Passkey endpoints', () => {
     }), mockEnv);
     expect(response.status).toBe(400);
     expect(kv.size).toBe(0);
+  });
+
+  it('returns unauthorized when completing registration for a suspended user', async () => {
+    const token = await new JWTService(mockEnv).createToken(userId, email);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: { status: 'DELETED' } }));
+    const response = await app.fetch(new Request('http://localhost/passkeys/register/complete', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token.token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'a'.repeat(64), response: passkeyResponse('create') }),
+    }), mockEnv);
+    expect(response.status).toBe(401);
   });
 
   it('verifies and stores a valid registration response', async () => {
@@ -159,6 +190,13 @@ describe('Passkey endpoints', () => {
     expect(body.credentialId).toBe('AQI');
     expect(kv.size).toBe(0);
     expect(fetchMock).toHaveBeenCalledWith('https://users.example.com/passkey-credentials', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('returns an internal error for malformed authentication JSON', async () => {
+    const response = await app.fetch(new Request('http://localhost/passkeys/authenticate/begin', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{',
+    }), mockEnv);
+    expect(response.status).toBe(500);
   });
 
   it('requires a valid email for authentication options', async () => {

--- a/auth-worker/tests/unit/passkey-endpoints.test.ts
+++ b/auth-worker/tests/unit/passkey-endpoints.test.ts
@@ -1,0 +1,322 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import app from '@/index';
+import { PasskeyService } from '@/services/passkey-service';
+import { JWTService } from '@/services/jwt-service';
+import type { Env } from '@/types/env';
+
+const { generateRegistrationOptions, generateAuthenticationOptions, verifyRegistrationResponse, verifyAuthenticationResponse } = vi.hoisted(() => ({
+  generateRegistrationOptions: vi.fn(),
+  generateAuthenticationOptions: vi.fn(),
+  verifyRegistrationResponse: vi.fn(),
+  verifyAuthenticationResponse: vi.fn(),
+}));
+
+vi.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions,
+  generateAuthenticationOptions,
+  verifyRegistrationResponse,
+  verifyAuthenticationResponse,
+}));
+
+const email = 'user@example.com';
+const userId = 'b4c9a289323b21a01c3e940f150eb9b8c542587f1abfd8f0e1cc1ffc5e475514';
+
+function passkeyResponse(kind: 'create' | 'get' = 'get') {
+  return kind === 'create'
+    ? {
+        id: 'AQI',
+        rawId: 'AQI',
+        type: 'public-key',
+        response: { clientDataJSON: 'Y2xpZW50', attestationObject: 'YXR0ZXN0' },
+      }
+    : {
+        id: 'AQI',
+        rawId: 'AQI',
+        type: 'public-key',
+        response: { clientDataJSON: 'Y2xpZW50', authenticatorData: 'YXV0aA', signature: 'c2ln' },
+      };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+}
+
+describe('Passkey endpoints', () => {
+  let mockEnv: Env;
+  let kv: Map<string, string>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeAll(async () => {
+    // @ts-expect-error Node.js crypto is only used by the Vitest environment.
+    const { webcrypto } = await import('node:crypto');
+    if (!(globalThis as any).crypto) (globalThis as any).crypto = webcrypto;
+  });
+
+  beforeEach(() => {
+    kv = new Map();
+    mockEnv = {
+      OTP_KV: {
+        put: vi.fn(async (key: string, value: string) => { kv.set(key, value); }),
+        get: vi.fn(async (key: string) => kv.get(key) ?? null),
+        delete: vi.fn(async (key: string) => { kv.delete(key); }),
+        list: vi.fn(),
+        getWithMetadata: vi.fn(),
+      } as unknown as KVNamespace,
+      USER_MANAGEMENT_WORKER_URL: 'https://users.example.com',
+      ENVIRONMENT: 'development',
+      JWT_SECRET: 'DUMMY_JWT_SECRET_FOR_TESTS_ONLY_32',
+      send_email: { send: vi.fn() },
+      WEBAUTHN_RP_ID: 'localhost',
+      WEBAUTHN_RP_NAME: 'Seasoned',
+      WEBAUTHN_ORIGIN: 'http://localhost:5173',
+    };
+
+    generateRegistrationOptions.mockResolvedValue({
+      challenge: 'Y2hhbGxlbmdl',
+      rp: { id: 'localhost', name: 'Seasoned' },
+      user: { id: 'dXNlcg', name: email, displayName: email },
+      excludeCredentials: [],
+    });
+    generateAuthenticationOptions.mockResolvedValue({
+      challenge: 'Y2hhbGxlbmdl',
+      rpId: 'localhost',
+      allowCredentials: [{ id: 'AQI', type: 'public-key' }],
+      userVerification: 'required',
+    });
+    verifyRegistrationResponse.mockReset();
+    verifyAuthenticationResponse.mockReset();
+
+    fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith(`/passkey-credentials/user/${userId}`)) return jsonResponse({ success: true, data: [] });
+      if (url.endsWith('/passkey-credentials')) return jsonResponse({ success: true }, 201);
+      return jsonResponse({ success: true, data: { status: 'ACTIVE' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  it('requires a JWT to begin registration', async () => {
+    const response = await app.fetch(new Request('http://localhost/passkeys/register/begin', { method: 'POST' }), mockEnv);
+    expect(response.status).toBe(401);
+  });
+
+  it('creates registration options and a one-time state', async () => {
+    const token = await new JWTService(mockEnv).createToken(userId, email);
+    const response = await app.fetch(new Request('http://localhost/passkeys/register/begin', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token.token}` },
+    }), mockEnv);
+    const body = await response.json() as any;
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.state).toMatch(/^[a-f0-9]{64}$/);
+    expect(kv.size).toBe(1);
+    expect(generateRegistrationOptions).toHaveBeenCalledWith(expect.objectContaining({
+      rpID: 'localhost',
+      userName: email,
+      authenticatorSelection: { residentKey: 'preferred', userVerification: 'required' },
+    }));
+  });
+
+  it('rejects malformed registration responses before consuming a challenge', async () => {
+    const token = await new JWTService(mockEnv).createToken(userId, email);
+    const response = await app.fetch(new Request('http://localhost/passkeys/register/complete', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token.token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'not-a-state', response: {} }),
+    }), mockEnv);
+    expect(response.status).toBe(400);
+    expect(kv.size).toBe(0);
+  });
+
+  it('verifies and stores a valid registration response', async () => {
+    const token = await new JWTService(mockEnv).createToken(userId, email);
+    const begin = await app.fetch(new Request('http://localhost/passkeys/register/begin', {
+      method: 'POST', headers: { Authorization: `Bearer ${token.token}` },
+    }), mockEnv);
+    const { state } = await begin.json() as { state: string };
+    verifyRegistrationResponse.mockResolvedValueOnce({
+      verified: true,
+      registrationInfo: {
+        credentialID: Uint8Array.from([1, 2]),
+        credentialPublicKey: Uint8Array.from([3, 4]),
+        counter: 0,
+        credentialDeviceType: 'singleDevice',
+        credentialBackedUp: false,
+      },
+    });
+
+    const response = await app.fetch(new Request('http://localhost/passkeys/register/complete', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token.token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state, response: passkeyResponse('create') }),
+    }), mockEnv);
+    const body = await response.json() as any;
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.credentialId).toBe('AQI');
+    expect(kv.size).toBe(0);
+    expect(fetchMock).toHaveBeenCalledWith('https://users.example.com/passkey-credentials', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('requires a valid email for authentication options', async () => {
+    const response = await app.fetch(new Request('http://localhost/passkeys/authenticate/begin', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email: 'invalid' }),
+    }), mockEnv);
+    expect(response.status).toBe(400);
+  });
+
+  it('returns no-passkey when the email has no registered credential', async () => {
+    const response = await app.fetch(new Request('http://localhost/passkeys/authenticate/begin', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email }),
+    }), mockEnv);
+    expect(response.status).toBe(404);
+    expect((await response.json() as any).message).toMatch(/no passkey/i);
+  });
+
+  it('verifies authentication, advances the counter, and issues the existing JWT contract', async () => {
+    const credentials = [{
+      credential_id: 'AQI', user_id: userId, public_key: 'AwQ', counter: 0,
+      device_type: 'singleDevice', backed_up: 0, transports: '["internal"]',
+    }];
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith(`/passkey-credentials/user/${userId}`)) return jsonResponse({ success: true, data: credentials });
+      if (url.endsWith('/passkey-credentials/AQI')) return jsonResponse({ success: true, data: credentials[0] });
+      if (url.endsWith('/counter')) return jsonResponse({ success: true, data: { ...credentials[0], counter: 1 } });
+      if (url.endsWith(`/users/${userId}`)) return jsonResponse({ success: true, data: { status: 'ACTIVE' } });
+      if (url.endsWith('/login-history')) return jsonResponse({ success: true }, 201);
+      return jsonResponse({ success: false }, 404);
+    });
+    const begin = await app.fetch(new Request('http://localhost/passkeys/authenticate/begin', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email }),
+    }), mockEnv);
+    const { state } = await begin.json() as { state: string };
+    verifyAuthenticationResponse.mockResolvedValueOnce({ verified: true, authenticationInfo: { newCounter: 1 } });
+
+    const response = await app.fetch(new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email, state, response: passkeyResponse() }),
+    }), mockEnv);
+    const body = await response.json() as any;
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.token).toBeTruthy();
+    expect(body.user).toEqual({ id: userId, email });
+    expect(fetchMock).toHaveBeenCalledWith('https://users.example.com/passkey-credentials/AQI/counter', expect.objectContaining({ method: 'PATCH' }));
+  });
+
+  it('handles default configuration, transport parsing, and service authentication headers', async () => {
+    const credentials = [
+      { credential_id: 'AQI', user_id: userId, public_key: 'AwQ', counter: 0, device_type: 'singleDevice', backed_up: 0, transports: null },
+      { credential_id: 'AQI', user_id: userId, public_key: 'AwQ', counter: 0, device_type: 'singleDevice', backed_up: 0, transports: 'not-json' },
+      { credential_id: 'AQI', user_id: userId, public_key: 'AwQ', counter: 0, device_type: 'singleDevice', backed_up: 0, transports: '{}' },
+      { credential_id: 'AQI', user_id: userId, public_key: 'AwQ', counter: 0, device_type: 'singleDevice', backed_up: 0, transports: '["internal"]' },
+    ];
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: credentials }));
+    const envWithDefaults = { ...mockEnv, WEBAUTHN_RP_ID: undefined, WEBAUTHN_RP_NAME: undefined, WEBAUTHN_ORIGIN: undefined, PASSKEY_SERVICE_TOKEN: 'DUMMY_TEST_SECRET_ONLY' };
+    const result = await new PasskeyService(envWithDefaults).beginRegistration(userId, email);
+    expect(result.success).toBe(true);
+    expect(generateRegistrationOptions).toHaveBeenCalledWith(expect.objectContaining({ rpID: 'localhost', rpName: 'Seasoned' }));
+    expect(fetchMock.mock.calls[0][1].headers.get('X-Internal-Auth')).toBe('DUMMY_TEST_SECRET_ONLY');
+  });
+
+  it('rejects missing, malformed, mismatched, and replayed challenge records', async () => {
+    const service = new PasskeyService(mockEnv);
+    const validState = 'a'.repeat(64);
+    expect((await service.completeRegistration(userId, 'bad-state', passkeyResponse('create') as any)).success).toBe(false);
+    expect((await service.completeRegistration(userId, validState, passkeyResponse('create') as any)).success).toBe(false);
+
+    kv.set(`passkey:challenge:${validState}`, 'not-json');
+    expect((await service.completeRegistration(userId, validState, passkeyResponse('create') as any)).success).toBe(false);
+
+    kv.set(`passkey:challenge:${validState}`, JSON.stringify({ flow: 'authentication', challenge: 'c', userId }));
+    expect((await service.completeRegistration(userId, validState, passkeyResponse('create') as any)).success).toBe(false);
+
+    kv.set(`passkey:challenge:${validState}`, JSON.stringify({ flow: 'registration', challenge: 'c', userId: 'other-user' }));
+    expect((await service.completeRegistration(userId, validState, passkeyResponse('create') as any)).success).toBe(false);
+  });
+
+  it('returns safe errors when registration verification or credential storage fails', async () => {
+    const service = new PasskeyService(mockEnv);
+    const state = 'b'.repeat(64);
+    kv.set(`passkey:challenge:${state}`, JSON.stringify({ flow: 'registration', challenge: 'c', userId }));
+    verifyRegistrationResponse.mockRejectedValueOnce(new Error('bad origin'));
+    expect((await service.completeRegistration(userId, state, passkeyResponse('create') as any)).error).toMatch(/registration failed/i);
+
+    kv.set(`passkey:challenge:${state}`, JSON.stringify({ flow: 'registration', challenge: 'c', userId }));
+    verifyRegistrationResponse.mockResolvedValueOnce({ verified: false });
+    expect((await service.completeRegistration(userId, state, passkeyResponse('create') as any)).success).toBe(false);
+
+    kv.set(`passkey:challenge:${state}`, JSON.stringify({ flow: 'registration', challenge: 'c', userId }));
+    verifyRegistrationResponse.mockResolvedValueOnce({ verified: true, registrationInfo: { credentialID: Uint8Array.from([1]), credentialPublicKey: Uint8Array.from([2]), counter: 0, credentialDeviceType: 'singleDevice', credentialBackedUp: false } });
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: false }, 409));
+    expect((await service.completeRegistration(userId, state, passkeyResponse('create') as any)).error).toMatch(/save passkey/i);
+  });
+
+  it('rejects authentication when the credential, signature, counter, or account is invalid', async () => {
+    const service = new PasskeyService(mockEnv);
+    const state = 'c'.repeat(64);
+    const baseCredential = { credential_id: 'AQI', user_id: userId, public_key: 'AwQ', counter: 2, device_type: 'singleDevice', backed_up: 0, transports: '[]' };
+    const seed = () => kv.set(`passkey:challenge:${state}`, JSON.stringify({ flow: 'authentication', challenge: 'c', userId }));
+
+    seed();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: false }, 404));
+    expect((await service.completeAuthentication(email, state, passkeyResponse() as any)).success).toBe(false);
+
+    seed();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: { ...baseCredential, user_id: 'other-user' } }));
+    expect((await service.completeAuthentication(email, state, passkeyResponse() as any)).success).toBe(false);
+
+    seed();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: baseCredential }));
+    verifyAuthenticationResponse.mockRejectedValueOnce(new Error('bad signature'));
+    expect((await service.completeAuthentication(email, state, passkeyResponse() as any)).success).toBe(false);
+
+    seed();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: baseCredential }));
+    verifyAuthenticationResponse.mockResolvedValueOnce({ verified: false });
+    expect((await service.completeAuthentication(email, state, passkeyResponse() as any)).success).toBe(false);
+
+    seed();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: baseCredential }));
+    verifyAuthenticationResponse.mockResolvedValueOnce({ verified: true, authenticationInfo: { newCounter: 2 } });
+    expect((await service.completeAuthentication(email, state, passkeyResponse() as any)).success).toBe(false);
+  });
+
+  it('rejects counter races and suspended or deleted users after valid verification', async () => {
+    const service = new PasskeyService(mockEnv);
+    const state = 'd'.repeat(64);
+    const credential = { credential_id: 'AQI', user_id: userId, public_key: 'AwQ', counter: 0, device_type: 'singleDevice', backed_up: 0, transports: '[]' };
+    const seed = () => kv.set(`passkey:challenge:${state}`, JSON.stringify({ flow: 'authentication', challenge: 'c', userId }));
+
+    seed();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: credential }))
+      .mockResolvedValueOnce(jsonResponse({ success: false }, 409));
+    verifyAuthenticationResponse.mockResolvedValueOnce({ verified: true, authenticationInfo: { newCounter: 1 } });
+    expect((await service.completeAuthentication(email, state, passkeyResponse() as any)).success).toBe(false);
+
+    seed();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: credential }))
+      .mockResolvedValueOnce(jsonResponse({ success: true }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, data: { status: 'SUSPENDED' } }));
+    verifyAuthenticationResponse.mockResolvedValueOnce({ verified: true, authenticationInfo: { newCounter: 1 } });
+    expect((await service.completeAuthentication(email, state, passkeyResponse() as any)).success).toBe(false);
+
+    seed();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true, data: credential }))
+      .mockResolvedValueOnce(jsonResponse({ success: true }))
+      .mockResolvedValueOnce(jsonResponse({ success: false }, 404));
+    verifyAuthenticationResponse.mockResolvedValueOnce({ verified: true, authenticationInfo: { newCounter: 1 } });
+    expect((await service.completeAuthentication(email, state, passkeyResponse() as any)).success).toBe(false);
+  });
+
+  it('rejects malformed authentication responses', async () => {
+    const response = await app.fetch(new Request('http://localhost/passkeys/authenticate/complete', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email, state: 'bad', response: {} }),
+    }), mockEnv);
+    expect(response.status).toBe(400);
+  });
+});

--- a/auth-worker/wrangler.toml
+++ b/auth-worker/wrangler.toml
@@ -42,6 +42,10 @@ enabled = true
 [env.preview]
 name = "auth-worker-preview"
 
+[[env.preview.migrations]]
+tag = "v1"
+new_classes = ["PasskeyChallengeObject"]
+
 [env.preview.vars]
 ENVIRONMENT = "preview"
 OTP_KV_PREFIX = "preview"
@@ -68,6 +72,10 @@ enabled = true
 [env.production]
 name = "auth-worker-production"
 
+[[env.production.migrations]]
+tag = "v1"
+new_classes = ["PasskeyChallengeObject"]
+
 [env.production.vars]
 ENVIRONMENT = "production"
 OTP_KV_PREFIX = "production"
@@ -93,6 +101,10 @@ enabled = true
 
 [env.staging]
 name = "auth-worker-staging"
+
+[[env.staging.migrations]]
+tag = "v1"
+new_classes = ["PasskeyChallengeObject"]
 
 [env.staging.vars]
 ENVIRONMENT = "staging"

--- a/auth-worker/wrangler.toml
+++ b/auth-worker/wrangler.toml
@@ -2,79 +2,117 @@ name = "auth-worker"
 main = "src/index.ts"
 compatibility_date = "2024-01-01"
 
-# KV Namespace for OTP storage
+# KV Namespace for OTP/challenge fallback storage. OTP_KV_PREFIX isolates environments.
 [[kv_namespaces]]
 binding = "OTP_KV"
-id = "1fdebf1b59e249a691746f85a9eb5e62" # Will be replaced with actual ID after creation
+id = "1fdebf1b59e249a691746f85a9eb5e62"
 
-# Environment variables
+[[durable_objects.bindings]]
+name = "PASSKEY_CHALLENGE_DO"
+class_name = "PasskeyChallengeObject"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["PasskeyChallengeObject"]
+
 [vars]
+ENVIRONMENT = "production"
+OTP_KV_PREFIX = "production"
 FROM_EMAIL = "verify@seasonedapp.com"
 USER_MANAGEMENT_WORKER_URL = "https://user-management-worker.nolanfoster.workers.dev"
+WEBAUTHN_RP_ID = "seasoned-frontend.pages.dev"
+WEBAUTHN_RP_NAME = "Seasoned"
+WEBAUTHN_ORIGIN = "https://seasoned-frontend.pages.dev"
 
-# Cloudflare Email Workers send_email binding
 [[send_email]]
 name = "send_email"
 
-# JWT configuration
-# JWT_SECRET must be set as a Cloudflare secret using:
-# wrangler secret put JWT_SECRET
-# This should be a strong, random string of at least 32 characters
+# JWT_SECRET and PASSKEY_SERVICE_TOKEN are secrets, not vars. Configure both
+# on auth-worker and user-management-worker for each deployed environment:
+#   wrangler secret put JWT_SECRET --env preview
+#   wrangler secret put PASSKEY_SERVICE_TOKEN --env preview
+#   wrangler secret put JWT_SECRET --env staging
+#   wrangler secret put PASSKEY_SERVICE_TOKEN --env staging
+#   wrangler secret put JWT_SECRET --env production
+#   wrangler secret put PASSKEY_SERVICE_TOKEN --env production
 
-# Observability settings
 [observability]
 enabled = true
 
-# Preview environment (development)
 [env.preview]
 name = "auth-worker-preview"
 
 [env.preview.vars]
+ENVIRONMENT = "preview"
+OTP_KV_PREFIX = "preview"
 FROM_EMAIL = "verify@seasonedapp.com"
-USER_MANAGEMENT_WORKER_URL = "https://user-management-worker.nolanfoster.workers.dev"
+USER_MANAGEMENT_WORKER_URL = "https://user-management-worker-preview.nolanfoster.workers.dev"
+WEBAUTHN_RP_ID = "seasoned-frontend.pages.dev"
+WEBAUTHN_RP_NAME = "Seasoned (Preview)"
+WEBAUTHN_ORIGIN = "https://seasoned-frontend.pages.dev"
 
 [[env.preview.send_email]]
 name = "send_email"
 
 [[env.preview.kv_namespaces]]
 binding = "OTP_KV"
-id = "1fdebf1b59e249a691746f85a9eb5e62" # Will be replaced with actual ID
+id = "1fdebf1b59e249a691746f85a9eb5e62"
+
+[[env.preview.durable_objects.bindings]]
+name = "PASSKEY_CHALLENGE_DO"
+class_name = "PasskeyChallengeObject"
 
 [env.preview.observability]
 enabled = true
 
-# Production environment
 [env.production]
 name = "auth-worker-production"
 
 [env.production.vars]
+ENVIRONMENT = "production"
+OTP_KV_PREFIX = "production"
 FROM_EMAIL = "verify@seasonedapp.com"
-USER_MANAGEMENT_WORKER_URL = "https://user-management-worker.nolanfoster.workers.dev"
+USER_MANAGEMENT_WORKER_URL = "https://user-management-worker-production.nolanfoster.workers.dev"
+WEBAUTHN_RP_ID = "seasoned-frontend.pages.dev"
+WEBAUTHN_RP_NAME = "Seasoned"
+WEBAUTHN_ORIGIN = "https://seasoned-frontend.pages.dev"
 
 [[env.production.send_email]]
 name = "send_email"
 
 [[env.production.kv_namespaces]]
 binding = "OTP_KV"
-id = "1fdebf1b59e249a691746f85a9eb5e62" # Will be replaced with actual ID
+id = "1fdebf1b59e249a691746f85a9eb5e62"
+
+[[env.production.durable_objects.bindings]]
+name = "PASSKEY_CHALLENGE_DO"
+class_name = "PasskeyChallengeObject"
 
 [env.production.observability]
 enabled = true
 
-# Staging environment
 [env.staging]
 name = "auth-worker-staging"
 
 [env.staging.vars]
+ENVIRONMENT = "staging"
+OTP_KV_PREFIX = "staging"
 FROM_EMAIL = "verify@seasonedapp.com"
-USER_MANAGEMENT_WORKER_URL = "https://user-management-worker.nolanfoster.workers.dev"
+USER_MANAGEMENT_WORKER_URL = "https://user-management-worker-staging.nolanfoster.workers.dev"
+WEBAUTHN_RP_ID = "seasoned-frontend.pages.dev"
+WEBAUTHN_RP_NAME = "Seasoned"
+WEBAUTHN_ORIGIN = "https://seasoned-frontend.pages.dev"
 
 [[env.staging.send_email]]
 name = "send_email"
 
 [[env.staging.kv_namespaces]]
 binding = "OTP_KV"
-id = "1fdebf1b59e249a691746f85a9eb5e62" # Will be replaced with actual ID
+id = "1fdebf1b59e249a691746f85a9eb5e62"
+
+[[env.staging.durable_objects.bindings]]
+name = "PASSKEY_CHALLENGE_DO"
+class_name = "PasskeyChallengeObject"
 
 [env.staging.observability]
 enabled = true

--- a/auth-worker/wrangler.toml
+++ b/auth-worker/wrangler.toml
@@ -11,9 +11,8 @@ id = "1fdebf1b59e249a691746f85a9eb5e62"
 name = "PASSKEY_CHALLENGE_DO"
 class_name = "PasskeyChallengeObject"
 
-[[migrations]]
-tag = "v1"
-new_classes = ["PasskeyChallengeObject"]
+[exports]
+"PasskeyChallengeObject" = { type = "durable-object" }
 
 [vars]
 ENVIRONMENT = "production"
@@ -42,9 +41,7 @@ enabled = true
 [env.preview]
 name = "auth-worker-preview"
 
-[[env.preview.migrations]]
-tag = "v1"
-new_classes = ["PasskeyChallengeObject"]
+
 
 [env.preview.vars]
 ENVIRONMENT = "preview"
@@ -72,9 +69,7 @@ enabled = true
 [env.production]
 name = "auth-worker-production"
 
-[[env.production.migrations]]
-tag = "v1"
-new_classes = ["PasskeyChallengeObject"]
+
 
 [env.production.vars]
 ENVIRONMENT = "production"
@@ -102,9 +97,7 @@ enabled = true
 [env.staging]
 name = "auth-worker-staging"
 
-[[env.staging.migrations]]
-tag = "v1"
-new_classes = ["PasskeyChallengeObject"]
+
 
 [env.staging.vars]
 ENVIRONMENT = "staging"

--- a/recipe-app/.env.development
+++ b/recipe-app/.env.development
@@ -16,5 +16,5 @@ VITE_RECIPE_GENERATION_URL=https://recipe-generation-worker-staging.nolanfoster.
 VITE_RECIPE_VIEW_URL=https://recipe.seasonedapp.com
 
 # Auth worker
-VITE_AUTH_WORKER_URL=https://staging-auth-worker.nolanfoster.workers.dev
+VITE_AUTH_WORKER_URL=https://auth-worker-preview.nolanfoster.workers.dev
 

--- a/recipe-app/.env.example
+++ b/recipe-app/.env.example
@@ -15,7 +15,7 @@ VITE_RECIPE_GENERATION_URL=https://your-recipe-generation-worker.your-subdomain.
 # Recipe view worker: GET /recipe/:id — serves shareable recipe pages
 VITE_RECIPE_VIEW_URL=https://your-recipe-view-worker.your-subdomain.workers.dev
 
-# Auth worker: POST /otp/generate, POST /otp/verify, POST /auth/validate, POST /auth/refresh
+# Auth worker: OTP/JWT endpoints plus /passkeys/* WebAuthn registration and authentication
 VITE_AUTH_WORKER_URL=https://your-auth-worker.your-subdomain.workers.dev
 
 # ── Flaggly (Cloudflare Pages / wrangler secrets; not VITE_*) ─────────────────

--- a/recipe-app/.env.production
+++ b/recipe-app/.env.production
@@ -7,5 +7,5 @@ VITE_API_URL=https://recipe-save-worker.nolanfoster.workers.dev
 VITE_RECIPE_VIEW_URL=https://recipe.seasonedapp.com
 
 # Auth worker
-VITE_AUTH_WORKER_URL=https://auth-worker.nolanfoster.workers.dev
+VITE_AUTH_WORKER_URL=https://auth-worker-production.nolanfoster.workers.dev
 

--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -69,9 +69,10 @@ function useDebounce(fn, delay) {
   return [schedule, cancel]
 }
 
-function UserMenu({ user, onSignOut }) {
+function UserMenu({ user, onSignOut, onRegisterPasskey }) {
   const [open, setOpen] = useState(false)
   const [opacity, setOpacity] = useState(1)
+  const [passkeyStatus, setPasskeyStatus] = useState('idle')
   const menuRef = useRef(null)
 
   useEffect(() => {
@@ -114,6 +115,32 @@ function UserMenu({ user, onSignOut }) {
           <div className="user-menu-info">
             <div className="user-menu-email">{user?.email}</div>
           </div>
+          {onRegisterPasskey && (
+            <button
+              className="user-menu-item"
+              disabled={passkeyStatus === 'loading'}
+              onClick={async () => {
+                setPasskeyStatus('loading')
+                try {
+                  await onRegisterPasskey()
+                  setPasskeyStatus('success')
+                  setTimeout(() => setPasskeyStatus('idle'), 2500)
+                } catch {
+                  setPasskeyStatus('error')
+                  setTimeout(() => setPasskeyStatus('idle'), 3000)
+                }
+              }}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="8" r="3"/>
+                <path d="M6 21v-1a6 6 0 0112 0v1M18 15l2 2 4-4"/>
+              </svg>
+              {passkeyStatus === 'loading' ? 'Adding passkey…'
+                : passkeyStatus === 'success' ? 'Passkey added!'
+                  : passkeyStatus === 'error' ? 'Passkey failed — try again'
+                    : 'Add a passkey'}
+            </button>
+          )}
           <button className="user-menu-item" onClick={() => { setOpen(false); onSignOut() }}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4M16 17l5-5-5-5M21 12H9"/>
@@ -334,7 +361,7 @@ export default function App() {
   }
 
   if (!auth.isAuthenticated) {
-    return <AuthScreen onRequestOTP={auth.requestOTP} onVerifyOTP={auth.verifyOTP} />
+    return <AuthScreen onRequestOTP={auth.requestOTP} onVerifyOTP={auth.verifyOTP} onSignInWithPasskey={auth.signInWithPasskey} />
   }
 
   function handleInputChange(e) {
@@ -639,7 +666,7 @@ export default function App() {
           onClose={() => setIsDrawerOpen(false)}
         />
       )}
-      <UserMenu user={auth.user} onSignOut={auth.signOut} />
+      <UserMenu user={auth.user} onSignOut={auth.signOut} onRegisterPasskey={auth.registerPasskey} />
       <div className="omnibox-wrapper">
         <div className="brand">
           <div className="brand-header">

--- a/recipe-app/src/AuthScreen.jsx
+++ b/recipe-app/src/AuthScreen.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react'
+import { canUsePasskeys } from './useAuth.js'
 
 const OTP_LENGTH = 6
 
-export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
+export default function AuthScreen({ onRequestOTP, onVerifyOTP, onSignInWithPasskey }) {
   const [step, setStep] = useState('email') // 'email' | 'otp'
   const [email, setEmail] = useState('')
   const [otp, setOtp] = useState(Array(OTP_LENGTH).fill(''))
@@ -51,6 +52,23 @@ export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
     }
   }
 
+  async function handlePasskeySignIn() {
+    if (!isValidEmail(email)) {
+      setErrorMsg('Enter your email address to use a passkey')
+      setStatus('error')
+      return
+    }
+    setStatus('loading')
+    setErrorMsg('')
+    try {
+      await onSignInWithPasskey(email)
+      setStatus('success')
+    } catch (err) {
+      setErrorMsg(err.message)
+      setStatus('error')
+    }
+  }
+
   function handleOtpChange(index, value) {
     if (value.length > 1) {
       const pasted = value.replace(/\D/g, '').slice(0, OTP_LENGTH).split('')
@@ -75,9 +93,7 @@ export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
   }
 
   function handleOtpKeyDown(index, e) {
-    if (e.key === 'Backspace' && !otp[index] && index > 0) {
-      otpRefs.current[index - 1]?.focus()
-    }
+    if (e.key === 'Backspace' && !otp[index] && index > 0) otpRefs.current[index - 1]?.focus()
   }
 
   async function submitOtp(digits) {
@@ -121,6 +137,7 @@ export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
   }
 
   const isLoading = status === 'loading'
+  const passkeysAvailable = canUsePasskeys() && typeof onSignInWithPasskey === 'function'
 
   return (
     <div className="auth-screen">
@@ -155,14 +172,12 @@ export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
                   value={email}
                   onChange={(e) => { setEmail(e.target.value); setErrorMsg(''); setStatus('idle') }}
                   disabled={isLoading}
-                  autoComplete="email"
+                  autoComplete="email webauthn"
                   autoFocus
                 />
               </div>
 
-              {status === 'error' && errorMsg && (
-                <p className="auth-error">{errorMsg}</p>
-              )}
+              {status === 'error' && errorMsg && <p className="auth-error">{errorMsg}</p>}
 
               <button
                 className="auth-submit"
@@ -176,9 +191,28 @@ export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
                     </svg>
                     Sending code…
                   </span>
-                ) : 'Continue'}
+                ) : 'Continue with email'}
               </button>
             </form>
+
+            {passkeysAvailable && (
+              <>
+                <div className="auth-divider"><span>or</span></div>
+                <button
+                  className="auth-passkey-btn"
+                  type="button"
+                  onClick={handlePasskeySignIn}
+                  disabled={isLoading || !email.trim()}
+                >
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+                    <circle cx="12" cy="8" r="3"/>
+                    <path d="M6 21v-1a6 6 0 0112 0v1"/>
+                  </svg>
+                  {isLoading ? 'Waiting for passkey…' : 'Use a passkey'}
+                </button>
+                <p className="auth-passkey-hint">Passkeys use your device's screen lock or biometrics.</p>
+              </>
+            )}
           </>
         ) : (
           <>
@@ -221,14 +255,8 @@ export default function AuthScreen({ onRequestOTP, onVerifyOTP }) {
                 Verifying…
               </p>
             )}
-
-            {status === 'success' && (
-              <p className="auth-success">Verified! Signing you in…</p>
-            )}
-
-            {status === 'error' && errorMsg && (
-              <p className="auth-error">{errorMsg}</p>
-            )}
+            {status === 'success' && <p className="auth-success">Verified! Signing you in…</p>}
+            {status === 'error' && errorMsg && <p className="auth-error">{errorMsg}</p>}
 
             <div className="auth-resend">
               <span className="auth-resend-text">Didn't get the code?</span>

--- a/recipe-app/src/__tests__/AuthScreen.test.jsx
+++ b/recipe-app/src/__tests__/AuthScreen.test.jsx
@@ -9,6 +9,7 @@ function setup(overrides = {}) {
     <AuthScreen
       onRequestOTP={overrides.onRequestOTP || onRequestOTP}
       onVerifyOTP={overrides.onVerifyOTP || onVerifyOTP}
+      onSignInWithPasskey={overrides.onSignInWithPasskey}
     />
   );
   return { onRequestOTP, onVerifyOTP, ...utils };
@@ -61,6 +62,36 @@ describe('AuthScreen — email step', () => {
     expect(await screen.findByText(/rate limited/i)).toBeInTheDocument();
   });
 });
+
+
+describe('AuthScreen — passkey sign-in', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'PublicKeyCredential', { value: function PublicKeyCredential() {}, configurable: true })
+    Object.defineProperty(navigator, 'credentials', { value: {}, configurable: true })
+  })
+
+  test('shows passkey action when the browser supports WebAuthn', () => {
+    setup({ onSignInWithPasskey: jest.fn(() => Promise.resolve({ success: true })) })
+    expect(screen.getByRole('button', { name: /use a passkey/i })).toBeDisabled()
+  })
+
+  test('calls passkey sign-in with the entered email', async () => {
+    const onSignInWithPasskey = jest.fn(() => Promise.resolve({ success: true }))
+    setup({ onSignInWithPasskey })
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'User@Example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: /use a passkey/i }))
+    await waitFor(() => expect(onSignInWithPasskey).toHaveBeenCalledWith('User@Example.com'))
+  })
+
+  test('shows a cancellation error without losing the email fallback', async () => {
+    const onSignInWithPasskey = jest.fn(() => Promise.reject(new Error('Passkey sign-in was cancelled')))
+    setup({ onSignInWithPasskey })
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'user@example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: /use a passkey/i }))
+    expect(await screen.findByText(/cancelled/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /continue with email/i })).toBeInTheDocument()
+  })
+})
 
 describe('AuthScreen — OTP step', () => {
   async function goToOtpStep(overrides = {}) {

--- a/recipe-app/src/__tests__/useAuth.test.jsx
+++ b/recipe-app/src/__tests__/useAuth.test.jsx
@@ -13,6 +13,8 @@ function TestHarness() {
       <span data-testid="email">{auth.user?.email || ''}</span>
       <button data-testid="request" onClick={() => auth.requestOTP('u@e.com')}>req</button>
       <button data-testid="verify" onClick={() => auth.verifyOTP('u@e.com', '123456')}>ver</button>
+      <button data-testid="passkey" onClick={() => auth.signInWithPasskey('U@E.COM')}>passkey</button>
+      <button data-testid="register-passkey" onClick={() => auth.registerPasskey()}>register</button>
       <button data-testid="signout" onClick={auth.signOut}>out</button>
     </div>
   );
@@ -102,6 +104,94 @@ describe('useAuth', () => {
     expect(screen.getByTestId('authenticated').textContent).toBe('true');
     expect(localStorage.getItem('seasoned_auth_token')).toBe('new-jwt');
   });
+
+  test('signInWithPasskey converts options and stores the returned session', async () => {
+    Object.defineProperty(window, 'PublicKeyCredential', { value: function PublicKeyCredential() {}, configurable: true })
+    const get = jest.fn(() => Promise.resolve({
+      id: 'credential-id',
+      rawId: Uint8Array.from([1, 2, 3]).buffer,
+      type: 'public-key',
+      response: {
+        clientDataJSON: Uint8Array.from([4]).buffer,
+        authenticatorData: Uint8Array.from([5]).buffer,
+        signature: Uint8Array.from([6]).buffer,
+        userHandle: null,
+      },
+      getClientExtensionResults: () => ({}),
+    }))
+    Object.defineProperty(navigator, 'credentials', { value: { get }, configurable: true })
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          success: true,
+          state: 'state',
+          options: {
+            challenge: 'Y2hhbGxlbmdl',
+            rpId: 'localhost',
+            allowCredentials: [{ id: 'AQID', type: 'public-key' }],
+            userVerification: 'required',
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ success: true, token: 'passkey-jwt', user: { id: 'hash', email: 'u@e.com' } }),
+      })
+
+    render(<TestHarness />)
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'))
+    await act(async () => screen.getByTestId('passkey').click())
+
+    expect(get).toHaveBeenCalledWith(expect.objectContaining({ publicKey: expect.objectContaining({ challenge: expect.any(ArrayBuffer) }) }))
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      `${AUTH_URL}/passkeys/authenticate/complete`,
+      expect.objectContaining({ method: 'POST', body: expect.stringContaining('credential-id') })
+    )
+    expect(screen.getByTestId('authenticated').textContent).toBe('true')
+    expect(localStorage.getItem('seasoned_auth_token')).toBe('passkey-jwt')
+  })
+
+  test('registerPasskey sends the bearer token and serialized attestation', async () => {
+    Object.defineProperty(window, 'PublicKeyCredential', { value: function PublicKeyCredential() {}, configurable: true })
+    const create = jest.fn(() => Promise.resolve({
+      id: 'new-credential',
+      rawId: Uint8Array.from([7, 8]).buffer,
+      type: 'public-key',
+      response: {
+        clientDataJSON: Uint8Array.from([9]).buffer,
+        attestationObject: Uint8Array.from([10]).buffer,
+        getTransports: () => ['internal'],
+      },
+      getClientExtensionResults: () => ({}),
+    }))
+    Object.defineProperty(navigator, 'credentials', { value: { create }, configurable: true })
+    localStorage.setItem('seasoned_auth_token', 'existing-token')
+    localStorage.setItem('seasoned_auth_user', JSON.stringify({ id: 'hash', email: 'u@e.com' }))
+    global.fetch
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ success: true, valid: true }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ success: true, token: 'refreshed-token', user: { id: 'hash', email: 'u@e.com' } }) })
+      .mockResolvedValueOnce({
+        ok: true, status: 200,
+        json: () => Promise.resolve({ success: true, state: 'register-state', options: { challenge: 'Y2hhbGxlbmdl', user: { id: 'dXNlcg', name: 'u@e.com', displayName: 'u@e.com' }, excludeCredentials: [] } }),
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ success: true }) })
+
+    render(<TestHarness />)
+    await waitFor(() => expect(screen.getByTestId('authenticated').textContent).toBe('true'))
+    await act(async () => screen.getByTestId('register-passkey').click())
+
+    expect(create).toHaveBeenCalled()
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      `${AUTH_URL}/passkeys/register/complete`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer refreshed-token' }),
+      })
+    )
+  })
 
   test('signOut clears token and user', async () => {
     localStorage.setItem('seasoned_auth_token', 'tok');

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -2166,3 +2166,62 @@ html, body {
     animation: none;
   }
 }
+
+/* Passkey authentication */
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 18px 0 14px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.auth-passkey-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.auth-passkey-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: rgba(200, 169, 110, 0.08);
+}
+
+.auth-passkey-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.auth-passkey-btn svg {
+  width: 19px;
+  height: 19px;
+}
+
+.auth-passkey-hint {
+  margin: 10px 0 0;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  line-height: 1.4;
+  text-align: center;
+}

--- a/recipe-app/src/useAuth.js
+++ b/recipe-app/src/useAuth.js
@@ -23,6 +23,89 @@ function clearAuth() {
   localStorage.removeItem(USER_KEY)
 }
 
+function base64urlToArrayBuffer(value) {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized + '='.repeat((4 - normalized.length % 4) % 4)
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i)
+  return bytes.buffer
+}
+
+function arrayBufferToBase64url(value) {
+  const bytes = new Uint8Array(value)
+  let binary = ''
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+function isPasskeyAvailable() {
+  return typeof window !== 'undefined' &&
+    typeof window.PublicKeyCredential !== 'undefined' &&
+    typeof navigator !== 'undefined' &&
+    !!navigator.credentials
+}
+
+function decodeCreationOptions(options) {
+  return {
+    ...options,
+    challenge: base64urlToArrayBuffer(options.challenge),
+    user: { ...options.user, id: base64urlToArrayBuffer(options.user.id) },
+    excludeCredentials: (options.excludeCredentials || []).map((credential) => ({
+      ...credential,
+      id: base64urlToArrayBuffer(credential.id),
+    })),
+  }
+}
+
+function decodeRequestOptions(options) {
+  return {
+    ...options,
+    challenge: base64urlToArrayBuffer(options.challenge),
+    allowCredentials: (options.allowCredentials || []).map((credential) => ({
+      ...credential,
+      id: base64urlToArrayBuffer(credential.id),
+    })),
+  }
+}
+
+function serializeCredential(credential) {
+  if (!credential) throw new Error('No passkey credential was returned')
+  const response = credential.response
+  const serialized = {
+    id: credential.id,
+    rawId: arrayBufferToBase64url(credential.rawId),
+    type: credential.type,
+    response: {},
+    clientExtensionResults: credential.getClientExtensionResults?.() || {},
+  }
+
+  for (const name of ['clientDataJSON', 'attestationObject', 'authenticatorData', 'signature', 'userHandle']) {
+    if (response[name] !== undefined && response[name] !== null) {
+      serialized.response[name] = typeof response[name] === 'string'
+        ? response[name]
+        : arrayBufferToBase64url(response[name])
+    }
+  }
+  if (typeof response.getTransports === 'function') serialized.response.transports = response.getTransports()
+  return serialized
+}
+
+function passkeyError(error) {
+  if (error?.name === 'NotAllowedError' || error?.name === 'AbortError') {
+    return new Error('Passkey sign-in was cancelled')
+  }
+  return error instanceof Error ? error : new Error('Passkey sign-in failed')
+}
+
+export function canUsePasskeys() {
+  return isPasskeyAvailable()
+}
+
+export function __testOnlyPasskeyHelpers() {
+  return { base64urlToArrayBuffer, arrayBufferToBase64url, decodeCreationOptions, decodeRequestOptions, serializeCredential }
+}
+
 export function useAuth() {
   const [user, setUser] = useState(null)
   const [token, setToken] = useState(null)
@@ -36,7 +119,7 @@ export function useAuth() {
           // Sliding expiration: renew the token on every app load
           const refreshed = await refreshToken(stored.token)
           const activeToken = refreshed ? refreshed.token : stored.token
-          const activeUser  = refreshed ? refreshed.user  : stored.user
+          const activeUser = refreshed ? refreshed.user : stored.user
           storeAuth(activeToken, activeUser)
           setToken(activeToken)
           setUser(activeUser)
@@ -89,9 +172,7 @@ export function useAuth() {
       body: JSON.stringify({ email }),
     })
     const data = await res.json()
-    if (!res.ok || !data.success) {
-      throw new Error(data.message || 'Failed to send verification code')
-    }
+    if (!res.ok || !data.success) throw new Error(data.message || 'Failed to send verification code')
     return data
   }
 
@@ -102,15 +183,78 @@ export function useAuth() {
       body: JSON.stringify({ email, otp }),
     })
     const data = await res.json()
-    if (!res.ok || !data.success) {
-      throw new Error(data.message || 'Verification failed')
-    }
+    if (!res.ok || !data.success) throw new Error(data.message || 'Verification failed')
     if (data.token && data.user) {
       storeAuth(data.token, data.user)
       setToken(data.token)
       setUser(data.user)
     }
     return data
+  }
+
+  async function signInWithPasskey(email) {
+    if (!isPasskeyAvailable()) throw new Error('Passkeys are not supported in this browser')
+    const normalizedEmail = email.trim().toLowerCase()
+    const beginResponse = await fetch(`${AUTH_WORKER_URL}/passkeys/authenticate/begin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: normalizedEmail }),
+    })
+    const beginData = await beginResponse.json()
+    if (!beginResponse.ok || !beginData.success) throw new Error(beginData.message || 'No passkey is registered for this email')
+
+    let assertion
+    try {
+      assertion = await navigator.credentials.get({ publicKey: decodeRequestOptions(beginData.options) })
+    } catch (error) {
+      throw passkeyError(error)
+    }
+
+    const completeResponse = await fetch(`${AUTH_WORKER_URL}/passkeys/authenticate/complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        email: normalizedEmail,
+        state: beginData.state,
+        response: serializeCredential(assertion),
+      }),
+    })
+    const completeData = await completeResponse.json()
+    if (!completeResponse.ok || !completeData.success || !completeData.token || !completeData.user) {
+      throw new Error(completeData.message || 'Passkey authentication failed')
+    }
+    storeAuth(completeData.token, completeData.user)
+    setToken(completeData.token)
+    setUser(completeData.user)
+    return completeData
+  }
+
+  async function registerPasskey() {
+    if (!isPasskeyAvailable()) throw new Error('Passkeys are not supported in this browser')
+    if (!token) throw new Error('Authentication required')
+
+    const beginResponse = await fetch(`${AUTH_WORKER_URL}/passkeys/register/begin`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    })
+    const beginData = await beginResponse.json()
+    if (!beginResponse.ok || !beginData.success) throw new Error(beginData.message || 'Unable to start passkey registration')
+
+    let credential
+    try {
+      credential = await navigator.credentials.create({ publicKey: decodeCreationOptions(beginData.options) })
+    } catch (error) {
+      throw passkeyError(error)
+    }
+
+    const completeResponse = await fetch(`${AUTH_WORKER_URL}/passkeys/register/complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ state: beginData.state, response: serializeCredential(credential) }),
+    })
+    const completeData = await completeResponse.json()
+    if (!completeResponse.ok || !completeData.success) throw new Error(completeData.message || 'Passkey registration failed')
+    return completeData
   }
 
   const signOut = useCallback(() => {
@@ -126,6 +270,8 @@ export function useAuth() {
     isAuthenticated: !!token && !!user,
     requestOTP,
     verifyOTP,
+    signInWithPasskey,
+    registerPasskey,
     signOut,
   }
 }

--- a/user-management-worker/README.md
+++ b/user-management-worker/README.md
@@ -356,3 +356,25 @@ SELECT * FROM user_login_history ORDER BY login_timestamp DESC LIMIT 10;
 ## License
 
 This project follows the same license as the main recipe-app repository.
+
+### Passkey database migration
+
+Passkey credential and audit storage is added by `migrations/001_add_passkey_credentials.sql`.
+Apply it once to each existing D1 environment **before** deploying the updated workers:
+
+```sh
+cd user-management-worker
+npm run migrate:preview   # or migrate:staging / migrate:production
+```
+
+The migration is additive. Do not run `schema.sql` against a populated database because the
+legacy setup script contains destructive `DROP TABLE` statements. Configure the same
+`PASSKEY_SERVICE_TOKEN` secret on the auth and user-management workers for each deployed
+environment.
+
+### Passkey storage and internal access
+
+Passkey credential routes (`/passkey-credentials/*`) and user-management data routes are
+worker-internal. In deployed environments they require the `PASSKEY_SERVICE_TOKEN` secret
+shared with `auth-worker`; local development bypasses this check. Apply the additive
+`migrations/001_add_passkey_credentials.sql` migration before deploying passkey support.

--- a/user-management-worker/migrations/001_add_passkey_credentials.sql
+++ b/user-management-worker/migrations/001_add_passkey_credentials.sql
@@ -1,0 +1,91 @@
+-- Additive migration for passkey credential storage.
+-- Apply this migration to each existing D1 environment. Do not run schema.sql
+-- against a populated database because that file contains DROP TABLE statements.
+
+CREATE TABLE IF NOT EXISTS passkey_credentials (
+    credential_id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    public_key TEXT NOT NULL,
+    counter INTEGER NOT NULL DEFAULT 0,
+    device_type TEXT NOT NULL CHECK (device_type IN ('singleDevice', 'multiDevice')),
+    backed_up INTEGER NOT NULL DEFAULT 0,
+    transports TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_passkey_credentials_user_id
+    ON passkey_credentials(user_id);
+CREATE INDEX IF NOT EXISTS idx_passkey_credentials_created_at
+    ON passkey_credentials(created_at);
+
+-- Keep passkey audit events separate from the legacy table's restrictive CHECK
+-- constraint. This lets the migration remain additive for existing databases.
+CREATE TABLE IF NOT EXISTS passkey_login_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    login_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    ip_address TEXT,
+    user_agent TEXT,
+    location_data TEXT,
+    country TEXT,
+    region TEXT,
+    city TEXT,
+    latitude REAL,
+    longitude REAL,
+    timezone TEXT,
+    login_method TEXT NOT NULL CHECK (login_method = 'PASSKEY'),
+    success BOOLEAN NOT NULL,
+    failure_reason TEXT,
+    device_fingerprint TEXT,
+    risk_score INTEGER DEFAULT 0,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_passkey_login_history_user_id
+    ON passkey_login_history(user_id);
+CREATE INDEX IF NOT EXISTS idx_passkey_login_history_timestamp
+    ON passkey_login_history(login_timestamp);
+
+-- Refresh analytics views so passkey events are visible on databases that had
+-- the original OTP-only views already installed.
+DROP VIEW IF EXISTS recent_login_activity;
+CREATE VIEW recent_login_activity AS
+WITH all_login_history AS (
+    SELECT user_id, login_timestamp, ip_address, country, city, login_method, success, risk_score
+    FROM user_login_history
+    UNION ALL
+    SELECT user_id, login_timestamp, ip_address, country, city, login_method, success, risk_score
+    FROM passkey_login_history
+)
+SELECT ulh.user_id, u.email_hash, ulh.login_timestamp, ulh.ip_address,
+       ulh.country, ulh.city, ulh.login_method, ulh.success, ulh.risk_score
+FROM all_login_history ulh
+JOIN users u ON ulh.user_id = u.user_id
+WHERE ulh.login_timestamp > datetime('now', '-30 days')
+ORDER BY ulh.login_timestamp DESC;
+
+DROP VIEW IF EXISTS user_statistics;
+CREATE VIEW user_statistics AS
+WITH all_login_history AS (
+    SELECT user_id, login_timestamp, ip_address, country, success FROM user_login_history
+    UNION ALL
+    SELECT user_id, login_timestamp, ip_address, country, success FROM passkey_login_history
+)
+SELECT u.user_id, u.email_hash, u.status, u.account_type, u.created_at,
+       u.last_activity_at, COUNT(ulh.user_id) AS total_logins,
+       COUNT(CASE WHEN ulh.success = TRUE THEN 1 END) AS successful_logins,
+       COUNT(CASE WHEN ulh.success = FALSE THEN 1 END) AS failed_logins,
+       MAX(ulh.login_timestamp) AS last_login,
+       COUNT(DISTINCT ulh.ip_address) AS unique_ips,
+       COUNT(DISTINCT ulh.country) AS unique_countries
+FROM users u
+LEFT JOIN all_login_history ulh ON u.user_id = ulh.user_id
+GROUP BY u.user_id, u.email_hash, u.status, u.account_type, u.created_at, u.last_activity_at;
+
+CREATE TRIGGER IF NOT EXISTS update_user_activity_passkey_trigger
+    AFTER INSERT ON passkey_login_history
+    BEGIN
+        UPDATE users SET last_activity_at = NEW.login_timestamp WHERE user_id = NEW.user_id;
+    END;

--- a/user-management-worker/package.json
+++ b/user-management-worker/package.json
@@ -15,7 +15,10 @@
     "test:performance": "vitest tests/performance/",
     "test:coverage": "vitest --coverage",
     "test:watch": "vitest --watch",
-    "test:run": "node tests/run-tests.js"
+    "test:run": "node tests/run-tests.js",
+    "migrate:preview": "wrangler d1 execute user-db-preview --env preview --remote --file migrations/001_add_passkey_credentials.sql",
+    "migrate:staging": "wrangler d1 execute user-db-staging --env staging --remote --file migrations/001_add_passkey_credentials.sql",
+    "migrate:production": "wrangler d1 execute user-db-production --env production --remote --file migrations/001_add_passkey_credentials.sql"
   },
   "dependencies": {
     "hono": "^3.12.0"

--- a/user-management-worker/schema.sql
+++ b/user-management-worker/schema.sql
@@ -1,9 +1,8 @@
 -- User Database Schema for User Management Worker
 -- This database stores user information, authentication data, and login history
 
--- Drop existing tables if they exist (for migrations)
-DROP TABLE IF EXISTS user_login_history;
-DROP TABLE IF EXISTS users;
+-- Initial schema for a new database. Existing databases must use the additive
+-- migrations directory; this file intentionally performs no destructive drops.
 
 -- Users table - core user information
 CREATE TABLE IF NOT EXISTS users (
@@ -33,13 +32,60 @@ CREATE TABLE IF NOT EXISTS user_login_history (
     latitude REAL,
     longitude REAL,
     timezone TEXT,
-    login_method TEXT NOT NULL CHECK (login_method IN ('OTP', 'MAGIC_LINK')) DEFAULT 'OTP',
+    login_method TEXT NOT NULL CHECK (login_method IN ('OTP', 'MAGIC_LINK', 'PASSKEY')) DEFAULT 'OTP',
     success BOOLEAN NOT NULL,
     failure_reason TEXT, -- NULL if successful
     device_fingerprint TEXT, -- For device recognition
     risk_score INTEGER DEFAULT 0, -- 0-100 risk assessment
     FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
+
+-- Passkey credentials. Existing databases should use migrations/001_add_passkey_credentials.sql.
+CREATE TABLE IF NOT EXISTS passkey_credentials (
+    credential_id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    public_key TEXT NOT NULL,
+    counter INTEGER NOT NULL DEFAULT 0,
+    device_type TEXT NOT NULL CHECK (device_type IN ('singleDevice', 'multiDevice')),
+    backed_up INTEGER NOT NULL DEFAULT 0,
+    transports TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_passkey_credentials_user_id
+    ON passkey_credentials(user_id);
+CREATE INDEX IF NOT EXISTS idx_passkey_credentials_created_at
+    ON passkey_credentials(created_at);
+
+-- Passkey events use a separate additive table so existing databases do not
+-- need their legacy login history CHECK constraint rebuilt.
+CREATE TABLE IF NOT EXISTS passkey_login_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    login_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    ip_address TEXT,
+    user_agent TEXT,
+    location_data TEXT,
+    country TEXT,
+    region TEXT,
+    city TEXT,
+    latitude REAL,
+    longitude REAL,
+    timezone TEXT,
+    login_method TEXT NOT NULL CHECK (login_method = 'PASSKEY'),
+    success BOOLEAN NOT NULL,
+    failure_reason TEXT,
+    device_fingerprint TEXT,
+    risk_score INTEGER DEFAULT 0,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_passkey_login_history_user_id
+    ON passkey_login_history(user_id);
+CREATE INDEX IF NOT EXISTS idx_passkey_login_history_timestamp
+    ON passkey_login_history(login_timestamp);
 
 -- Create indexes for better query performance
 
@@ -80,9 +126,18 @@ CREATE TRIGGER IF NOT EXISTS update_user_activity_trigger
 
 -- Create views for common queries
 
--- Recent login activity view
+-- Recent login activity view (includes OTP, magic-link, and passkey events)
 CREATE VIEW IF NOT EXISTS recent_login_activity AS
-SELECT 
+WITH all_login_history AS (
+    SELECT user_id, login_timestamp, ip_address, country, city,
+           login_method, success, risk_score
+    FROM user_login_history
+    UNION ALL
+    SELECT user_id, login_timestamp, ip_address, country, city,
+           login_method, success, risk_score
+    FROM passkey_login_history
+)
+SELECT
     ulh.user_id,
     u.email_hash,
     ulh.login_timestamp,
@@ -92,26 +147,40 @@ SELECT
     ulh.login_method,
     ulh.success,
     ulh.risk_score
-FROM user_login_history ulh
+FROM all_login_history ulh
 JOIN users u ON ulh.user_id = u.user_id
 WHERE ulh.login_timestamp > datetime('now', '-30 days')
 ORDER BY ulh.login_timestamp DESC;
 
--- User statistics view
+-- User statistics view (includes passkey events)
 CREATE VIEW IF NOT EXISTS user_statistics AS
-SELECT 
+WITH all_login_history AS (
+    SELECT user_id, login_timestamp, ip_address, country, success
+    FROM user_login_history
+    UNION ALL
+    SELECT user_id, login_timestamp, ip_address, country, success
+    FROM passkey_login_history
+)
+SELECT
     u.user_id,
     u.email_hash,
     u.status,
     u.account_type,
     u.created_at,
     u.last_activity_at,
-    COUNT(DISTINCT ulh.id) as total_logins,
-    COUNT(DISTINCT CASE WHEN ulh.success = TRUE THEN ulh.id END) as successful_logins,
-    COUNT(DISTINCT CASE WHEN ulh.success = FALSE THEN ulh.id END) as failed_logins,
+    COUNT(ulh.user_id) as total_logins,
+    COUNT(CASE WHEN ulh.success = TRUE THEN 1 END) as successful_logins,
+    COUNT(CASE WHEN ulh.success = FALSE THEN 1 END) as failed_logins,
     MAX(ulh.login_timestamp) as last_login,
     COUNT(DISTINCT ulh.ip_address) as unique_ips,
     COUNT(DISTINCT ulh.country) as unique_countries
 FROM users u
-LEFT JOIN user_login_history ulh ON u.user_id = ulh.user_id
+LEFT JOIN all_login_history ulh ON u.user_id = ulh.user_id
 GROUP BY u.user_id, u.email_hash, u.status, u.account_type, u.created_at, u.last_activity_at;
+
+-- Keep account activity current for passkey logins as well.
+CREATE TRIGGER IF NOT EXISTS update_user_activity_passkey_trigger
+    AFTER INSERT ON passkey_login_history
+    BEGIN
+        UPDATE users SET last_activity_at = NEW.login_timestamp WHERE user_id = NEW.user_id;
+    END;

--- a/user-management-worker/src/index.ts
+++ b/user-management-worker/src/index.ts
@@ -6,9 +6,26 @@ import { UserDatabaseService } from './services/user-database';
 
 const app = new Hono<{ Bindings: Bindings }>();
 
+function hasPasskeyServiceAccess(c: { env: Bindings; req: { header(name: string): string | undefined } }): boolean {
+  const configuredToken = c.env.PASSKEY_SERVICE_TOKEN;
+  if (c.env.ENVIRONMENT === 'development') return true;
+  return typeof configuredToken === 'string' && configuredToken.length > 0 && c.req.header('X-Internal-Auth') === configuredToken;
+}
+
 // Middleware
 app.use('*', logger());
 app.use('*', cors());
+
+// User data and audit routes are worker-internal. Development keeps the
+// existing local workflow convenient; deployed environments require the shared
+// PASSKEY_SERVICE_TOKEN secret configured on both workers.
+app.use('*', async (c, next) => {
+  if (c.req.path === '/' || c.req.path === '/health' || hasPasskeyServiceAccess(c)) {
+    await next();
+    return;
+  }
+  return c.json({ success: false, message: 'Unauthorized' }, 401);
+});
 
 // Health check endpoint
 app.get('/health', async (c) => {
@@ -345,7 +362,7 @@ app.post('/login-history', async (c) => {
       }, 400);
     }
 
-    if (!['OTP', 'MAGIC_LINK'].includes(login_method)) {
+    if (!['OTP', 'MAGIC_LINK', 'PASSKEY'].includes(login_method)) {
       return c.json({
         success: false,
         message: 'Invalid login method'
@@ -389,6 +406,123 @@ app.post('/login-history', async (c) => {
       success: false,
       message: 'Internal server error'
     }, 500);
+  }
+});
+
+// Passkey credential endpoints. These are intended for the Auth Worker and
+// can be protected with PASSKEY_SERVICE_TOKEN in deployed environments.
+app.get('/passkey-credentials/user/:user_id', async (c) => {
+  if (!hasPasskeyServiceAccess(c)) {
+    return c.json({ success: false, message: 'Unauthorized' }, 401);
+  }
+
+  try {
+    const userId = c.req.param('user_id');
+    const result = await new UserDatabaseService(c.env.USER_DB).getPasskeyCredentialsByUserId(userId);
+    return result.success
+      ? c.json({ success: true, data: result.data })
+      : c.json({ success: false, message: result.error }, 500);
+  } catch (error) {
+    console.error('Error getting passkey credentials:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+app.get('/passkey-credentials/:credential_id', async (c) => {
+  if (!hasPasskeyServiceAccess(c)) {
+    return c.json({ success: false, message: 'Unauthorized' }, 401);
+  }
+
+  try {
+    const credentialId = c.req.param('credential_id');
+    const result = await new UserDatabaseService(c.env.USER_DB).getPasskeyCredential(credentialId);
+    return result.success
+      ? c.json({ success: true, data: result.data })
+      : c.json({ success: false, message: result.error }, 404);
+  } catch (error) {
+    console.error('Error getting passkey credential:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+app.post('/passkey-credentials', async (c) => {
+  if (!hasPasskeyServiceAccess(c)) {
+    return c.json({ success: false, message: 'Unauthorized' }, 401);
+  }
+
+  try {
+    const body = await c.req.json();
+    const { credential_id, user_id, public_key, counter, device_type, backed_up, transports } = body;
+
+    if (typeof credential_id !== 'string' || !credential_id ||
+        typeof user_id !== 'string' || !user_id ||
+        typeof public_key !== 'string' || !public_key ||
+        !Number.isInteger(counter) || counter < 0 ||
+        !['singleDevice', 'multiDevice'].includes(device_type)) {
+      return c.json({ success: false, message: 'Invalid passkey credential' }, 400);
+    }
+
+    if (transports !== undefined && (!Array.isArray(transports) || transports.some((item) => typeof item !== 'string'))) {
+      return c.json({ success: false, message: 'Invalid passkey transports' }, 400);
+    }
+
+    const result = await new UserDatabaseService(c.env.USER_DB).createPasskeyCredential({
+      credential_id,
+      user_id,
+      public_key,
+      counter,
+      device_type,
+      backed_up: backed_up === true || backed_up === 1,
+      transports
+    });
+    return result.success
+      ? c.json({ success: true, data: result.data }, 201)
+      : c.json({ success: false, message: result.error }, 409);
+  } catch (error) {
+    console.error('Error creating passkey credential:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+app.patch('/passkey-credentials/:credential_id/counter', async (c) => {
+  if (!hasPasskeyServiceAccess(c)) {
+    return c.json({ success: false, message: 'Unauthorized' }, 401);
+  }
+
+  try {
+    const credentialId = c.req.param('credential_id');
+    const body = await c.req.json();
+    const { previous_counter, counter } = body;
+    if (!Number.isInteger(previous_counter) || previous_counter < 0 ||
+        !Number.isInteger(counter) || counter < 0 || counter < previous_counter) {
+      return c.json({ success: false, message: 'Invalid passkey counter' }, 400);
+    }
+
+    const result = await new UserDatabaseService(c.env.USER_DB).updatePasskeyCounter(credentialId, previous_counter, counter);
+    return result.success
+      ? c.json({ success: true, data: result.data })
+      : c.json({ success: false, message: result.error }, 409);
+  } catch (error) {
+    console.error('Error updating passkey counter:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+app.delete('/passkey-credentials/:credential_id', async (c) => {
+  if (!hasPasskeyServiceAccess(c)) {
+    return c.json({ success: false, message: 'Unauthorized' }, 401);
+  }
+
+  try {
+    const credentialId = c.req.param('credential_id');
+    const userId = c.req.query('user_id');
+    const result = await new UserDatabaseService(c.env.USER_DB).deletePasskeyCredential(credentialId, userId);
+    return result.success
+      ? c.json({ success: true, affectedRows: result.affectedRows })
+      : c.json({ success: false, message: result.error }, 500);
+  } catch (error) {
+    console.error('Error deleting passkey credential:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
   }
 });
 
@@ -519,13 +653,18 @@ app.get('/', (c) => {
         path: '/login-history',
         method: 'POST',
         description: 'Create login history record',
-        body: { user_id: 'string', login_method: 'OTP|MAGIC_LINK', success: 'boolean' }
+        body: { user_id: 'string', login_method: 'OTP|MAGIC_LINK|PASSKEY', success: 'boolean' }
       },
       {
         path: '/login-history/recent',
         method: 'GET',
         description: 'Get recent login activity',
         query: { limit: 'number?' }
+      },
+      {
+        path: '/passkey-credentials/*',
+        method: 'GET|POST|PATCH|DELETE',
+        description: 'Internal passkey credential storage routes'
       }
     ]
   });

--- a/user-management-worker/src/services/user-database.ts
+++ b/user-management-worker/src/services/user-database.ts
@@ -8,7 +8,9 @@ import {
   DatabaseResult,
   PaginatedResult,
   RecentLoginActivity,
-  UserStatistics
+  UserStatistics,
+  PasskeyCredential,
+  CreatePasskeyCredentialInput
 } from '../types/database';
 
 export class UserDatabaseService {
@@ -127,8 +129,11 @@ export class UserDatabaseService {
 
   async deleteUser(user_id: string): Promise<DatabaseResult<{ affectedRows: number }>> {
     try {
+      // Preserve a DELETED tombstone so authentication cannot recreate an
+      // identity from a still-valid JWT or a later OTP request.
       const result = await this.db.prepare(`
-        DELETE FROM users WHERE user_id = ?
+        UPDATE users SET status = 'DELETED', updated_at = CURRENT_TIMESTAMP
+        WHERE user_id = ? AND status != 'DELETED'
       `).bind(user_id).run();
 
       return { success: true, affectedRows: result.meta?.changes || 0 };
@@ -141,8 +146,14 @@ export class UserDatabaseService {
   // Login History Management
   async createLoginHistory(input: CreateLoginHistoryInput): Promise<DatabaseResult<UserLoginHistory>> {
     try {
+      // Existing databases keep the original login_method CHECK constraint. Keep
+      // passkey audit events in the additive table so the migration never has to
+      // rewrite or drop existing login history.
+      const historyTable = input.login_method === 'PASSKEY'
+        ? 'passkey_login_history'
+        : 'user_login_history';
       const result = await this.db.prepare(`
-        INSERT INTO user_login_history (
+        INSERT INTO ${historyTable} (
           user_id, ip_address, user_agent, location_data,
           country, region, city, latitude, longitude, timezone,
           login_method, success, failure_reason, device_fingerprint, risk_score
@@ -173,6 +184,104 @@ export class UserDatabaseService {
       return { success: true, data: result };
     } catch (error) {
       console.error('Error creating login history:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  // Passkey credential management
+  async getPasskeyCredentialsByUserId(userId: string): Promise<DatabaseResult<PasskeyCredential[]>> {
+    try {
+      const result = await this.db.prepare(`
+        SELECT * FROM passkey_credentials
+        WHERE user_id = ?
+        ORDER BY created_at ASC
+      `).bind(userId).all<PasskeyCredential>();
+
+      return { success: true, data: result.results };
+    } catch (error) {
+      console.error('Error getting passkey credentials:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async getPasskeyCredential(credentialId: string): Promise<DatabaseResult<PasskeyCredential>> {
+    try {
+      const result = await this.db.prepare(`
+        SELECT * FROM passkey_credentials WHERE credential_id = ?
+      `).bind(credentialId).first<PasskeyCredential>();
+
+      return result
+        ? { success: true, data: result }
+        : { success: false, error: 'Passkey credential not found' };
+    } catch (error) {
+      console.error('Error getting passkey credential:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async createPasskeyCredential(input: CreatePasskeyCredentialInput): Promise<DatabaseResult<PasskeyCredential>> {
+    try {
+      const result = await this.db.prepare(`
+        INSERT INTO passkey_credentials (
+          credential_id, user_id, public_key, counter, device_type, backed_up, transports
+        )
+        SELECT ?, ?, ?, ?, ?, ?, ?
+        WHERE EXISTS (
+          SELECT 1 FROM users WHERE user_id = ? AND status = 'ACTIVE'
+        )
+        RETURNING *
+      `).bind(
+        input.credential_id,
+        input.user_id,
+        input.public_key,
+        input.counter,
+        input.device_type,
+        input.backed_up ? 1 : 0,
+        input.transports ? JSON.stringify(input.transports) : null,
+        input.user_id
+      ).first<PasskeyCredential>();
+
+      return result
+        ? { success: true, data: result }
+        : { success: false, error: 'Failed to create passkey credential' };
+    } catch (error) {
+      console.error('Error creating passkey credential:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async updatePasskeyCounter(credentialId: string, previousCounter: number, newCounter: number): Promise<DatabaseResult<PasskeyCredential>> {
+    try {
+      const result = await this.db.prepare(`
+        UPDATE passkey_credentials
+        SET counter = ?, last_used_at = CURRENT_TIMESTAMP
+        WHERE credential_id = ? AND counter = ?
+          AND EXISTS (
+            SELECT 1 FROM users
+            WHERE users.user_id = passkey_credentials.user_id
+              AND users.status = 'ACTIVE'
+          )
+        RETURNING *
+      `).bind(newCounter, credentialId, previousCounter).first<PasskeyCredential>();
+
+      return result
+        ? { success: true, data: result }
+        : { success: false, error: 'Passkey counter changed or credential not found' };
+    } catch (error) {
+      console.error('Error updating passkey counter:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+    }
+  }
+
+  async deletePasskeyCredential(credentialId: string, userId?: string): Promise<DatabaseResult<{ affectedRows: number }>> {
+    try {
+      const statement = userId
+        ? this.db.prepare('DELETE FROM passkey_credentials WHERE credential_id = ? AND user_id = ?').bind(credentialId, userId)
+        : this.db.prepare('DELETE FROM passkey_credentials WHERE credential_id = ?').bind(credentialId);
+      const result = await statement.run();
+      return { success: true, affectedRows: result.meta?.changes || 0 };
+    } catch (error) {
+      console.error('Error deleting passkey credential:', error);
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
     }
   }

--- a/user-management-worker/src/types/database.ts
+++ b/user-management-worker/src/types/database.ts
@@ -14,6 +14,8 @@ export interface User {
   two_factor_enabled: boolean;
 }
 
+export type LoginMethod = 'OTP' | 'MAGIC_LINK' | 'PASSKEY';
+
 export interface UserLoginHistory {
   id?: number;
   user_id: string;
@@ -27,11 +29,23 @@ export interface UserLoginHistory {
   latitude?: number;
   longitude?: number;
   timezone?: string;
-  login_method: 'OTP' | 'MAGIC_LINK';
+  login_method: LoginMethod;
   success: boolean;
   failure_reason?: string;
   device_fingerprint?: string;
   risk_score: number;
+}
+
+export interface PasskeyCredential {
+  credential_id: string;
+  user_id: string;
+  public_key: string;
+  counter: number;
+  device_type: 'singleDevice' | 'multiDevice';
+  backed_up: number;
+  transports?: string;
+  created_at: string;
+  last_used_at?: string;
 }
 
 // Parsed types for JSON fields
@@ -54,7 +68,7 @@ export interface RecentLoginActivity {
   ip_address?: string;
   country?: string;
   city?: string;
-  login_method: 'OTP' | 'MAGIC_LINK';
+  login_method: LoginMethod;
   success: boolean;
   risk_score: number;
 }
@@ -95,11 +109,21 @@ export interface CreateLoginHistoryInput {
   latitude?: number;
   longitude?: number;
   timezone?: string;
-  login_method: 'OTP' | 'MAGIC_LINK';
+  login_method: LoginMethod;
   success: boolean;
   failure_reason?: string;
   device_fingerprint?: string;
   risk_score?: number;
+}
+
+export interface CreatePasskeyCredentialInput {
+  credential_id: string;
+  user_id: string;
+  public_key: string;
+  counter: number;
+  device_type: 'singleDevice' | 'multiDevice';
+  backed_up: boolean;
+  transports?: string[];
 }
 
 // Update types

--- a/user-management-worker/src/types/env.ts
+++ b/user-management-worker/src/types/env.ts
@@ -4,6 +4,8 @@ export interface Env {
   
   // Environment variables
   ENVIRONMENT: 'development' | 'preview' | 'staging' | 'production';
+  // Optional service-to-service secret for passkey credential routes.
+  PASSKEY_SERVICE_TOKEN?: string;
 }
 
 // Extend the interface to include index signature for Hono compatibility

--- a/user-management-worker/wrangler.toml
+++ b/user-management-worker/wrangler.toml
@@ -50,3 +50,8 @@ database_id = "171ffc3f-40bd-4738-b879-4ccd8d79db39"
 
 [env.staging.observability]
 enabled = true
+
+# Set the same secret on each environment before enabling passkey routes:
+#   wrangler secret put PASSKEY_SERVICE_TOKEN --env preview
+#   wrangler secret put PASSKEY_SERVICE_TOKEN --env staging
+#   wrangler secret put PASSKEY_SERVICE_TOKEN --env production


### PR DESCRIPTION
## Summary
- add WebAuthn/passkey registration and authentication to the auth worker
- add Durable Object challenge storage with one-time atomic claims
- add protected passkey credential storage, counter CAS, and audit history to the user-management worker
- add passkey sign-in/registration UI and client helpers to the recipe app
- add additive D1 migration, environment-specific worker configuration, and CI path fixes
- prevent suspended/deleted accounts from authenticating or being recreated

## Validation
- `auth-worker`: `npm test` (all tests passing)
- `auth-worker`: `npx wrangler deploy --env preview --dry-run`
- `git diff --check`
- recipe-app tests/build and user-management-worker coverage were run during implementation

## Deployment notes
Before deploying staging/production, configure matching secrets on auth-worker and user-management-worker:
- `JWT_SECRET`
- `PASSKEY_SERVICE_TOKEN`

Apply `user-management-worker/migrations/001_add_passkey_credentials.sql` to each existing D1 environment before enabling passkey traffic. Preview currently uses the Pages origin configuration; verify the deployed preview origin before production rollout.
