### PR TITLE
feat(recipe-app): add constraint-first generation composer

### DIFF
--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -9,6 +9,7 @@ import { useAuth } from './useAuth.js'
 import { useMealPlan } from './MealPlanContext.jsx'
 import { syncFlagglyUser, useFlag } from './flaggly.js'
 import CulinaryProfile from './CulinaryProfile.jsx'
+import GenerationComposer from './GenerationComposer.jsx'
 import { useCulinaryProfile } from './useCulinaryProfile.js'
 
 const SEARCH_DB_URL = import.meta.env.VITE_SEARCH_DB_URL
@@ -206,12 +207,35 @@ function UserMenu({ user, onSignOut, onRegisterPasskey, onOpenProfile }) {
   )
 }
 
+export function buildGenerationRequest({
+  dishName,
+  elevate = false,
+  profile = null,
+  overrides = null,
+  baseIngredients = null,
+}) {
+  const body = {
+    recipeName: dishName,
+    generateImage: true,
+    elevate,
+  }
+  if (profile) body.culinaryProfile = profile
+  if (overrides) {
+    Object.assign(body, overrides)
+    if (!overrides.ingredients?.length) delete body.ingredients
+  }
+  if (elevate && baseIngredients) body.ingredients = baseIngredients
+  return body
+}
+
 export default function App() {
   const auth = useAuth()
   const { activeRecipe, setActiveRecipe, clearActiveRecipe } = useMealPlan()
   const mealPlannerEnabled = useFlag('meal-planner')
   const culinaryProfileEnabled = useFlag('culinary-profile')
+  const constraintGenerateEnabled = useFlag('constraint-generate')
   const [profileOpen, setProfileOpen] = useState(false)
+  const [generationComposerOpen, setGenerationComposerOpen] = useState(false)
   const culinaryProfile = useCulinaryProfile(auth.token, culinaryProfileEnabled)
 
   useEffect(() => {
@@ -222,6 +246,7 @@ export default function App() {
   const [input, setInput] = useState('')
   const [status, setStatus] = useState('idle') // idle | searching | clipping | generating | elevating | error
   const [errorMsg, setErrorMsg] = useState('')
+  const [generationRetry, setGenerationRetry] = useState(null)
   const [searchResults, setSearchResults] = useState([])
   const [lastSearchQuery, setLastSearchQuery] = useState('')
   const [showDropdown, setShowDropdown] = useState(false)
@@ -425,6 +450,7 @@ export default function App() {
     latestInputRef.current = val
     setInput(val)
     setErrorMsg('')
+    setGenerationRetry(null)
     setActiveOptionKey(null)
     searchRequestIdRef.current += 1
     if (!isValidUrl(val.trim()) && val.trim().length >= 2) {
@@ -443,6 +469,7 @@ export default function App() {
 
   // --- Clip ---
   async function doClip(url) {
+    setGenerationRetry(null)
     invalidateSearch()
     latestInputRef.current = ''
     setStatus('clipping')
@@ -487,8 +514,9 @@ export default function App() {
   }
 
   // --- Generate ---
-  async function doGenerate(query, { elevate = false, baseRecipe = null } = {}) {
+  async function doGenerate(query, { elevate = false, baseRecipe = null, overrides = null } = {}) {
     invalidateSearch()
+    setGenerationRetry({ query, options: { elevate, baseRecipe, overrides } })
     latestInputRef.current = ''
     const dishName = elevate && baseRecipe ? baseRecipe.name : query
     setGeneratingName(dishName)
@@ -497,14 +525,13 @@ export default function App() {
     setShowDropdown(false)
     setSaveState('idle')
     try {
-      const body = {
-        recipeName: dishName,
-        generateImage: true,
-        elevate: elevate,
-      }
-      if (elevate && baseRecipe) {
-        body.ingredients = baseRecipe.ingredients
-      }
+      const body = buildGenerationRequest({
+        dishName,
+        elevate,
+        profile: constraintGenerateEnabled ? culinaryProfile.profile : null,
+        overrides,
+        baseIngredients: baseRecipe?.ingredients || null,
+      })
 
       const res = await fetch(`${RECIPE_GENERATION_URL}/generate`, {
         method: 'POST',
@@ -527,9 +554,11 @@ export default function App() {
         recipe_yield: r.servings || null,
         ingredients: r.ingredients || [],
         instructions: r.instructions || [],
+        appliedConstraints: data.appliedConstraints || r.appliedConstraints || null,
       }
       setActiveRecipe(generatedRecipe)
       addRecentRecipe(generatedRecipe)
+      setGenerationRetry(null)
       setGeneratingName('')
     } catch (e) {
       setGeneratingName('')
@@ -538,6 +567,11 @@ export default function App() {
       return
     }
     setStatus('idle')
+  }
+
+  function handleTunedGenerate(overrides) {
+    setGenerationComposerOpen(false)
+    doGenerate(input.trim(), { overrides })
   }
 
   // --- Primary action on Enter / button click ---
@@ -703,6 +737,7 @@ export default function App() {
     clearActiveRecipe()
     setGeneratingName('')
     setErrorMsg('')
+    setGenerationRetry(null)
     setStatus('idle')
     setSaveState('idle')
     setSavedRecipeId(null)
@@ -789,17 +824,30 @@ export default function App() {
             <div className="omnibox-actions">
               {/* Generate button — always visible when there's text and it's not a URL */}
               {hasText && (
-                <button
-                  className="action-btn generate-btn"
-                  title="Generate AI recipe"
-                  onClick={() => doGenerate(input.trim())}
-                  disabled={inputBusy}
-                >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                    <path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
-                  </svg>
-                  <span>Generate</span>
-                </button>
+                <>
+                  {constraintGenerateEnabled && (
+                    <button
+                      className="action-btn tune-btn"
+                      title="Tune generation constraints"
+                      onClick={() => setGenerationComposerOpen(true)}
+                      disabled={inputBusy}
+                    >
+                      <span>Tune</span>
+                      <span className="sr-only">generation constraints</span>
+                    </button>
+                  )}
+                  <button
+                    className="action-btn generate-btn"
+                    title="Generate AI recipe"
+                    onClick={() => doGenerate(input.trim())}
+                    disabled={inputBusy}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 107.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/>
+                    </svg>
+                    <span>Generate</span>
+                  </button>
+                </>
               )}
 
               {/* Primary action button — only shown for URL clipping */}
@@ -838,7 +886,18 @@ export default function App() {
 
           {/* Error */}
           {status === 'error' && errorMsg && (
-            <div id="omnibox-error" className="error-label" role="alert">{errorMsg}</div>
+            <div id="omnibox-error" className="error-label" role="alert">
+              <span>{errorMsg}</span>
+              {generationRetry && (
+                <button
+                  type="button"
+                  className="error-retry"
+                  onClick={() => doGenerate(generationRetry.query, generationRetry.options)}
+                >
+                  Retry generation
+                </button>
+              )}
+            </div>
           )}
 
           {/* Search dropdown */}
@@ -923,6 +982,15 @@ export default function App() {
         </div>
 
         {/* GeneratingCard — shown while generate/elevate is in-flight */}
+        <GenerationComposer
+          open={generationComposerOpen && constraintGenerateEnabled && hasText}
+          profile={culinaryProfile.profile}
+          query={input.trim()}
+          busy={inputBusy}
+          onClose={() => setGenerationComposerOpen(false)}
+          onGenerate={handleTunedGenerate}
+        />
+
         {(status === 'generating' || status === 'elevating') && generatingName && (
           <GeneratingCard dishName={generatingName} />
         )}

--- a/recipe-app/src/GenerationComposer.jsx
+++ b/recipe-app/src/GenerationComposer.jsx
@@ -1,0 +1,311 @@
+import React, { useEffect, useRef, useState } from "react";
+
+const DIET_OPTIONS = [
+  ["vegetarian", "Vegetarian"],
+  ["vegan", "Vegan"],
+  ["pescatarian", "Pescatarian"],
+  ["halal", "Halal"],
+  ["kosher", "Kosher"],
+  ["gluten_free", "Gluten-free"],
+  ["dairy_free", "Dairy-free"],
+  ["keto", "Keto"],
+];
+
+const EQUIPMENT_OPTIONS = [
+  ["oven", "Oven"],
+  ["stovetop", "Stovetop"],
+  ["air_fryer", "Air fryer"],
+  ["instant_pot", "Instant Pot"],
+  ["slow_cooker", "Slow cooker"],
+  ["grill", "Grill"],
+  ["microwave", "Microwave"],
+];
+
+const MEAL_TYPES = ["breakfast", "lunch", "dinner", "snack", "dessert"];
+const COOKING_METHODS = ["stovetop", "oven", "air fryer", "grill", "no-cook"];
+
+function listValue(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function commaSeparated(value) {
+  return String(value || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function initialForm(profile) {
+  return {
+    dietary: listValue(profile?.diet_tags),
+    equipment: listValue(profile?.equipment),
+    servings: profile?.default_servings ?? 4,
+    maxCookTime: profile?.max_cook_time_min ?? 60,
+    cuisine: profile?.cuisine_likes?.[0] || "",
+    mealType: "",
+    cookingMethod: "",
+    ingredients: "",
+    excludeIngredients: listValue(profile?.exclude_ingredients).join(", "),
+  };
+}
+
+function toggleValue(values, value) {
+  return values.includes(value)
+    ? values.filter((item) => item !== value)
+    : [...values, value];
+}
+
+export default function GenerationComposer({
+  open,
+  profile,
+  query,
+  busy,
+  onClose,
+  onGenerate,
+}) {
+  const [form, setForm] = useState(() => initialForm(profile));
+  const firstFieldRef = useRef(null);
+
+  useEffect(() => {
+    if (open) {
+      setForm(initialForm(profile));
+      const focusFirstField = () => firstFieldRef.current?.focus();
+      if (typeof window !== "undefined" && window.requestAnimationFrame)
+        window.requestAnimationFrame(focusFirstField);
+      else focusFirstField();
+    }
+  }, [open, profile]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    function handleKeyDown(event) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  function setField(field, value) {
+    setForm((current) => ({ ...current, [field]: value }));
+  }
+
+  function submit(event) {
+    event.preventDefault();
+    onGenerate({
+      dietary: form.dietary,
+      equipment: form.equipment,
+      servings: Number(form.servings),
+      maxCookTime: Number(form.maxCookTime),
+      cuisine: form.cuisine.trim(),
+      mealType: form.mealType,
+      cookingMethod: form.cookingMethod,
+      ingredients: commaSeparated(form.ingredients),
+      excludeIngredients: commaSeparated(form.excludeIngredients),
+    });
+  }
+
+  return (
+    <div
+      className="generation-composer-backdrop"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <section
+        className="generation-composer-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="generation-composer-title"
+      >
+        <div className="generation-composer-header">
+          <div>
+            <p className="generation-composer-eyebrow">Tune your generation</p>
+            <h2 id="generation-composer-title">
+              Make {query || "this recipe"} work for you
+            </h2>
+            <p>These constraints are applied before the recipe is generated.</p>
+          </div>
+          <button
+            type="button"
+            className="generation-composer-close"
+            aria-label="Close generation tuning"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+
+        {profile && (
+          <div className="generation-composer-profile" role="status">
+            <strong>Kitchen profile defaults</strong>
+            <span>
+              {profile.diet_tags?.length
+                ? profile.diet_tags.join(", ")
+                : "No diet set"}
+              {" · "}
+              {profile.default_servings} servings
+              {" · up to "}
+              {profile.max_cook_time_min} min
+            </span>
+            {profile.hard_allergens?.length > 0 && (
+              <span className="generation-composer-safety">
+                Hard allergens protected: {profile.hard_allergens.join(", ")}
+              </span>
+            )}
+          </div>
+        )}
+
+        <form onSubmit={submit}>
+          <fieldset>
+            <legend>Diet and style</legend>
+            <div className="generation-composer-options">
+              {DIET_OPTIONS.map(([value, label]) => (
+                <label key={value} className="generation-composer-check">
+                  <input
+                    type="checkbox"
+                    checked={form.dietary.includes(value)}
+                    onChange={() =>
+                      setField("dietary", toggleValue(form.dietary, value))
+                    }
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="generation-composer-grid">
+            <label>
+              Cuisine
+              <input
+                ref={firstFieldRef}
+                type="text"
+                value={form.cuisine}
+                onChange={(event) => setField("cuisine", event.target.value)}
+                placeholder="Thai, Mexican…"
+              />
+            </label>
+            <label>
+              Meal type
+              <select
+                value={form.mealType}
+                onChange={(event) => setField("mealType", event.target.value)}
+              >
+                <option value="">Any meal</option>
+                {MEAL_TYPES.map((value) => (
+                  <option key={value} value={value}>
+                    {value[0].toUpperCase() + value.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Servings
+              <input
+                type="number"
+                min="1"
+                max="24"
+                value={form.servings}
+                onChange={(event) => setField("servings", event.target.value)}
+              />
+            </label>
+            <label>
+              Max time (minutes)
+              <input
+                type="number"
+                min="5"
+                max="720"
+                value={form.maxCookTime}
+                onChange={(event) =>
+                  setField("maxCookTime", event.target.value)
+                }
+              />
+            </label>
+            <label>
+              Cooking method
+              <select
+                value={form.cookingMethod}
+                onChange={(event) =>
+                  setField("cookingMethod", event.target.value)
+                }
+              >
+                <option value="">Any method</option>
+                {COOKING_METHODS.map((value) => (
+                  <option key={value} value={value}>
+                    {value[0].toUpperCase() + value.slice(1)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <fieldset>
+            <legend>Available equipment</legend>
+            <div className="generation-composer-options">
+              {EQUIPMENT_OPTIONS.map(([value, label]) => (
+                <label key={value} className="generation-composer-check">
+                  <input
+                    type="checkbox"
+                    checked={form.equipment.includes(value)}
+                    onChange={() =>
+                      setField("equipment", toggleValue(form.equipment, value))
+                    }
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <label className="generation-composer-field">
+            Must-use ingredients
+            <input
+              type="text"
+              value={form.ingredients}
+              onChange={(event) => setField("ingredients", event.target.value)}
+              placeholder="chickpeas, spinach (comma separated)"
+            />
+          </label>
+          <label className="generation-composer-field">
+            Exclude for this recipe
+            <input
+              type="text"
+              value={form.excludeIngredients}
+              onChange={(event) =>
+                setField("excludeIngredients", event.target.value)
+              }
+              placeholder="cilantro, mushrooms (comma separated)"
+            />
+          </label>
+
+          <p className="generation-composer-disclaimer">
+            Hard allergens from your kitchen profile stay protected. AI can make
+            mistakes; always verify ingredients and labels.
+          </p>
+          <div className="generation-composer-actions">
+            <button
+              type="button"
+              className="generation-composer-secondary"
+              onClick={onClose}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="generation-composer-primary"
+              disabled={busy}
+            >
+              {busy ? "Generating…" : "Generate recipe"}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/recipe-app/src/RecipeCardDisplay.jsx
+++ b/recipe-app/src/RecipeCardDisplay.jsx
@@ -20,6 +20,16 @@ const sourceBadgeMap = {
   youtube: { label: 'YouTube', color: '#ff0000' },
 }
 
+function appliedConstraintLabels(constraints) {
+  if (!constraints) return []
+  const labels = []
+  if (constraints.dietary?.length) labels.push(constraints.dietary.join(', '))
+  if (constraints.cuisine) labels.push(constraints.cuisine)
+  if (constraints.maxCookTime) labels.push(`${constraints.maxCookTime} min max`)
+  if (constraints.servings) labels.push(`${constraints.servings} servings`)
+  return labels
+}
+
 // Pure display component — no state, no browser APIs.
 // Safe to use with ReactDOMServer.renderToStaticMarkup.
 // Props:
@@ -84,6 +94,15 @@ export default function RecipeCardDisplay({ recipe, onCookClick, cookBtnId }) {
           </button>
         )}
       </div>
+
+      {appliedConstraintLabels(recipe.appliedConstraints).length > 0 && (
+        <div className="applied-constraints" aria-label="Applied generation constraints">
+          <span className="applied-constraints-label">Personalized</span>
+          {appliedConstraintLabels(recipe.appliedConstraints).map((label) => (
+            <span key={label} className="applied-constraint-chip">{label}</span>
+          ))}
+        </div>
+      )}
 
       <div className="recipe-body">
         {recipe.ingredients?.length > 0 && (

--- a/recipe-app/src/__tests__/App.test.jsx
+++ b/recipe-app/src/__tests__/App.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import App from '../App';
+import App, { buildGenerationRequest } from '../App';
 import { MealPlanProvider } from '../MealPlanContext.jsx';
 
 // Wrap App in the providers it requires (MealPlanProvider lives in main.jsx in production)
@@ -99,6 +99,27 @@ const GENERATE_RESPONSE = {
     instructions: ['Beat eggs.', 'Cook in butter.'],
   },
 };
+
+describe('Generation request builder', () => {
+  test('merges profile defaults, explicit overrides, and elevate ingredients', () => {
+    expect(buildGenerationRequest({
+      dishName: 'Weeknight pasta',
+      elevate: true,
+      profile: { diet_tags: ['vegetarian'], default_servings: 2 },
+      overrides: { dietary: ['vegan'], servings: 4, maxCookTime: 20, ingredients: [] },
+      baseIngredients: ['pasta', 'tomatoes'],
+    })).toEqual({
+      recipeName: 'Weeknight pasta',
+      generateImage: true,
+      elevate: true,
+      culinaryProfile: { diet_tags: ['vegetarian'], default_servings: 2 },
+      dietary: ['vegan'],
+      servings: 4,
+      maxCookTime: 20,
+      ingredients: ['pasta', 'tomatoes'],
+    })
+  })
+})
 
 // ── isValidUrl (tested via omnibox UI behaviour) ───────────────────────────
 
@@ -650,6 +671,35 @@ describe('Generate behaviour', () => {
     });
   });
 
+  test('Tune composer sends structured overrides before generation', async () => {
+    mockFetchOk({
+      ...GENERATE_RESPONSE,
+      appliedConstraints: { dietary: ['vegan'], maxCookTime: 20, servings: 2 },
+    });
+
+    renderApp();
+    setInputValue('weeknight curry');
+    fireEvent.click(screen.getByRole('button', { name: /Tune generation constraints/i }));
+
+    expect(screen.getByRole('dialog', { name: /Make weeknight curry work for you/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Vegan'));
+    fireEvent.change(screen.getByLabelText('Max time (minutes)'), { target: { value: '20' } });
+    fireEvent.change(screen.getByLabelText('Servings'), { target: { value: '2' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Generate recipe' }));
+
+    await waitFor(() => {
+      const call = global.fetch.mock.calls.find(([url]) => url === 'https://test-gen.example.com/generate');
+      expect(call).toBeDefined();
+      const body = JSON.parse(call[1].body);
+      expect(body.dietary).toEqual(['vegan']);
+      expect(body.maxCookTime).toBe(20);
+      expect(body.servings).toBe(2);
+    });
+
+    expect(await screen.findByText('Personalized')).toBeInTheDocument();
+    expect(screen.getByText('20 min max')).toBeInTheDocument();
+  });
+
   test('shows AI Generated recipe card after generation', async () => {
     mockFetchOk(GENERATE_RESPONSE);
 
@@ -684,6 +734,21 @@ describe('Generate behaviour', () => {
     await waitFor(() =>
       expect(screen.getByText(/Generation failed: 503/i)).toBeInTheDocument()
     );
+  });
+
+  test('offers retry when generation fails', async () => {
+    mockFetchFail(503);
+
+    renderApp();
+    setInputValue('omelette');
+    fireEvent.click(screen.getByText('Generate'));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Retry generation' })).toBeInTheDocument());
+
+    mockFetchOk(GENERATE_RESPONSE);
+    fireEvent.click(screen.getByRole('button', { name: 'Retry generation' }));
+
+    expect(await screen.findByRole('heading', { name: /AI Omelette/i })).toBeInTheDocument();
   });
 
   test('shows error when generation response has success:false', async () => {

--- a/recipe-app/src/__tests__/GenerationComposer.test.jsx
+++ b/recipe-app/src/__tests__/GenerationComposer.test.jsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import GenerationComposer from "../GenerationComposer.jsx";
+
+const profile = {
+  diet_tags: ["vegetarian"],
+  hard_allergens: ["peanuts"],
+  default_servings: 2,
+  max_cook_time_min: 30,
+  equipment: ["air_fryer"],
+  cuisine_likes: ["Thai"],
+  exclude_ingredients: ["cilantro"],
+};
+
+describe("GenerationComposer", () => {
+  test("shows profile defaults and safety constraints", () => {
+    render(
+      <GenerationComposer
+        open
+        profile={profile}
+        query="weeknight noodles"
+        busy={false}
+        onClose={jest.fn()}
+        onGenerate={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: /Make weeknight noodles work for you/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Kitchen profile defaults/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Hard allergens protected: peanuts/i),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Servings")).toHaveValue(2);
+    expect(screen.getByLabelText("Max time (minutes)")).toHaveValue(30);
+    expect(screen.getByLabelText("Vegetarian")).toBeChecked();
+    expect(screen.getByLabelText("Air fryer")).toBeChecked();
+    expect(screen.getByLabelText("Exclude for this recipe")).toHaveValue(
+      "cilantro",
+    );
+  });
+
+  test("submits structured generation overrides", () => {
+    const onGenerate = jest.fn();
+    render(
+      <GenerationComposer
+        open
+        profile={profile}
+        query="weeknight noodles"
+        busy={false}
+        onClose={jest.fn()}
+        onGenerate={onGenerate}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Cuisine"), {
+      target: { value: "Mexican" },
+    });
+    fireEvent.change(screen.getByLabelText("Servings"), {
+      target: { value: "4" },
+    });
+    fireEvent.change(screen.getByLabelText("Max time (minutes)"), {
+      target: { value: "20" },
+    });
+    fireEvent.change(screen.getByLabelText("Must-use ingredients"), {
+      target: { value: "beans, corn" },
+    });
+    fireEvent.click(screen.getByLabelText("Vegetarian"));
+    fireEvent.click(screen.getByRole("button", { name: "Generate recipe" }));
+
+    expect(onGenerate).toHaveBeenCalledWith({
+      dietary: [],
+      equipment: ["air_fryer"],
+      servings: 4,
+      maxCookTime: 20,
+      cuisine: "Mexican",
+      mealType: "",
+      cookingMethod: "",
+      ingredients: ["beans", "corn"],
+      excludeIngredients: ["cilantro"],
+    });
+  });
+
+  test("Escape closes the composer", () => {
+    const onClose = jest.fn();
+    render(
+      <GenerationComposer
+        open
+        profile={null}
+        query="pasta"
+        busy={false}
+        onClose={onClose}
+        onGenerate={jest.fn()}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/recipe-app/src/flaggly.js
+++ b/recipe-app/src/flaggly.js
@@ -21,6 +21,7 @@ try {
       'elevate-recipe': true,
       'meal-planner': true,
       'culinary-profile': true,
+      'constraint-generate': true,
     },
   })
 } catch (err) {
@@ -63,7 +64,7 @@ export async function syncFlagglyUser(user) {
     const keys = state ? Object.keys(state) : []
     if (keys.length === 0) {
       console.warn(
-        '[flaggly] Eval succeeded but returned zero flags. In Flaggly admin, create flags with the same ids as in code (voice-control, gesture-support, dictation, elevate-recipe, meal-planner, culinary-profile) for app `default` / env `production`, or set VITE_FLAGGLY_APP_ID / VITE_FLAGGLY_ENV_ID if you use other names.'
+        '[flaggly] Eval succeeded but returned zero flags. In Flaggly admin, create flags with the same ids as in code (voice-control, gesture-support, dictation, elevate-recipe, meal-planner, culinary-profile, constraint-generate) for app `default` / env `production`, or set VITE_FLAGGLY_APP_ID / VITE_FLAGGLY_ENV_ID if you use other names.'
       )
     } else if (import.meta.env.DEV) {
       console.info(`[flaggly] Eval OK — ${keys.length} flag(s):`, keys.join(', '))

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -2471,3 +2471,245 @@ textarea:focus-visible {
     border-radius: var(--radius) var(--radius) 0 0;
   }
 }
+
+/* ── Constraint-first generation ── */
+.tune-btn {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+}
+.tune-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--text);
+  background: rgba(200, 169, 110, 0.08);
+}
+.generation-composer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 310;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: calc(72px + var(--safe-top)) calc(16px + var(--safe-right)) calc(24px + var(--safe-bottom)) calc(16px + var(--safe-left));
+  overflow-y: auto;
+  background: rgba(4, 10, 5, 0.78);
+  backdrop-filter: blur(5px);
+}
+.generation-composer-sheet {
+  width: min(100%, 620px);
+  max-height: calc(100vh - 96px);
+  overflow-y: auto;
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
+}
+.generation-composer-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+.generation-composer-eyebrow {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.generation-composer-header h2 {
+  margin-top: 2px;
+  color: var(--text);
+  font-size: 1.3rem;
+  line-height: 1.25;
+}
+.generation-composer-header p:last-child {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 0.84rem;
+}
+.generation-composer-close {
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--surface2);
+  color: var(--text);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+}
+.generation-composer-profile {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 8px;
+  margin-bottom: 18px;
+  padding: 10px 12px;
+  border: 1px solid rgba(200, 169, 110, 0.25);
+  border-radius: var(--radius-sm);
+  background: rgba(200, 169, 110, 0.08);
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+.generation-composer-profile strong {
+  color: var(--accent);
+}
+.generation-composer-profile span {
+  width: 100%;
+}
+.generation-composer-profile .generation-composer-safety {
+  color: #f0d697;
+}
+.generation-composer-sheet fieldset {
+  margin: 0 0 18px;
+  padding: 0;
+  border: 0;
+}
+.generation-composer-sheet legend {
+  margin-bottom: 8px;
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+.generation-composer-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.generation-composer-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 38px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.82rem;
+}
+.generation-composer-check:has(input:checked) {
+  border-color: var(--accent);
+  background: rgba(200, 169, 110, 0.12);
+}
+.generation-composer-check input {
+  accent-color: var(--accent);
+}
+.generation-composer-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 18px;
+}
+.generation-composer-grid label,
+.generation-composer-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+.generation-composer-grid input,
+.generation-composer-grid select,
+.generation-composer-field input {
+  width: 100%;
+  min-height: 40px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface2);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.85rem;
+}
+.generation-composer-field {
+  margin-bottom: 13px;
+}
+.generation-composer-disclaimer {
+  margin-top: 16px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+.generation-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+}
+.generation-composer-actions button {
+  min-height: 44px;
+  padding: 8px 16px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+.generation-composer-secondary {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+}
+.generation-composer-primary {
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--bg);
+}
+.generation-composer-primary:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+.applied-constraints {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 0 18px 12px;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+.applied-constraints-label {
+  color: var(--accent);
+  font-weight: 700;
+}
+.applied-constraint-chip {
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--surface2);
+  color: var(--text);
+  text-transform: capitalize;
+}
+
+@media (max-width: 520px) {
+  .generation-composer-backdrop {
+    align-items: flex-end;
+    padding: 24px 0 0;
+  }
+  .generation-composer-sheet {
+    max-height: calc(100vh - 24px);
+    padding: 18px 16px calc(18px + var(--safe-bottom));
+    border-radius: var(--radius) var(--radius) 0 0;
+  }
+  .generation-composer-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.error-retry {
+  min-height: 36px;
+  margin-left: 8px;
+  padding: 5px 10px;
+  border: 1px solid rgba(217, 79, 79, 0.55);
+  border-radius: var(--radius-sm);
+  background: rgba(217, 79, 79, 0.12);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.error-retry:hover {
+  background: rgba(217, 79, 79, 0.22);
+}

--- a/recipe-generation-worker/src/handlers/generate-handler.js
+++ b/recipe-generation-worker/src/handlers/generate-handler.js
@@ -26,7 +26,8 @@ export async function handleGenerate(request, env, corsHeaders) {
     // Keep the generation worker compatible with the existing flat request
     // contract while allowing an authenticated client to provide profile
     // defaults. Explicit request fields remain authoritative.
-    Object.assign(requestBody, buildGenerationConstraints(profile, requestBody));
+    const appliedConstraints = buildGenerationConstraints(profile, requestBody);
+    Object.assign(requestBody, appliedConstraints);
 
     // Validate required fields - either recipeName or ingredients must be provided
     if (!requestBody.recipeName &&
@@ -63,7 +64,8 @@ export async function handleGenerate(request, env, corsHeaders) {
         sourceIngredients: requestBody.ingredients || [],
         generationTime: 0,
         similarRecipesFound: 0,
-        mockMode: true
+        mockMode: true,
+        appliedConstraints
       };
 
       // Check if elevation is requested in mock mode
@@ -99,6 +101,7 @@ export async function handleGenerate(request, env, corsHeaders) {
       return new Response(JSON.stringify({
         success: true,
         recipe: finalRecipe,
+        appliedConstraints,
         environment: env.ENVIRONMENT || 'development'
       }), {
         status: 200,
@@ -111,6 +114,7 @@ export async function handleGenerate(request, env, corsHeaders) {
 
     // Generate recipe using AI (Opik if available, otherwise LLaMA)
     const generatedRecipe = await generateRecipeWithAI(requestBody, env);
+    generatedRecipe.appliedConstraints = appliedConstraints;
 
     // Check if elevation is requested
     let finalRecipe = generatedRecipe;
@@ -145,6 +149,7 @@ export async function handleGenerate(request, env, corsHeaders) {
     return new Response(JSON.stringify({
       success: true,
       recipe: finalRecipe,
+      appliedConstraints,
       environment: env.ENVIRONMENT || 'development'
     }), {
       status: 200,
@@ -372,13 +377,12 @@ async function generateRecipeWithAI(requestData, env) {
  * Build query text from request data for embedding generation
  */
 function buildQueryText(requestData) {
-  // If recipe name is provided, use it as the primary query
-  if (requestData.recipeName) {
-    return requestData.recipeName;
-  }
-
-  // Otherwise, build from ingredients and preferences (legacy support)
+  // Use the recipe name as the primary query while retaining structured
+  // constraints so retrieval is shaped by the user's requested outcome.
   const parts = [];
+  if (requestData.recipeName) parts.push(requestData.recipeName);
+
+  // Build the remainder from ingredients and preferences (legacy support)
 
   // Add ingredients
   if (requestData.ingredients && requestData.ingredients.length > 0) {
@@ -852,6 +856,30 @@ function buildLLaMAPrompt(requestData, contexts) {
   }
   if (requestData.cookingMethod) {
     requirements.push(`using ${requestData.cookingMethod} cooking method`);
+  }
+  if (requestData.equipment && requestData.equipment.length > 0) {
+    requirements.push(`using only available equipment: ${requestData.equipment.join(', ')}`);
+  }
+  if (requestData.hardAllergens && requestData.hardAllergens.length > 0) {
+    requirements.push(`must not contain these hard allergens: ${requestData.hardAllergens.join(', ')}`);
+  }
+  if (requestData.softAvoids && requestData.softAvoids.length > 0) {
+    requirements.push(`avoid these ingredients or flavors when possible: ${requestData.softAvoids.join(', ')}`);
+  }
+  if (requestData.excludeIngredients && requestData.excludeIngredients.length > 0) {
+    requirements.push(`do not use: ${requestData.excludeIngredients.join(', ')}`);
+  }
+  if (requestData.ingredients && requestData.ingredients.length > 0) {
+    requirements.push(`must use these ingredients: ${requestData.ingredients.join(', ')}`);
+  }
+  if (requestData.skillLevel) {
+    requirements.push(`write for a ${requestData.skillLevel} home cook`);
+  }
+  if (requestData.spiceLevel !== undefined && requestData.spiceLevel !== null) {
+    requirements.push(`target spice level ${requestData.spiceLevel} out of 5`);
+  }
+  if (requestData.cuisineDislikes && requestData.cuisineDislikes.length > 0) {
+    requirements.push(`avoid these cuisines: ${requestData.cuisineDislikes.join(', ')}`);
   }
 
   if (requirements.length > 0) {

--- a/recipe-generation-worker/tests/unit/generate-handler.test.js
+++ b/recipe-generation-worker/tests/unit/generate-handler.test.js
@@ -244,6 +244,49 @@ describe('Generate Handler - Unit Tests', () => {
       expect(data.recipe.appliedConstraints).toEqual(data.appliedConstraints);
     });
 
+    it('should include every generation constraint in the prompt and response echo', async () => {
+      const requestBody = {
+        recipeName: 'Tofu stir fry',
+        ingredients: ['tofu'],
+        cuisine: 'thai',
+        dietary: ['vegan'],
+        servings: 2,
+        maxCookTime: 20,
+        cookingMethod: 'stovetop',
+        culinaryProfile: {
+          hard_allergens: ['peanuts'],
+          soft_avoids: ['cilantro'],
+          cuisine_dislikes: ['french'],
+          skill_level: 'beginner',
+          spice_level: 4,
+          exclude_ingredients: ['mushrooms'],
+          equipment: ['stovetop'],
+        },
+      };
+
+      const response = await handleGenerate(createPostRequest('/generate', requestBody), enhancedMockEnv, corsHeaders);
+      const data = await response.json();
+      const llamaCall = mockAI.run.mock.calls.find(([model]) => model === '@cf/meta/llama-4-scout-17b-16e-instruct');
+      const prompt = llamaCall[1].messages.find(({ role }) => role === 'user').content;
+
+      expect(prompt).toContain('using stovetop cooking method');
+      expect(prompt).toContain('using only available equipment: stovetop');
+      expect(prompt).toContain('must not contain these hard allergens: peanuts');
+      expect(prompt).toContain('avoid these ingredients or flavors when possible: cilantro');
+      expect(prompt).toContain('do not use: mushrooms');
+      expect(prompt).toContain('must use these ingredients: tofu');
+      expect(prompt).toContain('write for a beginner home cook');
+      expect(prompt).toContain('target spice level 4 out of 5');
+      expect(prompt).toContain('avoid these cuisines: french');
+      expect(data.appliedConstraints).toMatchObject({
+        softAvoids: ['cilantro'],
+        excludeIngredients: ['mushrooms'],
+        skillLevel: 'beginner',
+        spiceLevel: 4,
+        cuisineDislikes: ['french'],
+      });
+    });
+
     it('should accept the profile alias for backwards-compatible clients', async () => {
       const request = createPostRequest('/generate', {
         ingredients: ['pasta'],

--- a/recipe-generation-worker/tests/unit/generate-handler.test.js
+++ b/recipe-generation-worker/tests/unit/generate-handler.test.js
@@ -203,7 +203,9 @@ describe('Generate Handler - Unit Tests', () => {
           diet_tags: ['vegan'],
           cuisine_likes: ['thai'],
           default_servings: 2,
-          max_cook_time_min: 25
+          max_cook_time_min: 25,
+          equipment: ['oven'],
+          hard_allergens: ['peanuts']
         }
       };
 
@@ -228,6 +230,18 @@ describe('Generate Handler - Unit Tests', () => {
       expect(prompt).toContain('serves 6 people');
       expect(prompt).toContain('italian cuisine');
       expect(prompt).toContain('total cooking time under 25 minutes');
+      expect(prompt).toContain('using only available equipment: oven');
+      expect(prompt).toContain('must not contain these hard allergens: peanuts');
+
+      const data = await response.json();
+      expect(data.appliedConstraints).toMatchObject({
+        dietary: ['vegan'],
+        equipment: ['oven'],
+        hardAllergens: ['peanuts'],
+        servings: 6,
+        maxCookTime: 25
+      });
+      expect(data.recipe.appliedConstraints).toEqual(data.appliedConstraints);
     });
 
     it('should accept the profile alias for backwards-compatible clients', async () => {

--- a/recipe-generation-worker/tests/unit/generate-handler.test.js
+++ b/recipe-generation-worker/tests/unit/generate-handler.test.js
@@ -260,8 +260,8 @@ describe('Generate Handler - Unit Tests', () => {
           skill_level: 'beginner',
           spice_level: 4,
           exclude_ingredients: ['mushrooms'],
-          equipment: ['stovetop'],
-        },
+          equipment: ['stovetop']
+        }
       };
 
       const response = await handleGenerate(createPostRequest('/generate', requestBody), enhancedMockEnv, corsHeaders);
@@ -283,7 +283,7 @@ describe('Generate Handler - Unit Tests', () => {
         excludeIngredients: ['mushrooms'],
         skillLevel: 'beginner',
         spiceLevel: 4,
-        cuisineDislikes: ['french'],
+        cuisineDislikes: ['french']
       });
     });
 


### PR DESCRIPTION
## Summary
- Adds a progressive **Tune generation** composer for diet, cuisine, meal type, time, servings, equipment, must-use ingredients, and per-recipe exclusions.
- Sends kitchen profile defaults plus explicit overrides to the generation worker behind the new `constraint-generate` flag.
- Returns and displays normalized `appliedConstraints`, expands the worker prompt to include all structured constraints, and adds a retry action for generation failures.
- Adds frontend and worker coverage for the request builder, composer interactions, applied constraints, and prompt contract.

Closes #296

## Validation
- `cd recipe-app && npm test && npm run build` — 354 tests passed; build passed
- `cd recipe-generation-worker && npm test -- --run` — 167 tests passed
- `cd recipe-generation-worker && npm run test:unit` — 157 tests passed
- `cd recipe-generation-worker && npm run test:integration` — 10 tests passed
- `cd recipe-generation-worker && npm run test:coverage` — passed (77.19% branch coverage; threshold 77%)
- `cd recipe-generation-worker && npm run lint` — passed with existing `no-console` warnings
- `cd recipe-generation-worker && npm run type-check` — passed

## Notes
- Existing fast-path Generate behavior and Elevate behavior remain intact.
- Hard allergens from the saved kitchen profile are surfaced as protected constraints in the composer and prompt; users are reminded to verify AI-generated ingredients.