### PR TITLE
feat(recipe): add constraint-preserving RecipeAdapt

### DIFF
--- a/recipe-app/src/AdaptComposer.jsx
+++ b/recipe-app/src/AdaptComposer.jsx
@@ -1,0 +1,218 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+const DIET_OPTIONS = [
+  ['dairy_free', 'Dairy-free'],
+  ['gluten_free', 'Gluten-free'],
+  ['vegan', 'Vegan'],
+  ['vegetarian', 'Vegetarian'],
+  ['keto', 'Lower carb'],
+]
+
+const EQUIPMENT_OPTIONS = [
+  ['air_fryer', 'Air fryer'],
+  ['oven', 'Oven'],
+  ['stovetop', 'Stovetop'],
+  ['instant_pot', 'Instant Pot'],
+  ['grill', 'Grill'],
+]
+
+const QUICK_ADAPTATIONS = [
+  { label: 'Dairy-free', dietary: 'dairy_free' },
+  { label: 'Gluten-free', dietary: 'gluten_free' },
+  { label: 'Higher protein', nutritionFocus: 'high_protein' },
+  { label: '30 minutes', maxCookTime: 30 },
+  { label: 'Air fryer', equipment: 'air_fryer' },
+  { label: 'Kid-mild', spiceLevel: 1 },
+]
+
+function initialForm(profile) {
+  return {
+    dietary: [],
+    equipment: [],
+    servings: profile?.default_servings ?? 4,
+    maxCookTime: profile?.max_cook_time_min ?? 60,
+    nutritionFocus: '',
+    spiceLevel: profile?.spice_level ?? 2,
+    excludeIngredients: '',
+    preserveNote: '',
+  }
+}
+
+function toggleValue(values, value) {
+  return values.includes(value)
+    ? values.filter((item) => item !== value)
+    : [...values, value]
+}
+
+function commaSeparated(value) {
+  return String(value || '').split(',').map((item) => item.trim()).filter(Boolean)
+}
+
+export default function AdaptComposer({ open, recipe, profile, busy, onClose, onAdapt }) {
+  const [form, setForm] = useState(() => initialForm(profile))
+  const firstFieldRef = useRef(null)
+
+  useEffect(() => {
+    if (!open) return
+    setForm(initialForm(profile))
+    const focusFirstField = () => firstFieldRef.current?.focus()
+    if (typeof window !== 'undefined' && window.requestAnimationFrame) {
+      window.requestAnimationFrame(focusFirstField)
+    } else {
+      focusFirstField()
+    }
+  }, [open, profile, recipe])
+
+  useEffect(() => {
+    if (!open) return undefined
+    function handleKeyDown(event) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  if (!open || !recipe) return null
+
+  function setField(field, value) {
+    setForm((current) => ({ ...current, [field]: value }))
+  }
+
+  function applyQuickAdaptation(adaptation) {
+    setForm((current) => {
+      const next = { ...current }
+      if (adaptation.dietary) next.dietary = toggleValue(current.dietary, adaptation.dietary)
+      if (adaptation.nutritionFocus) next.nutritionFocus = adaptation.nutritionFocus
+      if (adaptation.maxCookTime) next.maxCookTime = adaptation.maxCookTime
+      if (adaptation.equipment) next.equipment = toggleValue(current.equipment, adaptation.equipment)
+      if (adaptation.spiceLevel !== undefined) next.spiceLevel = adaptation.spiceLevel
+      return next
+    })
+  }
+
+  function submit(event) {
+    event.preventDefault()
+    onAdapt({
+      dietary: form.dietary,
+      equipment: form.equipment,
+      servings: Number(form.servings),
+      maxCookTime: Number(form.maxCookTime),
+      spiceLevel: Number(form.spiceLevel),
+      nutritionGoals: form.nutritionFocus ? { focus: form.nutritionFocus } : undefined,
+      excludeIngredients: commaSeparated(form.excludeIngredients),
+      preserve: form.preserveNote.trim() ? [form.preserveNote.trim()] : [],
+    })
+  }
+
+  return (
+    <div
+      className="generation-composer-backdrop"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <section className="generation-composer-sheet" role="dialog" aria-modal="true" aria-labelledby="adapt-composer-title">
+        <div className="generation-composer-header">
+          <div>
+            <p className="generation-composer-eyebrow">RecipeAdapt</p>
+            <h2 id="adapt-composer-title">Make {recipe.name} work for you</h2>
+            <p>Keep the dish recognizable while changing what does not fit your kitchen.</p>
+          </div>
+          <button type="button" className="generation-composer-close" aria-label="Close recipe adaptation" onClick={onClose}>×</button>
+        </div>
+
+        <div className="generation-composer-profile" role="status">
+          <strong>Quick adaptations</strong>
+          <div className="generation-composer-options">
+            {QUICK_ADAPTATIONS.map((adaptation) => (
+              <button
+                key={adaptation.label}
+                type="button"
+                className="generation-composer-check"
+                onClick={() => applyQuickAdaptation(adaptation)}
+              >
+                {adaptation.label}
+              </button>
+            ))}
+          </div>
+          {profile?.hard_allergens?.length > 0 && (
+            <span className="generation-composer-safety">Hard allergens protected: {profile.hard_allergens.join(', ')}</span>
+          )}
+        </div>
+
+        <form onSubmit={submit}>
+          <fieldset>
+            <legend>Constraints</legend>
+            <div className="generation-composer-options">
+              {DIET_OPTIONS.map(([value, label]) => (
+                <label key={value} className="generation-composer-check">
+                  <input
+                    type="checkbox"
+                    checked={form.dietary.includes(value)}
+                    onChange={() => setField('dietary', toggleValue(form.dietary, value))}
+                  />
+                  {label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div className="generation-composer-grid">
+            <label>
+              Servings
+              <input ref={firstFieldRef} type="number" min="1" max="24" value={form.servings} onChange={(event) => setField('servings', event.target.value)} />
+            </label>
+            <label>
+              Max time (minutes)
+              <input type="number" min="5" max="720" value={form.maxCookTime} onChange={(event) => setField('maxCookTime', event.target.value)} />
+            </label>
+            <label>
+              Nutrition focus
+              <select value={form.nutritionFocus} onChange={(event) => setField('nutritionFocus', event.target.value)}>
+                <option value="">No change</option>
+                <option value="high_protein">Higher protein</option>
+                <option value="low_sodium">Lower sodium</option>
+                <option value="lower_carb">Lower carb</option>
+              </select>
+            </label>
+            <label>
+              Spice level (0–5)
+              <input type="number" min="0" max="5" value={form.spiceLevel} onChange={(event) => setField('spiceLevel', event.target.value)} />
+            </label>
+          </div>
+
+          <fieldset>
+            <legend>Available equipment</legend>
+            <div className="generation-composer-options">
+              {EQUIPMENT_OPTIONS.map(([value, label]) => (
+                <label key={value} className="generation-composer-check">
+                  <input type="checkbox" checked={form.equipment.includes(value)} onChange={() => setField('equipment', toggleValue(form.equipment, value))} />
+                  {label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <label className="generation-composer-field">
+            Exclude ingredients
+            <input type="text" value={form.excludeIngredients} onChange={(event) => setField('excludeIngredients', event.target.value)} placeholder="cilantro, mushrooms" />
+          </label>
+          <label className="generation-composer-field">
+            Keep this detail
+            <input type="text" value={form.preserveNote} onChange={(event) => setField('preserveNote', event.target.value)} placeholder="the miso glaze, crispy edges…" />
+          </label>
+
+          <p className="generation-composer-disclaimer">Adapted recipes include a change list and remain linked to the original. AI can make mistakes; always verify ingredients and labels.</p>
+          <div className="generation-composer-actions">
+            <button type="button" className="generation-composer-secondary" onClick={onClose}>Cancel</button>
+            <button type="submit" className="generation-composer-primary" disabled={busy}>{busy ? 'Adapting…' : 'Adapt recipe'}</button>
+          </div>
+        </form>
+      </section>
+    </div>
+  )
+}

--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -10,6 +10,7 @@ import { useMealPlan } from './MealPlanContext.jsx'
 import { syncFlagglyUser, useFlag } from './flaggly.js'
 import CulinaryProfile from './CulinaryProfile.jsx'
 import GenerationComposer from './GenerationComposer.jsx'
+import AdaptComposer from './AdaptComposer.jsx'
 import { useCulinaryProfile } from './useCulinaryProfile.js'
 
 const SEARCH_DB_URL = import.meta.env.VITE_SEARCH_DB_URL
@@ -228,14 +229,23 @@ export function buildGenerationRequest({
   return body
 }
 
+export function buildAdaptRequest({ baseRecipe, profile = null, overrides = null }) {
+  const body = { baseRecipe }
+  if (profile) body.culinaryProfile = profile
+  if (overrides) body.constraints = overrides
+  return body
+}
+
 export default function App() {
   const auth = useAuth()
   const { activeRecipe, setActiveRecipe, clearActiveRecipe } = useMealPlan()
   const mealPlannerEnabled = useFlag('meal-planner')
   const culinaryProfileEnabled = useFlag('culinary-profile')
   const constraintGenerateEnabled = useFlag('constraint-generate')
+  const recipeAdaptEnabled = useFlag('recipe-adapt')
   const [profileOpen, setProfileOpen] = useState(false)
   const [generationComposerOpen, setGenerationComposerOpen] = useState(false)
+  const [adaptComposerOpen, setAdaptComposerOpen] = useState(false)
   const culinaryProfile = useCulinaryProfile(auth.token, culinaryProfileEnabled)
 
   useEffect(() => {
@@ -244,7 +254,7 @@ export default function App() {
   }, [auth.loading, auth.user])
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [input, setInput] = useState('')
-  const [status, setStatus] = useState('idle') // idle | searching | clipping | generating | elevating | error
+  const [status, setStatus] = useState('idle') // idle | searching | clipping | generating | elevating | adapting | error
   const [errorMsg, setErrorMsg] = useState('')
   const [generationRetry, setGenerationRetry] = useState(null)
   const [searchResults, setSearchResults] = useState([])
@@ -357,8 +367,8 @@ export default function App() {
     return () => document.removeEventListener('mousedown', handleClick)
   }, [cancelDebouncedSearch])
 
-  const busy = status === 'searching' || status === 'clipping' || status === 'generating' || status === 'elevating'
-  const inputBusy = status === 'clipping' || status === 'generating' || status === 'elevating'
+  const busy = status === 'searching' || status === 'clipping' || status === 'generating' || status === 'elevating' || status === 'adapting'
+  const inputBusy = status === 'clipping' || status === 'generating' || status === 'elevating' || status === 'adapting'
 
   // Restore focus after a blocking async action completes, but don't steal focus
   // from elements the user has intentionally focused.
@@ -569,6 +579,69 @@ export default function App() {
     setStatus('idle')
   }
 
+  async function doAdapt(baseRecipe, overrides = null) {
+    invalidateSearch()
+    setGenerationRetry({ mode: 'adapt', recipe: baseRecipe, overrides })
+    latestInputRef.current = ''
+    setGeneratingName(baseRecipe.name)
+    setInput('')
+    setStatus('adapting')
+    setShowDropdown(false)
+    setSaveState('idle')
+    try {
+      const body = buildAdaptRequest({
+        baseRecipe,
+        profile: culinaryProfileEnabled ? culinaryProfile.profile : null,
+        overrides,
+      })
+      const res = await fetch(`${RECIPE_GENERATION_URL}/adapt`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) throw new Error(`Adaptation failed: ${res.status}`)
+      const data = await res.json()
+      if (!data.success || !data.recipe) throw new Error(data.error || 'Adaptation returned no recipe')
+
+      const r = data.recipe
+      const adaptedRecipe = {
+        id: `adapt-${Date.now()}`,
+        source: 'adapted',
+        name: r.name || baseRecipe.name,
+        description: r.description || baseRecipe.description || '',
+        image: r.image_url || r.image || baseRecipe.image || '',
+        prep_time: r.prepTime || r.prep_time || baseRecipe.prep_time || null,
+        cook_time: r.cookTime || r.cook_time || baseRecipe.cook_time || null,
+        recipe_yield: r.servings || r.recipe_yield || baseRecipe.recipe_yield || null,
+        ingredients: r.ingredients || baseRecipe.ingredients || [],
+        instructions: r.instructions || baseRecipe.instructions || [],
+        source_url: r.source_url || baseRecipe.source_url || '',
+        dietary: r.dietary || baseRecipe.dietary || [],
+        appliedConstraints: data.appliedConstraints || r.appliedConstraints || null,
+        allergenSummary: r.allergenSummary || null,
+        adapted_from: r.adapted_from || baseRecipe.id || baseRecipe.source_url || null,
+        adaptation_constraints: r.adaptation_constraints || data.appliedConstraints || null,
+        substitutions: r.substitutions || [],
+        adaptationNotes: r.adaptationNotes || [],
+      }
+      setActiveRecipe(adaptedRecipe)
+      addRecentRecipe(adaptedRecipe)
+      setGenerationRetry(null)
+      setGeneratingName('')
+    } catch (e) {
+      setGeneratingName('')
+      setErrorMsg(e.message)
+      setStatus('error')
+      return
+    }
+    setStatus('idle')
+  }
+
+  function handleAdapt(overrides) {
+    setAdaptComposerOpen(false)
+    if (activeRecipe) doAdapt(activeRecipe, overrides)
+  }
+
   function handleTunedGenerate(overrides) {
     setGenerationComposerOpen(false)
     doGenerate(input.trim(), { overrides })
@@ -695,7 +768,9 @@ export default function App() {
   // --- Save ---
   async function doSave(r) {
     setSaveState('saving')
-    const recipeUrl = r.source_url || `https://seasoned.app/ai/${r.id}`
+    const recipeUrl = r.source === 'adapted'
+      ? `https://seasoned.app/adapted/${r.id}`
+      : r.source_url || `https://seasoned.app/ai/${r.id}`
     try {
       const res = await fetch(`${API_URL}/recipe/save`, {
         method: 'POST',
@@ -711,6 +786,11 @@ export default function App() {
             servings: r.recipe_yield || null,
             ingredients: r.ingredients || [],
             instructions: r.instructions || [],
+            source: r.source || null,
+            adapted_from: r.adapted_from || null,
+            adaptation_constraints: r.adaptation_constraints || null,
+            substitutions: r.substitutions || [],
+            adaptationNotes: r.adaptationNotes || [],
           },
           options: { overwrite: false },
         }),
@@ -892,7 +972,9 @@ export default function App() {
                 <button
                   type="button"
                   className="error-retry"
-                  onClick={() => doGenerate(generationRetry.query, generationRetry.options)}
+                  onClick={() => generationRetry.mode === 'adapt'
+                    ? doAdapt(generationRetry.recipe, generationRetry.overrides)
+                    : doGenerate(generationRetry.query, generationRetry.options)}
                 >
                   Retry generation
                 </button>
@@ -991,17 +1073,28 @@ export default function App() {
           onGenerate={handleTunedGenerate}
         />
 
-        {(status === 'generating' || status === 'elevating') && generatingName && (
+        <AdaptComposer
+          open={adaptComposerOpen && recipeAdaptEnabled && Boolean(activeRecipe)}
+          recipe={activeRecipe}
+          profile={culinaryProfile.profile}
+          busy={status === 'adapting'}
+          onClose={() => setAdaptComposerOpen(false)}
+          onAdapt={handleAdapt}
+        />
+
+        {(status === 'generating' || status === 'elevating' || status === 'adapting') && generatingName && (
           <GeneratingCard dishName={generatingName} />
         )}
 
         {/* Recipe card */}
-        {activeRecipe && !(status === 'generating') && (
+        {activeRecipe && !['generating', 'adapting'].includes(status) && (
           <RecipeCard
             recipe={activeRecipe}
             onClose={handleClose}
             onElevate={() => doGenerate(activeRecipe.name, { elevate: true, baseRecipe: activeRecipe })}
+            onAdapt={recipeAdaptEnabled ? () => setAdaptComposerOpen(true) : undefined}
             isElevating={status === 'elevating'}
+            isAdapting={status === 'adapting'}
             onSave={() => doSave(activeRecipe)}
             saveState={saveState}
             shareUrl={shareUrl}

--- a/recipe-app/src/RecipeCard.jsx
+++ b/recipe-app/src/RecipeCard.jsx
@@ -18,8 +18,9 @@ function parseDurationToMinutes(val) {
   return mins
 }
 
-export default function RecipeCard({ recipe, onClose, onElevate, isElevating, onSave, saveState, shareUrl }) {
+export default function RecipeCard({ recipe, onClose, onElevate, onAdapt, isElevating, isAdapting = false, onSave, saveState, shareUrl }) {
   const elevateRecipeEnabled = useFlag('elevate-recipe')
+  const recipeAdaptEnabled = useFlag('recipe-adapt')
   const mealPlannerEnabled = useFlag('meal-planner')
   const [shareCopied, setShareCopied] = useState(false)
   const [isCooking, setIsCooking] = useState(false)
@@ -160,7 +161,7 @@ export default function RecipeCard({ recipe, onClose, onElevate, isElevating, on
     <div className="recipe-card">
       <div className="card-menus" ref={menusRef}>
         {/* Remix menu */}
-        {elevateRecipeEnabled && (
+        {(elevateRecipeEnabled || (recipeAdaptEnabled && onAdapt)) && (
         <div className="action-menu">
           <button
             ref={(node) => { menuTriggerRefs.current.remix = node }}
@@ -196,6 +197,27 @@ export default function RecipeCard({ recipe, onClose, onElevate, isElevating, on
                 )}
                 {isElevating ? 'Elevating…' : 'Elevate'}
               </button>
+              {recipeAdaptEnabled && onAdapt && (
+                <button
+                  className="action-menu-item adapt-item"
+                  role="menuitem"
+                  onClick={() => { if (!isAdapting) { onAdapt(); closeMenu({ restoreFocus: true }); } }}
+                  disabled={isAdapting}
+                  title="Adapt this recipe to your diet, time, or equipment"
+                >
+                  {isAdapting ? (
+                    <svg className="spinner" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M21 12a9 9 0 11-6.219-8.56"/>
+                    </svg>
+                  ) : (
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M4 7h16M4 12h10M4 17h16"/>
+                      <circle cx="17" cy="12" r="2"/>
+                    </svg>
+                  )}
+                  {isAdapting ? 'Adapting…' : 'Adapt'}
+                </button>
+              )}
             </div>
           )}
         </div>

--- a/recipe-app/src/RecipeCardDisplay.jsx
+++ b/recipe-app/src/RecipeCardDisplay.jsx
@@ -17,6 +17,7 @@ const sourceBadgeMap = {
   clipped: { label: 'Clipped', color: '#5bb87a' },
   ai_generated: { label: 'AI Generated', color: '#c8a96e' },
   elevated: { label: 'Elevated', color: '#e8c87a' },
+  adapted: { label: 'Adapted', color: '#7fbf91' },
   youtube: { label: 'YouTube', color: '#ff0000' },
 }
 
@@ -114,6 +115,28 @@ export default function RecipeCardDisplay({ recipe, onCookClick, cookBtnId }) {
             <span key={label} className="applied-constraint-chip">{label}</span>
           ))}
         </div>
+      )}
+
+      {(recipe.substitutions?.length > 0 || recipe.adaptationNotes?.length > 0) && (
+        <section className="adaptation-summary" aria-label="Recipe adaptation details">
+          <h3>What changed</h3>
+          {recipe.substitutions?.length > 0 && (
+            <ul className="adaptation-substitutions">
+              {recipe.substitutions.map((change, index) => (
+                <li key={`${change.from || 'change'}-${index}`}>
+                  <strong>{change.from}</strong> → {change.to}
+                  {change.reason && <span>{change.reason}</span>}
+                </li>
+              ))}
+            </ul>
+          )}
+          {recipe.adaptationNotes?.length > 0 && (
+            <ul className="adaptation-notes">
+              {recipe.adaptationNotes.map((note, index) => <li key={`${note}-${index}`}>{note}</li>)}
+            </ul>
+          )}
+          {recipe.adapted_from && <p className="adaptation-lineage">Adapted from the original recipe.</p>}
+        </section>
       )}
 
       <div className="recipe-body">

--- a/recipe-app/src/__tests__/App.test.jsx
+++ b/recipe-app/src/__tests__/App.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import App, { buildGenerationRequest } from '../App';
+import App, { buildGenerationRequest, buildAdaptRequest } from '../App';
 import { MealPlanProvider } from '../MealPlanContext.jsx';
 
 // Wrap App in the providers it requires (MealPlanProvider lives in main.jsx in production)
@@ -99,6 +99,21 @@ const GENERATE_RESPONSE = {
     instructions: ['Beat eggs.', 'Cook in butter.'],
   },
 };
+
+describe('Adaptation request builder', () => {
+  test('keeps the complete base recipe and sends profile plus explicit constraints', () => {
+    const baseRecipe = { id: 'recipe-1', name: 'Pasta', ingredients: ['pasta'], instructions: ['Cook pasta'] }
+    expect(buildAdaptRequest({
+      baseRecipe,
+      profile: { hard_allergens: ['milk'] },
+      overrides: { dietary: ['dairy_free'], maxCookTime: 30 },
+    })).toEqual({
+      baseRecipe,
+      culinaryProfile: { hard_allergens: ['milk'] },
+      constraints: { dietary: ['dairy_free'], maxCookTime: 30 },
+    })
+  })
+})
 
 describe('Generation request builder', () => {
   test('merges profile defaults, explicit overrides, and elevate ingredients', () => {
@@ -850,6 +865,53 @@ describe('Elevate behaviour', () => {
     );
   });
 });
+
+// ── RecipeAdapt ─────────────────────────────────────────────────────────────
+
+describe('RecipeAdapt behaviour', () => {
+  async function loadRecipe() {
+    mockFetchOk(SEARCH_RESPONSE)
+    mockFetchOk(FULL_RECIPE_RESPONSE)
+
+    renderApp()
+    setInputValue('cake')
+    pressEnter()
+    await waitFor(() => screen.getByText('Chocolate Cake'))
+    fireEvent.click(screen.getByText('Chocolate Cake'))
+    await waitFor(() => screen.getByRole('heading', { name: /Chocolate Cake/i }))
+  }
+
+  test('sends the selected recipe and constraints to the adapt endpoint', async () => {
+    await loadRecipe()
+    mockFetchOk({
+      success: true,
+      appliedConstraints: { dietary: ['dairy_free'], maxCookTime: 30 },
+      recipe: {
+        name: 'Dairy-free Chocolate Cake',
+        description: 'A better-fit cake.',
+        ingredients: ['2 cups rice flour'],
+        instructions: ['Mix and bake.'],
+        substitutions: [{ from: 'flour', to: 'rice flour', reason: 'Avoid wheat.' }],
+        adaptationNotes: ['The chocolate profile remains intact.'],
+        adapted_from: 'abc123',
+      },
+    })
+
+    fireEvent.click(screen.getByTitle('Remix with AI'))
+    fireEvent.click(screen.getByTitle(/Adapt this recipe/i))
+    fireEvent.click(screen.getByRole('button', { name: 'Adapt recipe' }))
+
+    await waitFor(() => {
+      const call = global.fetch.mock.calls.find(([url]) => url === 'https://test-gen.example.com/adapt')
+      expect(call).toBeDefined()
+      const body = JSON.parse(call[1].body)
+      expect(body.baseRecipe.name).toBe('Chocolate Cake')
+      expect(body.constraints).toEqual(expect.objectContaining({ dietary: [], servings: 4 }))
+    })
+    expect(await screen.findByRole('heading', { name: /Dairy-free Chocolate Cake/i })).toBeInTheDocument()
+    expect(screen.getByText('What changed')).toBeInTheDocument()
+  })
+})
 
 // ── Recipe card lifecycle ──────────────────────────────────────────────────
 

--- a/recipe-app/src/__tests__/RecipeCard.test.jsx
+++ b/recipe-app/src/__tests__/RecipeCard.test.jsx
@@ -233,6 +233,14 @@ describe('RecipeCard — elevate-recipe feature flag', () => {
     renderCard();
     expect(screen.getByTitle('Remix with AI')).toBeInTheDocument();
   });
+
+  test('shows and invokes RecipeAdapt when the feature is enabled', () => {
+    const onAdapt = jest.fn();
+    renderCard({}, { onAdapt });
+    fireEvent.click(screen.getByTitle('Remix with AI'));
+    fireEvent.click(screen.getByTitle('Adapt this recipe to your diet, time, or equipment'));
+    expect(onAdapt).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('RecipeCard — accessibility baseline', () => {

--- a/recipe-app/src/flaggly.js
+++ b/recipe-app/src/flaggly.js
@@ -22,6 +22,7 @@ try {
       'meal-planner': true,
       'culinary-profile': true,
       'constraint-generate': true,
+      'recipe-adapt': true,
     },
   })
 } catch (err) {
@@ -64,7 +65,7 @@ export async function syncFlagglyUser(user) {
     const keys = state ? Object.keys(state) : []
     if (keys.length === 0) {
       console.warn(
-        '[flaggly] Eval succeeded but returned zero flags. In Flaggly admin, create flags with the same ids as in code (voice-control, gesture-support, dictation, elevate-recipe, meal-planner, culinary-profile, constraint-generate) for app `default` / env `production`, or set VITE_FLAGGLY_APP_ID / VITE_FLAGGLY_ENV_ID if you use other names.'
+        '[flaggly] Eval succeeded but returned zero flags. In Flaggly admin, create flags with the same ids as in code (voice-control, gesture-support, dictation, elevate-recipe, meal-planner, culinary-profile, constraint-generate, recipe-adapt) for app `default` / env `production`, or set VITE_FLAGGLY_APP_ID / VITE_FLAGGLY_ENV_ID if you use other names.'
       )
     } else if (import.meta.env.DEV) {
       console.info(`[flaggly] Eval OK — ${keys.length} flag(s):`, keys.join(', '))

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -2724,3 +2724,45 @@ textarea:focus-visible {
 .error-retry:hover {
   background: rgba(217, 79, 79, 0.22);
 }
+
+.action-menu-item.adapt-item {
+  color: #7fbf91;
+}
+.action-menu-item.adapt-item:hover:not(:disabled) {
+  background: rgba(127, 191, 145, 0.12);
+  color: #a5d6b2;
+}
+
+.adaptation-summary {
+  margin: 0 18px 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(127, 191, 145, 0.32);
+  border-radius: var(--radius-sm);
+  background: rgba(127, 191, 145, 0.08);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+.adaptation-summary h3 {
+  margin-bottom: 7px;
+  color: var(--text);
+  font-size: 0.86rem;
+}
+.adaptation-substitutions,
+.adaptation-notes {
+  padding-left: 18px;
+}
+.adaptation-substitutions li,
+.adaptation-notes li {
+  margin: 4px 0;
+}
+.adaptation-substitutions li span {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+.adaptation-lineage {
+  margin-top: 8px;
+  color: #a5d6b2;
+  font-size: 0.74rem;
+}

--- a/recipe-generation-worker/src/handlers/adapt-handler.js
+++ b/recipe-generation-worker/src/handlers/adapt-handler.js
@@ -1,0 +1,359 @@
+import { buildGenerationConstraints, normalizeCulinaryProfile } from '../../../shared/culinary-profile.js';
+import {
+  AllergenSafetyError,
+  enforceAllergenSafety
+} from '../../../shared/allergen-graph.js';
+
+const ADAPT_CONSTRAINT_FIELDS = [
+  'dietary',
+  'hardAllergens',
+  'softAvoids',
+  'cuisine',
+  'equipment',
+  'servings',
+  'maxCookTime',
+  'spiceLevel',
+  'skillLevel',
+  'excludeIngredients',
+  'nutritionGoals',
+  'units',
+  'preserve'
+];
+
+const MOCK_SUBSTITUTIONS = [
+  {
+    allergen: 'milk',
+    terms: /\b(?:milk|butter|ghee|cream|cheese|yogurt|yoghurt|whey)\b/i,
+    replacement: 'olive oil or an unsweetened plant-based alternative',
+    reason: 'Replaces dairy while preserving richness and moisture.'
+  },
+  {
+    allergen: 'eggs',
+    terms: /\b(?:eggs?|mayonnaise)\b/i,
+    replacement: '1 tablespoon ground flaxseed mixed with 3 tablespoons water',
+    reason: 'Provides binding without using eggs.'
+  },
+  {
+    allergen: 'fish',
+    terms: /\b(?:fish|salmon|tuna|cod|anchov(?:y|ies)|sardines?|fish sauce)\b/i,
+    replacement: 'mushrooms and a splash of tamari-free vegetable broth',
+    reason: 'Adds savory depth without fish.'
+  },
+  {
+    allergen: 'shellfish',
+    terms: /\b(?:shellfish|shrimp|prawn|crab|lobster|scallop|mussel|oyster|clam)\b/i,
+    replacement: 'hearts of palm or mushrooms',
+    reason: 'Preserves a satisfying bite without shellfish.'
+  },
+  {
+    allergen: 'tree_nuts',
+    terms: /\b(?:almonds?|walnuts?|pecans?|cashews?|pistachios?|hazelnuts?|macadamias?|pine nuts?|marzipan)\b/i,
+    replacement: 'toasted pumpkin seeds',
+    reason: 'Adds crunch without tree nuts.'
+  },
+  {
+    allergen: 'peanuts',
+    terms: /\b(?:peanuts?|groundnuts?|peanut butter)\b/i,
+    replacement: 'sunflower seed butter',
+    reason: 'Preserves the creamy, nutty role without peanuts.'
+  },
+  {
+    allergen: 'wheat',
+    terms: /\b(?:wheat|gluten|flour|bread|pasta|semolina|couscous|panko|breadcrumb)\b/i,
+    replacement: 'certified rice noodles or corn-based alternative',
+    reason: 'Keeps the recipe structure while avoiding wheat.'
+  },
+  {
+    allergen: 'soy',
+    terms: /\b(?:soy|soya|soybean|tofu|tempeh|edamame|miso|tamari|soy sauce|lecithin)\b/i,
+    replacement: 'coconut aminos',
+    reason: 'Adds umami without soy.'
+  },
+  {
+    allergen: 'sesame',
+    terms: /\b(?:sesame|tahini|benne|gomasio)\b/i,
+    replacement: 'toasted pumpkin seeds',
+    reason: 'Adds a similar toasted finish without sesame.'
+  }
+];
+
+function objectOrEmpty(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function asString(value, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function recipeLines(value) {
+  return Array.isArray(value)
+    ? value.filter((item) => typeof item === 'string' && item.trim())
+    : [];
+}
+
+function buildConstraintOverrides(requestBody) {
+  const nested = objectOrEmpty(requestBody.constraints);
+  const topLevel = {};
+  for (const field of ADAPT_CONSTRAINT_FIELDS) {
+    if (requestBody[field] !== undefined) topLevel[field] = requestBody[field];
+  }
+  return { ...nested, ...topLevel };
+}
+
+function findSubstitution(line, constraints) {
+  const allergens = new Set([
+    ...(constraints.hardAllergens || []),
+    ...((constraints.dietary || []).includes('dairy_free') || (constraints.dietary || []).includes('vegan') ? ['milk'] : []),
+    ...((constraints.dietary || []).includes('vegan') ? ['eggs'] : []),
+    ...((constraints.dietary || []).includes('gluten_free') ? ['wheat'] : [])
+  ]);
+  for (const substitution of MOCK_SUBSTITUTIONS) {
+    if (allergens.has(substitution.allergen) && substitution.terms.test(line)) {
+      return substitution;
+    }
+  }
+  return null;
+}
+
+function mockAdaptRecipe(baseRecipe, constraints) {
+  const substitutions = [];
+  const ingredients = recipeLines(baseRecipe.ingredients).map((line) => {
+    const substitution = findSubstitution(line, constraints);
+    if (!substitution) return line;
+    const adaptedLine = line.replace(substitution.terms, substitution.replacement);
+    substitutions.push({
+      from: line,
+      to: adaptedLine,
+      reason: substitution.reason
+    });
+    return adaptedLine;
+  });
+
+  const adaptationNotes = [
+    'The dish identity, cuisine, and cooking sequence were preserved where possible.'
+  ];
+  if (constraints.maxCookTime) {
+    adaptationNotes.push(`Keep the total cook time at or below ${constraints.maxCookTime} minutes.`);
+  }
+  if (constraints.equipment?.length) {
+    adaptationNotes.push(`Use only the available equipment: ${constraints.equipment.join(', ')}.`);
+  }
+  if (substitutions.length === 0) {
+    adaptationNotes.push('No direct ingredient substitutions were required for the selected constraints.');
+  }
+
+  return {
+    ...baseRecipe,
+    ingredients: ingredients.length > 0 ? ingredients : baseRecipe.ingredients || [],
+    instructions: recipeLines(baseRecipe.instructions),
+    substitutions,
+    adaptationNotes,
+    adaptationMethod: 'mock-ai',
+    mockMode: true
+  };
+}
+
+function normalizeAdaptedRecipe(response, baseRecipe) {
+  let adapted = response;
+  if (typeof adapted === 'string') {
+    try {
+      adapted = JSON.parse(adapted);
+    } catch {
+      throw new Error('AI returned invalid JSON for recipe adaptation');
+    }
+  }
+  if (adapted?.recipe && typeof adapted.recipe === 'object') adapted = adapted.recipe;
+  if (!adapted || typeof adapted !== 'object' || Array.isArray(adapted)) {
+    throw new Error('AI returned an invalid recipe adaptation');
+  }
+
+  const normalized = { ...adapted };
+  if (normalized.Ingredients && !normalized.ingredients) normalized.ingredients = normalized.Ingredients;
+  if (normalized.Instructions && !normalized.instructions) normalized.instructions = normalized.Instructions;
+  if (normalized.Name && !normalized.name) normalized.name = normalized.Name;
+  if (normalized.Description && !normalized.description) normalized.description = normalized.Description;
+  if (normalized.dietaryConsiderations && !normalized.dietary) normalized.dietary = normalized.dietaryConsiderations;
+
+  return {
+    ...baseRecipe,
+    ...normalized,
+    name: asString(normalized.name, baseRecipe.name || 'Adapted recipe'),
+    description: asString(normalized.description, baseRecipe.description || ''),
+    ingredients: recipeLines(normalized.ingredients).length > 0
+      ? recipeLines(normalized.ingredients)
+      : recipeLines(baseRecipe.ingredients),
+    instructions: recipeLines(normalized.instructions).length > 0
+      ? recipeLines(normalized.instructions)
+      : recipeLines(baseRecipe.instructions),
+    substitutions: Array.isArray(normalized.substitutions) ? normalized.substitutions : [],
+    adaptationNotes: Array.isArray(normalized.adaptationNotes)
+      ? normalized.adaptationNotes
+      : Array.isArray(normalized.adaptation_notes) ? normalized.adaptation_notes : [],
+    dietary: Array.isArray(normalized.dietary) ? normalized.dietary : baseRecipe.dietary || []
+  };
+}
+
+function applyLineage(recipe, baseRecipe, constraints, method) {
+  const baseId = baseRecipe.id || baseRecipe.recipeId || baseRecipe.source_url || baseRecipe.url || null;
+  return {
+    ...recipe,
+    source: 'adapted',
+    adapted_from: baseId,
+    adaptedFrom: baseId,
+    adaptation_constraints: constraints,
+    adaptationConstraints: constraints,
+    adaptationMethod: recipe.adaptationMethod || method,
+    adaptedAt: new Date().toISOString(),
+    substitutions: Array.isArray(recipe.substitutions) ? recipe.substitutions : [],
+    adaptationNotes: Array.isArray(recipe.adaptationNotes) ? recipe.adaptationNotes : []
+  };
+}
+
+async function adaptWithAI(baseRecipe, constraints, env) {
+  const systemPrompt = `You are a careful culinary adaptation expert. Rewrite an existing recipe to fit the requested constraints while preserving its recognizable dish identity, cuisine, core protein, and cooking sequence whenever possible.
+
+Return valid JSON only. Never include commentary outside the JSON. Hard allergens are absolute: do not include them, even in optional garnishes or substitutions. Keep measurements and times honest. Explain every meaningful ingredient change in substitutions and adaptationNotes. Unknown packaged ingredients should be called out for label verification.
+
+Required JSON fields: name, description, ingredients, instructions, prepTime, cookTime, totalTime, servings, difficulty, cuisine, dietary, substitutions, adaptationNotes.`;
+  const userPrompt = `Adapt this recipe without turning it into a completely different dish.
+
+Base recipe:
+${JSON.stringify(baseRecipe)}
+
+Requested constraints:
+${JSON.stringify(constraints)}
+
+Preserve these aspects where possible: flavor profile, cuisine, core protein, recognizable name, and overall recipe structure.
+Hard allergens to exclude: ${(constraints.hardAllergens || []).join(', ') || 'none'}.
+Return substitutions as objects with from, to, and reason fields. Return adaptationNotes as concise strings.`;
+
+  const response = await env.AI.run('@cf/meta/llama-4-scout-17b-16e-instruct', {
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt }
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'recipe_adaptation',
+        schema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            description: { type: 'string' },
+            ingredients: { type: 'array', items: { type: 'string' } },
+            instructions: { type: 'array', items: { type: 'string' } },
+            prepTime: { type: 'string' },
+            cookTime: { type: 'string' },
+            totalTime: { type: 'string' },
+            servings: { type: 'string' },
+            difficulty: { type: 'string' },
+            cuisine: { type: 'string' },
+            dietary: { type: 'array', items: { type: 'string' } },
+            substitutions: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  from: { type: 'string' },
+                  to: { type: 'string' },
+                  reason: { type: 'string' }
+                },
+                required: ['from', 'to', 'reason']
+              }
+            },
+            adaptationNotes: { type: 'array', items: { type: 'string' } }
+          },
+          required: ['name', 'description', 'ingredients', 'instructions', 'substitutions', 'adaptationNotes']
+        }
+      }
+    },
+    max_tokens: 3072,
+    temperature: 0.35
+  });
+
+  if (!response || response.response === undefined) {
+    throw new Error('Invalid response from LLaMA model for recipe adaptation');
+  }
+  return normalizeAdaptedRecipe(response.response, baseRecipe);
+}
+
+/**
+ * Adapt an existing recipe to explicit constraints while preserving its identity.
+ * The endpoint is deliberately separate from /generate and the legacy Elevate flow.
+ */
+export async function handleAdapt(request, env, corsHeaders) {
+  try {
+    const contentType = request.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+      return new Response(JSON.stringify({ error: 'Content-Type must be application/json' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    const requestBody = objectOrEmpty(await request.json());
+    const baseRecipe = objectOrEmpty(requestBody.baseRecipe || requestBody.recipe);
+    if (!baseRecipe.name || !Array.isArray(baseRecipe.ingredients) || baseRecipe.ingredients.length === 0) {
+      return new Response(JSON.stringify({
+        error: 'baseRecipe with a name and non-empty ingredients array is required'
+      }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    const profile = requestBody.culinaryProfile || requestBody.profile || {};
+    const constraintOverrides = buildConstraintOverrides(requestBody);
+    const constraints = buildGenerationConstraints(profile, constraintOverrides);
+    // A profile's hard allergens are safety policy, not a per-adaptation toggle.
+    // Explicit additions are accepted, but an adaptation cannot clear saved blocks.
+    const profileHardAllergens = normalizeCulinaryProfile(profile).hard_allergens;
+    const requestedHardAllergens = Array.isArray(constraintOverrides.hardAllergens)
+      ? constraintOverrides.hardAllergens
+      : [];
+    constraints.hardAllergens = [...new Set([...profileHardAllergens, ...requestedHardAllergens])];
+    constraints.preserve = Array.isArray(constraintOverrides.preserve)
+      ? constraintOverrides.preserve.filter((item) => typeof item === 'string' && item.trim()).slice(0, 10)
+      : [];
+
+    const adapted = env.AI
+      ? await adaptWithAI(baseRecipe, constraints, env)
+      : mockAdaptRecipe(baseRecipe, constraints);
+    const finalRecipe = enforceAllergenSafety(
+      applyLineage(adapted, baseRecipe, constraints, env.AI ? 'llama-ai-recipe-adapt' : 'mock-ai'),
+      constraints.hardAllergens
+    );
+
+    return new Response(JSON.stringify({
+      success: true,
+      recipe: finalRecipe,
+      appliedConstraints: constraints,
+      environment: env.ENVIRONMENT || 'development'
+    }), {
+      status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    if (error instanceof AllergenSafetyError) {
+      return new Response(JSON.stringify({
+        error: 'Recipe adaptation failed allergen safety validation',
+        code: error.code,
+        allergenSummary: error.summary
+      }), {
+        status: error.status,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    return new Response(JSON.stringify({
+      error: 'Failed to adapt recipe',
+      details: error.message
+    }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+    });
+  }
+}
+
+export { buildConstraintOverrides, mockAdaptRecipe, normalizeAdaptedRecipe };

--- a/recipe-generation-worker/src/handlers/root-handler.js
+++ b/recipe-generation-worker/src/handlers/root-handler.js
@@ -29,11 +29,24 @@ export async function handleRoot(request, env, corsHeaders) {
         },
         response: 'JSON object with generated recipe (implementation coming soon)',
         status: 'Coming Soon'
+      },
+      'POST /adapt': {
+        description: 'Adapt an existing recipe to dietary, allergen, time, equipment, or nutrition constraints',
+        requestBody: {
+          type: 'application/json',
+          schema: {
+            baseRecipe: 'Recipe object with name, ingredients, and instructions',
+            constraints: 'Optional explicit adaptation constraints',
+            culinaryProfile: 'Optional persisted kitchen profile'
+          }
+        },
+        response: 'JSON object with adapted recipe, substitutions, notes, and lineage metadata'
       }
     },
     usage: {
       healthCheck: 'curl https://recipe-generation-worker.nolanfoster.workers.dev/health',
-      recipeGeneration: 'curl -X POST https://recipe-generation-worker.nolanfoster.workers.dev/generate -H "Content-Type: application/json" -d \'{"ingredients": ["chicken", "rice"], "cuisine": "italian"}\''
+      recipeGeneration: 'curl -X POST https://recipe-generation-worker.nolanfoster.workers.dev/generate -H "Content-Type: application/json" -d \'{"ingredients": ["chicken", "rice"], "cuisine": "italian"}\'',
+      recipeAdaptation: 'curl -X POST https://recipe-generation-worker.nolanfoster.workers.dev/adapt -H "Content-Type: application/json" -d \'{"baseRecipe": {"name": "Pasta", "ingredients": ["1 cup pasta"], "instructions": ["Cook pasta"]}, "constraints": {"dietary": ["gluten_free"]}}\''
     },
     environments: {
       preview: 'For development and testing',

--- a/recipe-generation-worker/src/index.js
+++ b/recipe-generation-worker/src/index.js
@@ -1,6 +1,7 @@
 import { handleRoot } from './handlers/root-handler.js';
 import { handleHealth } from './handlers/health-handler.js';
 import { handleGenerate } from './handlers/generate-handler.js';
+import { handleAdapt } from './handlers/adapt-handler.js';
 import { handleGroceryList } from './handlers/grocery-list-handler.js';
 
 export default {
@@ -32,6 +33,11 @@ export default {
     // Recipe generation endpoint
     if (url.pathname === '/generate' && request.method === 'POST') {
       return handleGenerate(request, env, corsHeaders);
+    }
+
+    // Recipe adaptation endpoint
+    if (url.pathname === '/adapt' && request.method === 'POST') {
+      return handleAdapt(request, env, corsHeaders);
     }
 
     // Grocery list aggregation endpoint

--- a/recipe-generation-worker/tests/unit/adapt-handler.test.js
+++ b/recipe-generation-worker/tests/unit/adapt-handler.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleAdapt, mockAdaptRecipe, normalizeAdaptedRecipe } from '../../src/handlers/adapt-handler.js';
+import { createPostRequest } from '../setup.js';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
+const baseRecipe = {
+  id: 'recipe-123',
+  name: 'Creamy Pasta',
+  description: 'A weeknight pasta.',
+  cuisine: 'Italian',
+  ingredients: ['8 oz pasta', '2 tbsp butter', '1 egg'],
+  instructions: ['Boil the pasta.', 'Toss with butter and egg.'],
+  prepTime: '10 minutes',
+  cookTime: '20 minutes',
+  servings: '2 servings'
+};
+
+function responseBody(response) {
+  return response.json();
+}
+
+describe('RecipeAdapt handler', () => {
+  it('adapts a recipe in mock mode and returns substitutions and lineage', async () => {
+    const request = createPostRequest('/adapt', {
+      baseRecipe,
+      constraints: {
+        dietary: ['vegan', 'gluten_free'],
+        maxCookTime: 30,
+        preserve: ['the creamy texture']
+      }
+    });
+
+    const response = await handleAdapt(request, { ENVIRONMENT: 'test' }, corsHeaders);
+    const data = await responseBody(response);
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.recipe.source).toBe('adapted');
+    expect(data.recipe.adapted_from).toBe('recipe-123');
+    expect(data.recipe.adaptation_constraints.preserve).toEqual(['the creamy texture']);
+    expect(data.recipe.substitutions).toHaveLength(3);
+    expect(data.recipe.ingredients.join(' ')).not.toMatch(/\b(?:butter|egg|pasta)\b/i);
+    expect(data.recipe.adaptationNotes.length).toBeGreaterThan(0);
+  });
+
+  it('uses explicit constraints over culinary profile defaults', async () => {
+    const request = createPostRequest('/adapt', {
+      baseRecipe: { ...baseRecipe, ingredients: ['1 cup rice'], instructions: ['Cook rice.'] },
+      culinaryProfile: {
+        diet_tags: ['vegan'],
+        default_servings: 2,
+        max_cook_time_min: 20
+      },
+      constraints: {
+        dietary: [],
+        servings: 6,
+        maxCookTime: 45
+      }
+    });
+
+    const response = await handleAdapt(request, { ENVIRONMENT: 'test' }, corsHeaders);
+    const data = await responseBody(response);
+
+    expect(response.status).toBe(200);
+    expect(data.appliedConstraints.dietary).toEqual([]);
+    expect(data.appliedConstraints.servings).toBe(6);
+    expect(data.appliedConstraints.maxCookTime).toBe(45);
+  });
+
+  it('supports the recipe alias and normalized nested AI response', async () => {
+    const run = vi.fn().mockResolvedValue({
+      response: JSON.stringify({
+        recipe: {
+          Name: 'Adapted Pasta',
+          Description: 'A better-fit pasta.',
+          ingredients: ['8 oz rice noodles'],
+          instructions: ['Cook the noodles.'],
+          substitutions: [{ from: 'pasta', to: 'rice noodles', reason: 'Avoid wheat.' }],
+          adaptationNotes: ['The Italian flavor profile remains intact.']
+        }
+      })
+    });
+
+    const response = await handleAdapt(
+      createPostRequest('/adapt', {
+        recipe: baseRecipe,
+        constraints: { dietary: ['gluten_free'] }
+      }),
+      { ENVIRONMENT: 'test', AI: { run } },
+      corsHeaders
+    );
+    const data = await responseBody(response);
+
+    expect(response.status).toBe(200);
+    expect(data.recipe.name).toBe('Adapted Pasta');
+    expect(data.recipe.substitutions[0].to).toBe('rice noodles');
+    expect(run).toHaveBeenCalledWith('@cf/meta/llama-4-scout-17b-16e-instruct', expect.objectContaining({
+      response_format: expect.objectContaining({
+        json_schema: expect.objectContaining({ name: 'recipe_adaptation' })
+      })
+    }));
+  });
+
+  it('fails closed when an AI adaptation contains a hard allergen', async () => {
+    const run = vi.fn().mockResolvedValue({
+      response: {
+        name: 'Unsafe adaptation',
+        ingredients: ['2 eggs'],
+        instructions: ['Cook eggs.'],
+        substitutions: [],
+        adaptationNotes: []
+      }
+    });
+
+    const response = await handleAdapt(
+      createPostRequest('/adapt', {
+        baseRecipe: { ...baseRecipe, ingredients: ['1 cup rice'] },
+        constraints: { hardAllergens: ['eggs'] }
+      }),
+      { AI: { run } },
+      corsHeaders
+    );
+    const data = await responseBody(response);
+
+    expect(response.status).toBe(422);
+    expect(data.code).toBe('ALLERGEN_SAFETY_BLOCK');
+    expect(data.allergenSummary.blocked).toEqual(['eggs']);
+  });
+
+  it('validates content type and base recipe input', async () => {
+    const invalidType = new Request('https://test.com/adapt', { method: 'POST', body: '{}' });
+    const typeResponse = await handleAdapt(invalidType, {}, corsHeaders);
+    expect(typeResponse.status).toBe(400);
+
+    const invalidRecipe = createPostRequest('/adapt', { baseRecipe: { name: 'Empty' } });
+    const recipeResponse = await handleAdapt(invalidRecipe, {}, corsHeaders);
+    const data = await responseBody(recipeResponse);
+    expect(recipeResponse.status).toBe(400);
+    expect(data.error).toMatch(/baseRecipe/);
+  });
+
+  it('normalizes missing AI fields without losing the base recipe structure', () => {
+    const normalized = normalizeAdaptedRecipe({ name: 'New name' }, baseRecipe);
+    expect(normalized.name).toBe('New name');
+    expect(normalized.ingredients).toEqual(baseRecipe.ingredients);
+    expect(normalized.instructions).toEqual(baseRecipe.instructions);
+    expect(normalized.substitutions).toEqual([]);
+  });
+
+  it('keeps a safe recipe unchanged when no matching adaptation is needed', () => {
+    const adapted = mockAdaptRecipe({ ...baseRecipe, ingredients: ['1 cup rice'], instructions: ['Cook rice.'] }, {
+      dietary: [],
+      hardAllergens: [],
+      equipment: [],
+      maxCookTime: 60
+    });
+    expect(adapted.ingredients).toEqual(['1 cup rice']);
+    expect(adapted.substitutions).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a feature-flagged RecipeAdapt flow for clipped, searched, and AI recipes.
- Add `POST /adapt` with structured constraints, profile hard-allergen preservation, mock/AI adaptation paths, safety enforcement, substitutions, notes, and lineage metadata.
- Add the Adapt composer/menu action, adapted recipe display, unique variant save URLs, and persistence metadata.
- Keep the existing Elevate flow unchanged.

Closes #297

## Validation
- `recipe-app`: `npm test -- --watch=false` (358 passed)
- `recipe-app`: `npm run build`
- `recipe-generation-worker`: `npm test -- --run` (176 passed)
- `recipe-generation-worker`: `npm run test:coverage` (92.2% lines, 97.95% functions)
- `recipe-generation-worker`: `npm run type-check`
- `recipe-generation-worker`: `npm run lint` (0 errors; existing console warnings remain)
