### PR TITLE
feat(safety): add fail-closed allergen filtering

### DIFF
--- a/docs/ALLERGEN_SAFETY.md
+++ b/docs/ALLERGEN_SAFETY.md
@@ -1,0 +1,70 @@
+# Allergen safety
+
+Seasoned treats allergy preferences as a safety constraint, not as a recipe
+label. The shared `shared/allergen-graph.js` module detects the FDA major
+allergen set (milk, eggs, fish, shellfish, tree nuts, peanuts, wheat, soy, and
+sesame) using canonical IDs and explainable ingredient synonyms.
+
+## Request flow
+
+1. Culinary profile and request overrides are normalized by
+   `buildGenerationConstraints`.
+2. The generation worker adds hard allergens to retrieval and model prompts.
+   Similar recipes containing a blocked allergen are excluded before they can
+   become model context.
+3. Generated and elevated recipes are checked after the model response is
+   normalized. The response includes `allergenSummary` and
+   `allergenValidation: "PASSED"` only after the check succeeds.
+4. The recommendation worker accepts the same `hardAllergens`/profile input.
+   It only returns recipes with ingredient data that pass the shared checker;
+   name-only fallbacks and unverified AI-only names are omitted when a hard
+   allergen policy is active.
+
+## Fail-closed behavior
+
+A recipe containing a requested hard allergen is never returned. The generate
+endpoint responds with HTTP `422` and a payload like:
+
+```json
+{
+  "error": "Recipe failed allergen safety validation",
+  "code": "ALLERGEN_SAFETY_BLOCK",
+  "allergenSummary": {
+    "checked": true,
+    "safe": false,
+    "contains": ["peanuts"],
+    "blocked": ["peanuts"],
+    "may_contain_uncertain": []
+  }
+}
+```
+
+Opaque terms such as broth, seasoning blends, natural flavors, and shared
+facility statements are reported in `may_contain_uncertain`. When a user has
+any hard allergen configured, uncertainty also fails closed so it cannot be
+silently mistaken for an allergen-free result. Custom hard-allergen tags that
+are outside the canonical graph are likewise marked unverified.
+
+Every summary is an audit aid, not a medical guarantee. The app should continue
+to display a clear reminder that AI can miss allergens and cross-contact and
+that users must verify packaging and preparation conditions with the
+manufacturer or a qualified professional.
+
+## Adding synonyms
+
+Add a lowercase term to `ALLERGEN_TERMS` in `shared/allergen-graph.js`, then add
+a focused test demonstrating the ingredient phrase and expected canonical ID.
+Prefer specific phrases over broad terms to reduce false positives. Plant-based
+milk exceptions are intentionally handled separately because coconut, oat,
+rice, hemp, pea, and cashew milk should not be classified as dairy milk (their
+own allergen mappings still apply where appropriate).
+
+## Validation checklist
+
+- Run shared allergen graph tests.
+- Run generation worker unit tests, including the 422 fail-closed path.
+- Run recommendation filtering tests with both blocked and safe recipes.
+- Verify a recipe with only opaque ingredient terms is not returned when a hard
+  allergen profile is active.
+- Keep the user-facing copy factual: allergen detection reduces risk but does
+  not detect cross-contact or replace label verification.

--- a/recipe-app/src/RecipeCardDisplay.jsx
+++ b/recipe-app/src/RecipeCardDisplay.jsx
@@ -43,6 +43,10 @@ export default function RecipeCardDisplay({ recipe, onCookClick, cookBtnId }) {
   })
 
   const sourceBadge = sourceBadgeMap[recipe.source]
+  const allergenSummary = recipe.allergenSummary
+  const hardAllergens = recipe.appliedConstraints?.hardAllergens || []
+  const showAllergenNotice = hardAllergens.length > 0 || allergenSummary
+  const blockedAllergens = allergenSummary?.blocked || []
 
   return (
     <>
@@ -63,6 +67,14 @@ export default function RecipeCardDisplay({ recipe, onCookClick, cookBtnId }) {
 
       {recipe.description && (
         <p className="recipe-description">{recipe.description}</p>
+      )}
+
+      {showAllergenNotice && (
+        <div className="recipe-allergen-notice" role="note">
+          {blockedAllergens.length > 0
+            ? `Allergen safety blocked: ${blockedAllergens.join(', ')}.`
+            : 'Allergen check completed. AI can miss allergens and cross-contact; verify labels and preparation conditions.'}
+        </div>
       )}
 
       <div className="recipe-meta">

--- a/recipe-app/src/__tests__/RecipeCardDisplay.test.jsx
+++ b/recipe-app/src/__tests__/RecipeCardDisplay.test.jsx
@@ -66,6 +66,16 @@ describe('RecipeCardDisplay', () => {
     expect(screen.getByTitle('Step-by-step cooking mode')).toHaveAttribute('id', 'cook-btn')
   })
 
+  test('shows the allergen safety notice when a recipe has a hard-allergen check', () => {
+    render(<RecipeCardDisplay recipe={{
+      ...baseRecipe,
+      appliedConstraints: { hardAllergens: ['peanuts'] },
+      allergenSummary: { checked: true, blocked: [] },
+    }} />)
+
+    expect(screen.getByText(/AI can miss allergens and cross-contact/i)).toBeInTheDocument()
+  })
+
   test('handles object ingredients', () => {
     render(<RecipeCardDisplay recipe={{ ...baseRecipe, ingredients: [{ name: '2 eggs' }] }} />)
     expect(screen.getByText('2 eggs')).toBeInTheDocument()

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -663,6 +663,17 @@ textarea:focus-visible {
   box-shadow: inset 0 0 0 1px rgba(255,255,255,0.06);
 }
 
+.recipe-allergen-notice {
+  margin: 0.75rem 0;
+  padding: 0.65rem 0.8rem;
+  border: 1px solid rgba(232, 200, 122, 0.45);
+  border-radius: 10px;
+  color: var(--text, #e8f0e4);
+  background: rgba(232, 200, 122, 0.1);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
 .recipe-description {
   padding: 16px 20px 0;
   font-size: 0.9375rem;

--- a/recipe-generation-worker/src/handlers/generate-handler.js
+++ b/recipe-generation-worker/src/handlers/generate-handler.js
@@ -1,6 +1,11 @@
 import { OpikClient } from '../opik-client.js';
 import { getRecipeFromKV } from '../../../shared/kv-storage.js';
 import { buildGenerationConstraints } from '../../../shared/culinary-profile.js';
+import {
+  AllergenSafetyError,
+  enforceAllergenSafety,
+  isRecipeSafe
+} from '../../../shared/allergen-graph.js';
 
 /**
  * Recipe generation endpoint handler - processes recipe generation requests
@@ -69,15 +74,17 @@ export async function handleGenerate(request, env, corsHeaders) {
       };
 
       // Check if elevation is requested in mock mode
-      let finalRecipe = mockRecipe;
+      let finalRecipe = enforceAllergenSafety(mockRecipe, appliedConstraints.hardAllergens);
       if (requestBody.elevate === true) {
         try {
           finalRecipe = await elevateRecipe(mockRecipe, env);
         } catch (elevationError) {
+          // Safety failures must never fall back to an unchecked recipe.
+          if (elevationError instanceof AllergenSafetyError) throw elevationError;
           // If elevation fails, return the original recipe with a warning
           console.warn('Recipe elevation failed in mock mode:', elevationError.message);
           finalRecipe = {
-            ...mockRecipe,
+            ...finalRecipe,
             elevationError: 'Recipe elevation failed, returning original recipe',
             elevationFailed: true
           };
@@ -114,18 +121,24 @@ export async function handleGenerate(request, env, corsHeaders) {
 
     // Generate recipe using AI (Opik if available, otherwise LLaMA)
     const generatedRecipe = await generateRecipeWithAI(requestBody, env);
-    generatedRecipe.appliedConstraints = appliedConstraints;
+    let finalRecipe = enforceAllergenSafety(generatedRecipe, appliedConstraints.hardAllergens);
+    finalRecipe.appliedConstraints = appliedConstraints;
 
     // Check if elevation is requested
-    let finalRecipe = generatedRecipe;
     if (requestBody.elevate === true) {
       try {
-        finalRecipe = await elevateRecipe(generatedRecipe, env);
+        finalRecipe = enforceAllergenSafety(
+          await elevateRecipe(finalRecipe, env),
+          appliedConstraints.hardAllergens
+        );
+        finalRecipe.appliedConstraints = appliedConstraints;
       } catch (elevationError) {
+        // Safety failures must never fall back to an unchecked recipe.
+        if (elevationError instanceof AllergenSafetyError) throw elevationError;
         // If elevation fails, return the original recipe with a warning
         console.warn('Recipe elevation failed:', elevationError.message);
         finalRecipe = {
-          ...generatedRecipe,
+          ...finalRecipe,
           elevationError: 'Recipe elevation failed, returning original recipe',
           elevationFailed: true
         };
@@ -159,6 +172,21 @@ export async function handleGenerate(request, env, corsHeaders) {
       }
     });
   } catch (error) {
+    // Allergen failures are client-actionable and must not expose the unsafe recipe.
+    if (error instanceof AllergenSafetyError) {
+      return new Response(JSON.stringify({
+        error: 'Recipe failed allergen safety validation',
+        code: error.code,
+        allergenSummary: error.summary
+      }), {
+        status: error.status,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+
     // Error processing recipe generation request
     return new Response(JSON.stringify({
       error: 'Failed to process recipe generation request',
@@ -224,8 +252,15 @@ async function generateRecipeWithAI(requestData, env) {
 
     // Step 3: Search for similar recipes using vectorize and fetch full data
     operationData.searchStartTime = new Date().toISOString();
-    const similarRecipes = await findSimilarRecipes(queryEmbedding, env.RECIPE_VECTORS, env);
-    // Found ${similarRecipes.length} similar recipes
+    const candidateRecipes = await findSimilarRecipes(queryEmbedding, env.RECIPE_VECTORS, env);
+    const hardAllergens = requestData.hardAllergens || [];
+    const similarRecipes = hardAllergens.length > 0
+      ? candidateRecipes.filter((candidate) => isRecipeSafe(
+        candidate.fullRecipe || { ingredients: [candidate.metadata?.title || ''] },
+        hardAllergens
+      ))
+      : candidateRecipes;
+    // Found allergen-safe similar recipes
     operationData.similarRecipes = similarRecipes;
     operationData.searchEndTime = new Date().toISOString();
 
@@ -397,6 +432,10 @@ function buildQueryText(requestData) {
   // Add dietary restrictions
   if (requestData.dietary && requestData.dietary.length > 0) {
     parts.push(`Dietary restrictions: ${requestData.dietary.join(', ')}`);
+  }
+
+  if (requestData.hardAllergens && requestData.hardAllergens.length > 0) {
+    parts.push(`Exclude allergens: ${requestData.hardAllergens.join(', ')}`);
   }
 
   // Add meal type
@@ -910,6 +949,11 @@ Make the recipe practical for home cooks with commonly available ingredients. In
  * better ingredient specificity, and educational cooking insights.
  */
 export async function elevateRecipe(recipe, env) {
+  const hardAllergens = recipe?.appliedConstraints?.hardAllergens || recipe?.hardAllergens || [];
+  const annotateElevated = (value) => hardAllergens.length > 0
+    ? enforceAllergenSafety(value, hardAllergens)
+    : value;
+
   // Check if we're in a local development environment without AI access
   if (!env.AI) {
     // Ensure ingredients and instructions are arrays before mapping
@@ -924,7 +968,7 @@ export async function elevateRecipe(recipe, env) {
       : [];
 
     // Return mock elevated recipe for local testing
-    return {
+    return annotateElevated({
       ...recipe,
       name: `Elevated ${recipe.name}`,
       description: `${recipe.description} (Enhanced with professional culinary techniques)`,
@@ -943,7 +987,7 @@ export async function elevateRecipe(recipe, env) {
       elevatedAt: new Date().toISOString(),
       elevationMethod: 'mock-ai',
       mockMode: true
-    };
+    });
   }
 
   // Create the culinary expert system prompt
@@ -1019,6 +1063,10 @@ Remember: Your goal is to transform a good recipe into an exceptional one while 
     : (recipe.tips || 'None provided');
 
   // Create the user prompt with the recipe to elevate
+  const safetyInstruction = hardAllergens.length > 0
+    ? `\n\nHARD SAFETY REQUIREMENT: do not add or retain these allergens: ${hardAllergens.join(', ')}. If a substitution is needed, choose an ingredient that is verifiably free of them.`
+    : '';
+
   const userPrompt = `Please elevate this recipe with your professional culinary expertise:
 
 **Original Recipe:**
@@ -1041,7 +1089,7 @@ additionalDetails:
 - dietary: ${safeDietary}
 - tips: ${safeTips}
 
-Please provide the elevated version following the same JSON structure, with enhanced ingredients, improved instructions, and additional professional tips.`;
+Please provide the elevated version following the same JSON structure, with enhanced ingredients, improved instructions, and additional professional tips.${safetyInstruction}`;
 
   // Validate prompt length and content
   if (userPrompt.length > 8000) {
@@ -1243,7 +1291,7 @@ Please provide the elevated version following the same JSON structure, with enha
     delete elevatedRecipe.dietaryConsiderations;
   }
 
-  return elevatedRecipe;
+  return annotateElevated(elevatedRecipe);
 }
 
 /**

--- a/recipe-generation-worker/tests/unit/generate-handler.test.js
+++ b/recipe-generation-worker/tests/unit/generate-handler.test.js
@@ -2121,3 +2121,93 @@ describe('Generate Handler - Unit Tests', () => {
     });
   });
 });
+
+describe('Allergen safety enforcement', () => {
+  const allergenCorsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  };
+  const allergenMockAI = { run: vi.fn() };
+  const allergenEnv = {
+    ...mockEnv,
+    AI: allergenMockAI,
+    RECIPE_VECTORS: { query: vi.fn().mockResolvedValue({ matches: [] }) }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allergenMockAI.run.mockImplementation((model) => {
+      if (model === '@cf/baai/bge-small-en-v1.5') {
+        return Promise.resolve({ data: [[0.1, 0.2, 0.3]] });
+      }
+      return Promise.resolve({
+        response: {
+          name: 'Rice bowl',
+          description: 'Safe test recipe',
+          ingredients: ['2 cups rice', '1 cup carrots'],
+          instructions: ['Mix and serve'],
+          prepTime: '5 minutes',
+          cookTime: '5 minutes',
+          totalTime: '10 minutes',
+          servings: '2 servings',
+          difficulty: 'Easy',
+          dietary: []
+        }
+      });
+    });
+  });
+
+  it('fails closed without returning a generated recipe containing a hard allergen', async () => {
+    allergenMockAI.run.mockImplementation((model) => {
+      if (model === '@cf/baai/bge-small-en-v1.5') {
+        return Promise.resolve({ data: [[0.1, 0.2, 0.3]] });
+      }
+      return Promise.resolve({
+        response: {
+          name: 'Peanut satay',
+          description: 'Unsafe test recipe',
+          ingredients: ['1 cup peanuts', '2 cups rice'],
+          instructions: ['Mix and serve'],
+          prepTime: '5 minutes',
+          cookTime: '5 minutes',
+          totalTime: '10 minutes',
+          servings: '2 servings',
+          difficulty: 'Easy',
+          dietary: []
+        }
+      });
+    });
+
+    const response = await handleGenerate(createPostRequest('/generate', {
+      recipeName: 'Satay',
+      hardAllergens: ['peanut']
+    }), allergenEnv, allergenCorsHeaders);
+
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data).toMatchObject({
+      error: 'Recipe failed allergen safety validation',
+      code: 'ALLERGEN_SAFETY_BLOCK',
+      allergenSummary: {
+        checked: true,
+        blocked: ['peanuts']
+      }
+    });
+    expect(data.recipe).toBeUndefined();
+  });
+
+  it('echoes a passed allergen validation summary for safe generated recipes', async () => {
+    const response = await handleGenerate(createPostRequest('/generate', {
+      recipeName: 'Rice bowl',
+      hardAllergens: ['peanuts']
+    }), allergenEnv, allergenCorsHeaders);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.recipe).toMatchObject({
+      allergenValidation: 'PASSED',
+      allergenSummary: { checked: true, blocked: [] }
+    });
+  });
+});

--- a/recipe-recommendation-worker/src/handlers/recommendations-handler.js
+++ b/recipe-recommendation-worker/src/handlers/recommendations-handler.js
@@ -5,6 +5,7 @@
 import { log, generateRequestId } from '../../../shared/utility-functions.js';
 import { metrics, categorizeError, sendAnalytics } from '../shared-utilities.js';
 import { getRecipeRecommendations } from '../recommendation-service.js';
+import { buildGenerationConstraints } from '../../../shared/culinary-profile.js';
 
 export async function handleRecommendations(request, env, corsHeaders, requestId) {
   const startTime = Date.now();
@@ -15,6 +16,8 @@ export async function handleRecommendations(request, env, corsHeaders, requestId
     // Parse request body
     const body = await request.json();
     const { location, date, limit = 3, aiGenerated = 0 } = body; // Default limit is 3 recipes per category, 0 AI-generated
+    const constraints = buildGenerationConstraints(body.culinaryProfile || body.profile || {}, body);
+    const hardAllergens = constraints.hardAllergens;
 
     // Validate and log input parameters
     const hasLocation = location && location.trim() !== '';
@@ -40,7 +43,16 @@ export async function handleRecommendations(request, env, corsHeaders, requestId
     });
 
     // Get recommendations from the recommendation service
-    const recommendations = await getRecipeRecommendations(location, recommendationDate, recipesPerCategory, aiGeneratedCount, env, requestId);
+    const recommendationArgs = [
+      location,
+      recommendationDate,
+      recipesPerCategory,
+      aiGeneratedCount,
+      env,
+      requestId,
+    ];
+    if (hardAllergens.length > 0) recommendationArgs.push({ hardAllergens });
+    const recommendations = await getRecipeRecommendations(...recommendationArgs);
 
     const duration = Date.now() - startTime;
     metrics.timing('recommendations_duration', duration);
@@ -74,7 +86,8 @@ export async function handleRecommendations(request, env, corsHeaders, requestId
       requestId,
       processingTime: `${duration}ms`,
       recipesPerCategory,
-      aiGeneratedCount
+      aiGeneratedCount,
+      hardAllergens
     }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });

--- a/recipe-recommendation-worker/src/recommendation-service.js
+++ b/recipe-recommendation-worker/src/recommendation-service.js
@@ -6,6 +6,7 @@ import { log } from '../../shared/utility-functions.js';
 import { metrics, sendAnalytics } from './shared-utilities.js';
 import { getRecipeFromKV as getRecipeFromKVShared } from '../../shared/kv-storage.js';
 import { generateRecipeImages } from './utils/image-generator.js';
+import { isRecipeSafe, withAllergenSummary } from '../../shared/allergen-graph.js';
 
 // Generate relevant ingredients from dish name for better image generation
 function generateIngredientsFromName(dishName) {
@@ -142,7 +143,8 @@ function getContextualCategory(season, date, hasLocation) {
 }
 
 // Main recommendation function
-export async function getRecipeRecommendations(location, date, recipesPerCategory, aiGeneratedCount, env, requestId) {
+export async function getRecipeRecommendations(location, date, recipesPerCategory, aiGeneratedCount, env, requestId, options = {}) {
+  const hardAllergens = Array.isArray(options.hardAllergens) ? options.hardAllergens : [];
   const startTime = Date.now();
   
   // Check if we have AI binding
@@ -169,6 +171,9 @@ export async function getRecipeRecommendations(location, date, recipesPerCategor
   
   // Build dynamic prompt based on context
   let basePrompt = `Generate ${recipesPerCategory} recipe recommendations for each category. ${promptContext}`;
+  if (hardAllergens.length > 0) {
+    basePrompt += ` Do not recommend dishes containing these hard allergens: ${hardAllergens.join(', ')}.`;
+  }
   
   if (upcomingHoliday) {
     basePrompt += ` It's near ${upcomingHoliday}, so include holiday-appropriate recipes.`;
@@ -303,7 +308,8 @@ Make the categories relevant to the season, location, and context. Be specific w
       categoryRecommendations, 
       recipesPerCategory, 
       env, 
-      requestId
+      requestId,
+      hardAllergens
     );
 
     // Generate additional AI recipes per category if requested
@@ -321,7 +327,10 @@ Make the categories relevant to the season, location, and context. Be specific w
       Object.keys(enhancedRecommendations).forEach(category => {
         if (aiGeneratedPerCategory[category]) {
           // Add AI-generated recipe names as simple strings
-          enhancedRecommendations[category].push(...aiGeneratedPerCategory[category]);
+          const generatedRecipes = hardAllergens.length > 0
+            ? [] // Names without ingredient lists cannot be verified for hard allergens.
+            : aiGeneratedPerCategory[category];
+          enhancedRecommendations[category].push(...generatedRecipes);
         }
       });
     }
@@ -893,7 +902,7 @@ Make the dishes creative, unique, and specific to each category. Be descriptive 
 }
 
 // Enhanced recommendations with actual recipes and cross-category duplicate prevention
-export async function enhanceRecommendationsWithRecipes(categoryRecommendations, recipesPerCategory, env, requestId) {
+export async function enhanceRecommendationsWithRecipes(categoryRecommendations, recipesPerCategory, env, requestId, hardAllergens = []) {
   const startTime = Date.now();
   
   try {
@@ -907,18 +916,44 @@ export async function enhanceRecommendationsWithRecipes(categoryRecommendations,
     const globalSeenRecipeIds = new Set();
     const globalSeenRecipeNames = new Set();
     const enhancedRecommendations = {};
+
+    const filterUnsafeRecipes = (recipes) => {
+      if (!hardAllergens.length) return recipes;
+      return recipes
+        .filter((recipe) => {
+          // A recommendation without ingredient data cannot be verified safely.
+          if (!Array.isArray(recipe.ingredients) || recipe.ingredients.length === 0) {
+            log('debug', 'Excluded unverified recipe from allergen-filtered recommendations', {
+              requestId,
+              recipeId: recipe.id,
+              recipeName: recipe.name,
+            });
+            return false;
+          }
+          const safe = isRecipeSafe(recipe, hardAllergens);
+          if (!safe) {
+            log('info', 'Excluded recipe containing a hard allergen', {
+              requestId,
+              recipeId: recipe.id,
+              recipeName: recipe.name,
+            });
+          }
+          return safe;
+        })
+        .map((recipe) => withAllergenSummary(recipe, hardAllergens));
+    };
     
     // Process categories sequentially to maintain cross-category duplicate prevention
     for (const [categoryName, dishNames] of Object.entries(categoryRecommendations)) {
       try {
         // Search for recipes based on the category and dish names
-        const recipes = await searchRecipeByCategory(
+        const recipes = filterUnsafeRecipes(await searchRecipeByCategory(
           categoryName, 
           dishNames, 
           recipesPerCategory, 
           env, 
           requestId
-        );
+        ));
         
         // Filter out duplicates across categories
         const uniqueRecipes = [];
@@ -969,13 +1004,13 @@ export async function enhanceRecommendationsWithRecipes(categoryRecommendations,
           });
           
           // Try to get more recipes with different search terms
-          const additionalRecipes = await searchRecipeByCategory(
+          const additionalRecipes = filterUnsafeRecipes(await searchRecipeByCategory(
             categoryName, 
             dishNames.slice(0, Math.ceil(dishNames.length / 2)), // Use fewer terms
             recipesPerCategory - uniqueRecipes.length, 
             env, 
             requestId
-          );
+          ));
           
           // Filter additional recipes for cross-category duplicates
           for (const recipe of additionalRecipes) {
@@ -1011,8 +1046,9 @@ export async function enhanceRecommendationsWithRecipes(categoryRecommendations,
           error: error.message
         });
         
-        // Fall back to original dish names
-        enhancedRecommendations[categoryName] = dishNames.map((dish, index) => ({
+        // Fall back to original dish names only when there is no hard-allergen
+        // policy. A name-only suggestion cannot be safely verified.
+        enhancedRecommendations[categoryName] = hardAllergens.length > 0 ? [] : dishNames.map((dish, index) => ({
           id: `ai_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
           name: dish,
           description: `A delicious ${dish.toLowerCase()} perfect for ${categoryName.toLowerCase()}`,

--- a/recipe-recommendation-worker/tests/allergen-filtering.test.js
+++ b/recipe-recommendation-worker/tests/allergen-filtering.test.js
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import { enhanceRecommendationsWithRecipes } from '../src/recommendation-service.js'
+
+describe('recommendation allergen filtering', () => {
+  it('removes recipes with hard allergens and annotates verified results', async () => {
+    const storage = new Map([
+      ['recipe-peanut', JSON.stringify({ data: { ingredients: ['1 cup peanuts', 'rice'] } })],
+      ['recipe-safe', JSON.stringify({ data: { ingredients: ['rice', 'carrots'] } })],
+    ])
+    const env = {
+      SEARCH_WORKER: {
+        fetch: vi.fn().mockResolvedValue(new Response(JSON.stringify({
+          results: [
+            { id: 'recipe-peanut', properties: { title: 'Peanut bowl' } },
+            { id: 'recipe-safe', properties: { title: 'Rice bowl' } },
+          ],
+          strategy: 'test',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+      },
+      RECIPE_STORAGE: {
+        get: vi.fn((id) => Promise.resolve(storage.get(id))),
+      },
+    }
+
+    const result = await enhanceRecommendationsWithRecipes(
+      { 'Test bowls': ['peanut bowl', 'rice bowl'] },
+      2,
+      env,
+      'allergen-test',
+      ['peanuts'],
+    )
+
+    expect(result['Test bowls']).toHaveLength(1)
+    expect(result['Test bowls'][0]).toMatchObject({
+      id: 'recipe-safe',
+      name: 'Rice bowl',
+      allergenValidation: 'PASSED',
+      allergenSummary: { checked: true, blocked: [] },
+    })
+  })
+
+  it('does not return name-only fallbacks while hard allergens are active', async () => {
+    const result = await enhanceRecommendationsWithRecipes(
+      { 'Unavailable': ['peanut satay'] },
+      1,
+      { SEARCH_WORKER: { fetch: vi.fn().mockRejectedValue(new Error('offline')) } },
+      'allergen-fallback-test',
+      ['peanuts'],
+    )
+
+    expect(result).toEqual({ Unavailable: [] })
+  })
+})

--- a/shared/__tests__/allergen-graph.test.js
+++ b/shared/__tests__/allergen-graph.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  analyzeRecipeAllergens,
+  buildAllergenGraph,
+  detectAllergens,
+  enforceAllergenSafety,
+  isRecipeSafe,
+  normalizeAllergenList,
+} from '../allergen-graph.js'
+
+describe('allergen graph', () => {
+  it('normalizes canonical ids and common profile aliases', () => {
+    expect(normalizeAllergenList(['dairy', 'tree nuts', 'peanut', 'gluten', 'sesame']))
+      .toEqual(['milk', 'tree_nuts', 'peanuts', 'wheat', 'sesame'])
+  })
+
+  it('detects Big 9 allergens from ingredient phrases', () => {
+    const matches = detectAllergens([
+      '1 cup almond milk',
+      '2 tablespoons tahini',
+      '1 tablespoon soy sauce',
+      '1 cup wheat flour',
+      '1 egg',
+    ])
+
+    expect(matches.map((match) => match.allergen)).toEqual(expect.arrayContaining([
+      'tree_nuts',
+      'sesame',
+      'soy',
+      'wheat',
+      'eggs',
+    ]))
+    expect(matches.find((match) => match.allergen === 'sesame')).toMatchObject({
+      matchedTerm: 'tahini',
+      confidence: 'high',
+    })
+  })
+
+  it('does not classify plant milk as dairy milk', () => {
+    const matches = detectAllergens(['2 cups coconut milk', '1 cup oat milk'])
+    expect(matches.map((match) => match.allergen)).not.toContain('milk')
+  })
+
+  it('builds explainable nodes and ingredient edges', () => {
+    const graph = buildAllergenGraph({ ingredients: ['1 tablespoon peanut butter'] })
+    expect(graph.nodes).toEqual([{ id: 'peanuts', label: 'Peanuts' }])
+    expect(graph.edges[0]).toMatchObject({
+      from: '1 tablespoon peanut butter',
+      to: 'peanuts',
+      matchedTerm: 'peanut butter',
+    })
+  })
+
+  it('reports blocked and uncertain ingredients for hard-allergen profiles', () => {
+    const summary = analyzeRecipeAllergens({
+      ingredients: ['1 cup vegetable broth', '2 cups rice'],
+    }, ['peanuts'])
+
+    expect(summary.checked).toBe(true)
+    expect(summary.safe).toBe(false)
+    expect(summary.blocked).toEqual([])
+    expect(summary.may_contain_uncertain).toEqual(['1 cup vegetable broth'])
+  })
+
+  it('fails closed when hard-allergen checks have no ingredient data', () => {
+    const summary = analyzeRecipeAllergens({ name: 'Incomplete recipe' }, ['peanuts'])
+    expect(summary.ingredient_data_available).toBe(false)
+    expect(summary.safe).toBe(false)
+    expect(() => enforceAllergenSafety({ name: 'Incomplete recipe' }, ['peanuts']))
+      .toThrow(/allergen safety validation/)
+  })
+
+  it('fails closed for a matched hard allergen and passes safe recipes', () => {
+    expect(isRecipeSafe({ ingredients: ['2 cups rice', '1 cup carrots'] }, ['peanuts'])).toBe(true)
+    expect(isRecipeSafe({ ingredients: ['2 tablespoons peanut butter'] }, ['peanuts'])).toBe(false)
+
+    expect(() => enforceAllergenSafety({ ingredients: ['peanuts'] }, ['peanuts']))
+      .toThrow(/allergen safety validation/)
+
+    const safeRecipe = enforceAllergenSafety({ ingredients: ['rice'] }, ['peanuts'])
+    expect(safeRecipe).toMatchObject({ allergenValidation: 'PASSED' })
+    expect(safeRecipe.allergenSummary).toMatchObject({ checked: true, blocked: [] })
+  })
+
+  it('supports nested KV recipe data', () => {
+    expect(isRecipeSafe({ data: { ingredients: ['1 cup milk'] } }, ['milk'])).toBe(false)
+  })
+})

--- a/shared/allergen-graph.js
+++ b/shared/allergen-graph.js
@@ -1,0 +1,281 @@
+/**
+ * Shared allergen detection and safety helpers.
+ *
+ * This module intentionally uses a conservative, explainable ingredient graph
+ * instead of treating a model's dietary label as proof of safety. It is used
+ * at the boundary where generated or recommended recipes are returned.
+ */
+
+import { HARD_ALLERGENS } from './culinary-profile.js'
+
+export const ALLERGEN_LABELS = Object.freeze({
+  milk: 'Milk',
+  eggs: 'Eggs',
+  fish: 'Fish',
+  shellfish: 'Shellfish',
+  tree_nuts: 'Tree nuts',
+  peanuts: 'Peanuts',
+  wheat: 'Wheat',
+  soy: 'Soy',
+  sesame: 'Sesame',
+})
+
+const ALLERGEN_ALIASES = Object.freeze({
+  dairy: 'milk',
+  milk: 'milk',
+  egg: 'eggs',
+  eggs: 'eggs',
+  fish: 'fish',
+  seafood: 'shellfish',
+  shellfish: 'shellfish',
+  'tree nut': 'tree_nuts',
+  'tree nuts': 'tree_nuts',
+  treenut: 'tree_nuts',
+  treenuts: 'tree_nuts',
+  peanut: 'peanuts',
+  peanuts: 'peanuts',
+  wheat: 'wheat',
+  gluten: 'wheat',
+  soy: 'soy',
+  soybean: 'soy',
+  soybeans: 'soy',
+  sesame: 'sesame',
+})
+
+/** Common ingredient terms that imply an FDA major allergen. */
+const ALLERGEN_TERMS = Object.freeze({
+  milk: [
+    'milk', 'dairy', 'butter', 'ghee', 'cheese', 'cream', 'whey', 'casein',
+    'lactose', 'buttermilk', 'yogurt', 'yoghurt', 'curd', 'kefir',
+    'mozzarella', 'parmesan', 'ricotta', 'cheddar', 'brie', 'mascarpone',
+    'sour cream', 'half-and-half', 'ice cream',
+  ],
+  eggs: ['egg', 'eggs', 'albumin', 'ovalbumin', 'mayonnaise', 'meringue'],
+  fish: [
+    'fish', 'salmon', 'tuna', 'cod', 'anchovy', 'anchovies', 'sardine',
+    'sardines', 'tilapia', 'trout', 'haddock', 'pollock', 'fish sauce',
+    'worcestershire sauce',
+  ],
+  shellfish: [
+    'shellfish', 'shrimp', 'prawn', 'prawns', 'crab', 'lobster', 'crawfish',
+    'crayfish', 'scallop', 'scallops', 'mussel', 'mussels', 'oyster', 'oysters',
+    'clam', 'clams',
+  ],
+  tree_nuts: [
+    'almond', 'almonds', 'walnut', 'walnuts', 'pecan', 'pecans', 'cashew',
+    'cashews', 'pistachio', 'pistachios', 'hazelnut', 'hazelnuts', 'macadamia',
+    'brazil nut', 'pine nut', 'pine nuts', 'nut butter', 'marzipan', 'praline',
+  ],
+  peanuts: ['peanut', 'peanuts', 'groundnut', 'groundnuts', 'arachis', 'peanut butter'],
+  wheat: [
+    'wheat', 'gluten', 'flour', 'bread', 'pasta', 'semolina', 'couscous',
+    'seitan', 'panko', 'breadcrumb', 'breadcrumbs', 'malt', 'farina',
+  ],
+  soy: [
+    'soy', 'soya', 'soybean', 'soybeans', 'tofu', 'tempeh', 'edamame', 'miso',
+    'tamari', 'soy sauce', 'lecithin',
+  ],
+  sesame: ['sesame', 'tahini', 'benne', 'gomasio', 'sesame oil', 'sesame seed', 'sesame seeds'],
+})
+
+const UNCERTAIN_TERMS = Object.freeze([
+  /\bmay contain\b/i,
+  /\bprocessed in a facility\b/i,
+  /\bshared equipment\b/i,
+  /\bnatural flavors?\b/i,
+  /\bartificial flavors?\b/i,
+  /\bspice blend\b/i,
+  /\bseasoning blend\b/i,
+  /\bbouillon\b/i,
+  /\b(?:chicken|beef|vegetable) stock\b/i,
+  /\b(?:chicken|beef|vegetable) broth\b/i,
+  /\bprotein powder\b/i,
+])
+
+const KNOWN_ALLERGENS = new Set(HARD_ALLERGENS)
+
+function normalizeText(value) {
+  return typeof value === 'string'
+    ? value.trim().toLowerCase().replace(/[\u2019']/g, '').replace(/[\s-]+/g, ' ')
+    : ''
+}
+
+function normalizeKey(value) {
+  return normalizeText(value).replace(/[^a-z0-9_ ]/g, '').replace(/\s+/g, '_')
+}
+
+/** Normalize canonical IDs and the aliases accepted by culinary profiles. */
+export function normalizeAllergen(value) {
+  const text = normalizeText(value)
+  if (!text) return null
+  return ALLERGEN_ALIASES[text] || ALLERGEN_ALIASES[text.replace(/_/g, ' ')] || normalizeKey(text)
+}
+
+/** Normalize and de-duplicate a hard-allergen list without dropping custom tags. */
+export function normalizeAllergenList(value) {
+  if (!Array.isArray(value)) return []
+  return value
+    .map(normalizeAllergen)
+    .filter(Boolean)
+    .filter((item, index, items) => items.indexOf(item) === index)
+}
+
+function toIngredientLines(recipeOrIngredients) {
+  if (Array.isArray(recipeOrIngredients)) {
+    return recipeOrIngredients.filter((item) => typeof item === 'string' && item.trim())
+  }
+  if (!recipeOrIngredients || typeof recipeOrIngredients !== 'object') return []
+
+  const lines = []
+  for (const field of ['ingredients', 'sourceIngredients']) {
+    if (Array.isArray(recipeOrIngredients[field])) {
+      lines.push(...recipeOrIngredients[field])
+    }
+  }
+  if (recipeOrIngredients.data && typeof recipeOrIngredients.data === 'object') {
+    lines.push(...toIngredientLines(recipeOrIngredients.data))
+  }
+  return lines.filter((item) => typeof item === 'string' && item.trim())
+}
+
+function termPattern(term) {
+  const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+')
+  return new RegExp(`(?:^|[^a-z])${escaped}(?:$|[^a-z])`, 'i')
+}
+
+const TERM_PATTERNS = Object.freeze(Object.fromEntries(
+  Object.entries(ALLERGEN_TERMS).map(([allergen, terms]) => [
+    allergen,
+    terms
+      .map((term) => ({ term, pattern: termPattern(term) }))
+      .sort((left, right) => right.term.length - left.term.length),
+  ]),
+))
+
+function isPlantMilkException(line, term, allergen) {
+  if (allergen !== 'milk') return false
+  if (term === 'milk') {
+    return /\b(?:almond|coconut|oat|rice|hemp|pea|cashew)\s+milk\b/i.test(line)
+  }
+  if (term === 'butter') {
+    return /\b(?:peanut|almond|cashew|sunflower|seed)\s+butter\b/i.test(line)
+  }
+  return false
+}
+
+/**
+ * Detect known allergens in ingredient lines. Matches are intentionally
+ * explainable so a UI or audit log can show the exact ingredient and term.
+ */
+export function detectAllergens(recipeOrIngredients) {
+  const lines = toIngredientLines(recipeOrIngredients)
+  const matches = []
+
+  for (const [allergen, terms] of Object.entries(TERM_PATTERNS)) {
+    for (const line of lines) {
+      for (const { term, pattern } of terms) {
+        if (!pattern.test(line) || isPlantMilkException(line, term, allergen)) continue
+        matches.push({
+          allergen,
+          label: ALLERGEN_LABELS[allergen],
+          ingredient: line,
+          matchedTerm: term,
+          confidence: 'high',
+        })
+      }
+    }
+  }
+
+  return matches.filter((match, index, items) => items.findIndex((candidate) =>
+    candidate.allergen === match.allergen && candidate.ingredient === match.ingredient
+  ) === index)
+}
+
+function findUncertainIngredients(recipeOrIngredients) {
+  const lines = toIngredientLines(recipeOrIngredients)
+  return lines.filter((line) => UNCERTAIN_TERMS.some((pattern) => pattern.test(line)))
+}
+
+/**
+ * Build the allergen graph for a recipe. Nodes represent canonical allergen
+ * IDs and edges explain which ingredient line caused each node to be present.
+ */
+export function buildAllergenGraph(recipeOrIngredients) {
+  const matches = detectAllergens(recipeOrIngredients)
+  const nodes = [...new Set(matches.map((match) => match.allergen))].map((id) => ({
+    id,
+    label: ALLERGEN_LABELS[id] || id,
+  }))
+  const edges = matches.map((match) => ({
+    from: match.ingredient,
+    to: match.allergen,
+    matchedTerm: match.matchedTerm,
+    confidence: match.confidence,
+  }))
+  return { nodes, edges }
+}
+
+/**
+ * Analyze a recipe against a user's hard allergen list. Unknown custom hard
+ * allergens and opaque ingredient terms fail closed when any hard allergen is
+ * configured; they must be reviewed rather than silently passed through.
+ */
+export function analyzeRecipeAllergens(recipeOrIngredients, hardAllergens = []) {
+  const hard = normalizeAllergenList(hardAllergens)
+  const matches = detectAllergens(recipeOrIngredients)
+  const contains = [...new Set(matches.map((match) => match.allergen))]
+  const blocked = contains.filter((allergen) => hard.includes(allergen))
+  const ingredientLines = toIngredientLines(recipeOrIngredients)
+  const mayContainUncertain = findUncertainIngredients(recipeOrIngredients)
+  const unknownHardAllergens = hard.filter((allergen) => !KNOWN_ALLERGENS.has(allergen))
+
+  return {
+    checked: true,
+    ingredient_data_available: ingredientLines.length > 0,
+    safe: hard.length === 0 || (ingredientLines.length > 0 && blocked.length === 0 && mayContainUncertain.length === 0 && unknownHardAllergens.length === 0),
+    contains,
+    blocked,
+    matches,
+    may_contain_uncertain: mayContainUncertain,
+    unknown_hard_allergens: unknownHardAllergens,
+  }
+}
+
+export function isRecipeSafe(recipeOrIngredients, hardAllergens = []) {
+  return analyzeRecipeAllergens(recipeOrIngredients, hardAllergens).safe
+}
+
+/** Add the machine-readable safety result to a recipe without mutating it. */
+export function withAllergenSummary(recipe, hardAllergens = []) {
+  const allergenSummary = analyzeRecipeAllergens(recipe, hardAllergens)
+  return {
+    ...recipe,
+    allergenSummary,
+    allergenValidation: allergenSummary.safe ? 'PASSED' : 'FAILED',
+  }
+}
+
+export class AllergenSafetyError extends Error {
+  constructor(summary) {
+    const blocked = summary.blocked.length > 0
+      ? `blocked allergens: ${summary.blocked.join(', ')}`
+      : 'ingredient safety could not be verified'
+    super(`Recipe failed allergen safety validation (${blocked})`)
+    this.name = 'AllergenSafetyError'
+    this.code = 'ALLERGEN_SAFETY_BLOCK'
+    this.status = 422
+    this.summary = summary
+  }
+}
+
+/**
+ * Annotate a recipe and throw before it crosses an API boundary if it is not
+ * safe for the configured hard allergens.
+ */
+export function enforceAllergenSafety(recipe, hardAllergens = []) {
+  const annotated = withAllergenSummary(recipe, hardAllergens)
+  if (!annotated.allergenSummary.safe && normalizeAllergenList(hardAllergens).length > 0) {
+    throw new AllergenSafetyError(annotated.allergenSummary)
+  }
+  return annotated
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -13,7 +13,8 @@
     "./nutrition": "./nutrition-calculator.js",
     "./metrics-collector": "./metrics-collector.js",
     "./metrics": "./metrics-collector.js",
-    "./culinary-profile": "./culinary-profile.js"
+    "./culinary-profile": "./culinary-profile.js",
+    "./allergen-graph": "./allergen-graph.js"
   },
   "scripts": {
     "test": "node test-simple.js",


### PR DESCRIPTION
## Summary
- Implements the core safety slice for the highest-priority open P0 safety issue (#298).
- Adds a shared, explainable Big-9 + sesame allergen graph with aliases, uncertainty detection, nested recipe support, and fail-closed enforcement.
- Filters unsafe retrieval context and recommendation results, omitting unverified name-only fallbacks when hard allergens are active.
- Adds generation/elevation API safety validation (HTTP 422, no unsafe recipe in the response) and a recipe-card trust notice.
- Documents the safety flow and extension/testing guidance.

Related to #298.

## Validation
- `npx vitest run` in `shared`: 75 passed.
- `npm run lint` in `recipe-generation-worker`: 0 errors (existing no-console warnings).
- `npx vitest run` in `recipe-generation-worker`: 169 passed.
- `npx vitest run` in `recipe-recommendation-worker`: 194 passed, 11 skipped.
- `npm test -- --runInBand` in `recipe-app`: 355 passed.
- `npm run build` in `recipe-app`: passed.

Note: the shared package's legacy default `npm test` invokes `test-simple.js`, which has a pre-existing invalid-base64 decompression failure; the full Vitest suite passes.