### PR TITLE
feat(safety): complete allergen trust checks across recipe flows

### DIFF
--- a/docs/ALLERGEN_SAFETY.md
+++ b/docs/ALLERGEN_SAFETY.md
@@ -45,6 +45,20 @@ any hard allergen configured, uncertainty also fails closed so it cannot be
 silently mistaken for an allergen-free result. Custom hard-allergen tags that
 are outside the canonical graph are likewise marked unverified.
 
+The summary also exposes `needs_review` and `review_reasons`. This is distinct
+from a detected conflict: it means the abstract recipe could not be completely
+verified (for example, it contains an opaque packaged-ingredient term or lacks
+an ingredient list). Ingredient objects and recipe instructions are scanned as
+well as plain ingredient strings so an additive mentioned only in a step cannot
+silently bypass the graph. A `needs_review` result is never presented as a
+positive safety clearance.
+
+When a hard-allergen warning is active, the same notice is shown on the recipe
+card and at cooking-mode entry. A recipe with an unresolved failed check cannot
+be added to the meal planner. Clipped recipes are annotated for the current
+profile and remain explicitly subject to label and cross-contact verification;
+clipping does not turn a graph result into a medical or product-level guarantee.
+
 Every summary is an audit aid, not a medical guarantee. The app should continue
 to display a clear reminder that AI can miss allergens and cross-contact and
 that users must verify packaging and preparation conditions with the

--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -12,6 +12,7 @@ import CulinaryProfile from './CulinaryProfile.jsx'
 import GenerationComposer from './GenerationComposer.jsx'
 import AdaptComposer from './AdaptComposer.jsx'
 import { useCulinaryProfile } from './useCulinaryProfile.js'
+import { withAllergenSummary } from '../../shared/allergen-graph.js'
 
 const SEARCH_DB_URL = import.meta.env.VITE_SEARCH_DB_URL
 const CLIPPER_API_URL = import.meta.env.VITE_CLIPPER_API_URL
@@ -236,6 +237,18 @@ export function buildAdaptRequest({ baseRecipe, profile = null, overrides = null
   return body
 }
 
+export function annotateRecipeForProfile(recipe, profile) {
+  const hardAllergens = profile?.hard_allergens || profile?.hardAllergens || []
+  if (!Array.isArray(hardAllergens) || hardAllergens.length === 0) return recipe
+  return withAllergenSummary({
+    ...recipe,
+    appliedConstraints: {
+      ...(recipe.appliedConstraints || {}),
+      hardAllergens,
+    },
+  }, hardAllergens)
+}
+
 export default function App() {
   const auth = useAuth()
   const { activeRecipe, setActiveRecipe, clearActiveRecipe } = useMealPlan()
@@ -309,7 +322,7 @@ export default function App() {
             if (!r.ok) return null
             const full = await r.json()
             const d = full.data || full
-            return {
+            const searchRecipe = {
               id: node.id,
               name: d.name || d.title || 'Untitled',
               description: d.description || '',
@@ -320,7 +333,9 @@ export default function App() {
               ingredients: d.ingredients || d.recipeIngredient || [],
               instructions: d.instructions || d.recipeInstructions || [],
               source_url: d.url || d.source_url || '',
+              allergenSummary: d.allergenSummary || null,
             }
+            return annotateRecipeForProfile(searchRecipe, culinaryProfile.profile)
           } catch {
             return null
           }
@@ -497,7 +512,7 @@ export default function App() {
       const data = await res.json()
       const d = data.recipe || data
       const isYouTube = d.sourceType === 'youtube' || isYouTubeUrl(url)
-      const clippedRecipe = {
+      const clippedRecipe = annotateRecipeForProfile({
         id: `clip-${Date.now()}`,
         source: isYouTube ? 'youtube' : 'clipped',
         name: d.name || d.title || 'Clipped Recipe',
@@ -509,7 +524,8 @@ export default function App() {
         ingredients: d.ingredients || d.recipeIngredient || [],
         instructions: d.instructions || d.recipeInstructions || [],
         source_url: url,
-      }
+        allergenSummary: d.allergenSummary || null,
+      }, culinaryProfile.profile)
       setActiveRecipe(clippedRecipe)
       addRecentRecipe(clippedRecipe)
       setInput('')
@@ -538,7 +554,9 @@ export default function App() {
       const body = buildGenerationRequest({
         dishName,
         elevate,
-        profile: constraintGenerateEnabled ? culinaryProfile.profile : null,
+        // Hard-allergen enforcement is safety-critical and must not depend on
+        // the optional Tune/composer flag.
+        profile: culinaryProfileEnabled ? culinaryProfile.profile : null,
         overrides,
         baseIngredients: baseRecipe?.ingredients || null,
       })
@@ -565,6 +583,8 @@ export default function App() {
         ingredients: r.ingredients || [],
         instructions: r.instructions || [],
         appliedConstraints: data.appliedConstraints || r.appliedConstraints || null,
+        allergenSummary: r.allergenSummary || data.allergenSummary || null,
+        allergenValidation: r.allergenValidation || data.allergenValidation || null,
       }
       setActiveRecipe(generatedRecipe)
       addRecentRecipe(generatedRecipe)

--- a/recipe-app/src/CookingNavigator.jsx
+++ b/recipe-app/src/CookingNavigator.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { useFlag } from './flaggly.js'
 import useGestureMode from './useGestureMode.js'
-import RecipeCardDisplay from './RecipeCardDisplay.jsx'
+import RecipeCardDisplay, { AllergenSafetyNotice } from './RecipeCardDisplay.jsx'
 
 // ── Normalization helpers ─────────────────────────────────────────────────────
 
@@ -315,6 +315,9 @@ function formatTime(secs) {
 export default function CookingNavigator({ recipe, onClose }) {
   const instructions = normalizeInstructions(recipe.instructions)
   const ingredients = normalizeIngredients(recipe.ingredients)
+  const hardAllergens = recipe.appliedConstraints?.hardAllergens
+    || recipe.appliedConstraints?.hard_allergens
+    || []
   const total = instructions.length
 
   const [currentStep, setCurrentStep] = useState(-1)
@@ -902,6 +905,11 @@ export default function CookingNavigator({ recipe, onClose }) {
         )}
 
         <div className="cn-scroll-body">
+        <AllergenSafetyNotice
+          summary={recipe.allergenSummary}
+          hardAllergens={hardAllergens}
+          className="cn-allergen-notice"
+        />
         {showRecipe ? (
           <div className="cn-recipe-panel">
             <RecipeCardDisplay recipe={recipe} />

--- a/recipe-app/src/RecipeCard.jsx
+++ b/recipe-app/src/RecipeCard.jsx
@@ -38,8 +38,18 @@ export default function RecipeCard({ recipe, onClose, onElevate, onAdapt, isElev
   const menuIdPrefix = useId()
 
   const mealPlanContext = useMealPlan()
+  const hardAllergens = recipe?.appliedConstraints?.hardAllergens
+    || recipe?.appliedConstraints?.hard_allergens
+    || []
+  const hasUnresolvedAllergenConflict = hardAllergens.length > 0
+    && recipe?.allergenSummary
+    && recipe.allergenSummary.safe === false
   const canAddToPlanner = Boolean(
-    mealPlannerEnabled && mealPlanContext && recipe?.id && recipe?.name
+    mealPlannerEnabled
+      && mealPlanContext
+      && recipe?.id
+      && recipe?.name
+      && !hasUnresolvedAllergenConflict
   )
 
   const recipeDurationMins =
@@ -106,11 +116,15 @@ export default function RecipeCard({ recipe, onClose, onElevate, onAdapt, isElev
   function handleDaySelected(dateString, mealType) {
     setShowDaySelector(false)
     setOpenMenu(null)
-    try {
-      mealPlanContext.addMeal(dateString, mealType, recipe)
-      setPlannerFeedback('success')
-    } catch {
-      setPlannerFeedback('error')
+    if (hasUnresolvedAllergenConflict) {
+      setPlannerFeedback('blocked')
+    } else {
+      try {
+        mealPlanContext.addMeal(dateString, mealType, recipe)
+        setPlannerFeedback('success')
+      } catch {
+        setPlannerFeedback('error')
+      }
     }
     clearTimeout(plannerFeedbackTimerRef.current)
     plannerFeedbackTimerRef.current = setTimeout(() => setPlannerFeedback(null), 2500)
@@ -260,9 +274,11 @@ export default function RecipeCard({ recipe, onClose, onElevate, onAdapt, isElev
                 title={
                   canAddToPlanner
                     ? 'Add to meal planner'
-                    : !mealPlannerEnabled
-                      ? 'Meal planner is off'
-                      : 'Meal planner unavailable'
+                    : hasUnresolvedAllergenConflict
+                      ? 'Resolve the allergen warning before adding to the planner'
+                      : !mealPlannerEnabled
+                        ? 'Meal planner is off'
+                        : 'Meal planner unavailable'
                 }
               >
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -373,6 +389,13 @@ export default function RecipeCard({ recipe, onClose, onElevate, onAdapt, isElev
                 <path d="M20 6L9 17l-5-5"/>
               </svg>
               Added to planner
+            </>
+          ) : plannerFeedback === 'blocked' ? (
+            <>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" width="16" height="16">
+                <path d="M18 6L6 18M6 6l12 12"/>
+              </svg>
+              Resolve the allergen warning before planning this recipe
             </>
           ) : (
             <>

--- a/recipe-app/src/RecipeCardDisplay.jsx
+++ b/recipe-app/src/RecipeCardDisplay.jsx
@@ -31,6 +31,62 @@ function appliedConstraintLabels(constraints) {
   return labels
 }
 
+function allergenLabel(value) {
+  return String(value || '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+/**
+ * Explain the graph result without claiming that a recipe is medically safe.
+ * The same notice is rendered in the recipe card and cooking navigator so the
+ * warning remains visible when a user moves from browsing to cooking.
+ */
+export function AllergenSafetyNotice({ summary, hardAllergens = [], className = '' }) {
+  if (!summary && hardAllergens.length === 0) return null
+
+  const blocked = summary?.blocked || []
+  const contains = summary?.contains || []
+  const uncertain = summary?.may_contain_uncertain || []
+  const needsReview = Boolean(
+    summary?.needs_review
+      || (summary && summary.safe === false && blocked.length === 0)
+      || (hardAllergens.length > 0 && summary?.ingredient_data_available === false)
+  )
+  const noticeClass = [
+    'recipe-allergen-notice',
+    blocked.length > 0 ? 'recipe-allergen-notice--blocked' : '',
+    needsReview ? 'recipe-allergen-notice--review' : '',
+    className,
+  ].filter(Boolean).join(' ')
+
+  return (
+    <div className={noticeClass} role={blocked.length > 0 ? 'alert' : 'note'}>
+      <strong>
+        {blocked.length > 0
+          ? 'Allergen conflict detected'
+          : needsReview
+            ? 'Needs verification'
+            : 'Allergen check'}
+      </strong>
+      <p>
+        {blocked.length > 0
+          ? `This recipe includes ${blocked.map(allergenLabel).join(', ')}. Do not use it for those saved hard allergens.`
+          : needsReview
+            ? 'The recipe could not be fully verified from its available ingredient information.'
+            : 'No mapped conflict was found for the saved hard allergens.'}
+      </p>
+      {contains.length > 0 && (
+        <p>Detected allergens: {contains.map(allergenLabel).join(', ')}.</p>
+      )}
+      {uncertain.length > 0 && (
+        <p>Review these ingredients or preparation notes: {uncertain.join('; ')}.</p>
+      )}
+      <p>AI can miss allergens and cross-contact; verify labels and preparation conditions.</p>
+    </div>
+  )
+}
+
 // Pure display component — no state, no browser APIs.
 // Safe to use with ReactDOMServer.renderToStaticMarkup.
 // Props:
@@ -45,9 +101,9 @@ export default function RecipeCardDisplay({ recipe, onCookClick, cookBtnId }) {
 
   const sourceBadge = sourceBadgeMap[recipe.source]
   const allergenSummary = recipe.allergenSummary
-  const hardAllergens = recipe.appliedConstraints?.hardAllergens || []
-  const showAllergenNotice = hardAllergens.length > 0 || allergenSummary
-  const blockedAllergens = allergenSummary?.blocked || []
+  const hardAllergens = recipe.appliedConstraints?.hardAllergens
+    || recipe.appliedConstraints?.hard_allergens
+    || []
 
   return (
     <>
@@ -70,13 +126,7 @@ export default function RecipeCardDisplay({ recipe, onCookClick, cookBtnId }) {
         <p className="recipe-description">{recipe.description}</p>
       )}
 
-      {showAllergenNotice && (
-        <div className="recipe-allergen-notice" role="note">
-          {blockedAllergens.length > 0
-            ? `Allergen safety blocked: ${blockedAllergens.join(', ')}.`
-            : 'Allergen check completed. AI can miss allergens and cross-contact; verify labels and preparation conditions.'}
-        </div>
-      )}
+      <AllergenSafetyNotice summary={allergenSummary} hardAllergens={hardAllergens} />
 
       <div className="recipe-meta">
         {recipe.prep_time && (

--- a/recipe-app/src/__tests__/App.test.jsx
+++ b/recipe-app/src/__tests__/App.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import App, { buildGenerationRequest, buildAdaptRequest } from '../App';
+import App, { buildGenerationRequest, buildAdaptRequest, annotateRecipeForProfile } from '../App';
 import { MealPlanProvider } from '../MealPlanContext.jsx';
 
 // Wrap App in the providers it requires (MealPlanProvider lives in main.jsx in production)
@@ -99,6 +99,25 @@ const GENERATE_RESPONSE = {
     instructions: ['Beat eggs.', 'Cook in butter.'],
   },
 };
+
+describe('Allergen profile annotation', () => {
+  test('annotates a recipe with a graph summary for hard allergens', () => {
+    const recipe = { name: 'Peanut bowl', ingredients: ['1 cup peanuts'] }
+    const annotated = annotateRecipeForProfile(recipe, { hard_allergens: ['peanuts'] })
+
+    expect(annotated).toMatchObject({
+      appliedConstraints: { hardAllergens: ['peanuts'] },
+      allergenSummary: { checked: true, blocked: ['peanuts'], safe: false },
+      allergenValidation: 'FAILED',
+    })
+    expect(recipe.allergenSummary).toBeUndefined()
+  })
+
+  test('leaves recipes unchanged when no hard allergens are configured', () => {
+    const recipe = { name: 'Rice bowl', ingredients: ['rice'] }
+    expect(annotateRecipeForProfile(recipe, { hard_allergens: [] })).toBe(recipe)
+  })
+})
 
 describe('Adaptation request builder', () => {
   test('keeps the complete base recipe and sends profile plus explicit constraints', () => {

--- a/recipe-app/src/__tests__/CookingNavigator.test.jsx
+++ b/recipe-app/src/__tests__/CookingNavigator.test.jsx
@@ -83,6 +83,14 @@ describe('CookingNavigator — rendering', () => {
     expect(screen.getByText(/gather and prepare all/i)).toBeInTheDocument()
   })
 
+  test('keeps the allergen warning visible at cooking entry', () => {
+    renderNavigator({
+      appliedConstraints: { hardAllergens: ['peanuts'] },
+      allergenSummary: { checked: true, safe: true, blocked: [] },
+    })
+    expect(screen.getByText(/AI can miss allergens and cross-contact/i)).toBeInTheDocument()
+  })
+
   test('renders Prev and Start Cooking navigation buttons', () => {
     renderNavigator()
     expect(screen.getByText('← Prev')).toBeInTheDocument()

--- a/recipe-app/src/__tests__/RecipeCardDisplay.test.jsx
+++ b/recipe-app/src/__tests__/RecipeCardDisplay.test.jsx
@@ -76,6 +76,31 @@ describe('RecipeCardDisplay', () => {
     expect(screen.getByText(/AI can miss allergens and cross-contact/i)).toBeInTheDocument()
   })
 
+  test('explains blocked allergens and uncertain ingredients', () => {
+    render(<RecipeCardDisplay recipe={{
+      ...baseRecipe,
+      appliedConstraints: { hardAllergens: ['peanuts'] },
+      allergenSummary: {
+        checked: true,
+        safe: false,
+        blocked: ['peanuts'],
+        contains: ['peanuts'],
+        needs_review: true,
+        may_contain_uncertain: ['1 cup seasoning blend'],
+      },
+    }} />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Allergen conflict detected')
+    expect(screen.getByRole('alert')).toHaveTextContent('Peanuts')
+    expect(screen.getByRole('alert')).toHaveTextContent('Review these ingredients')
+    expect(screen.getByRole('alert')).toHaveTextContent('AI can miss allergens and cross-contact')
+  })
+
+  test('does not render an allergen notice without a check or saved allergens', () => {
+    render(<RecipeCardDisplay recipe={baseRecipe} />)
+    expect(screen.queryByText(/AI can miss allergens and cross-contact/i)).not.toBeInTheDocument()
+  })
+
   test('handles object ingredients', () => {
     render(<RecipeCardDisplay recipe={{ ...baseRecipe, ingredients: [{ name: '2 eggs' }] }} />)
     expect(screen.getByText('2 eggs')).toBeInTheDocument()

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -674,6 +674,25 @@ textarea:focus-visible {
   line-height: 1.45;
 }
 
+.recipe-allergen-notice strong,
+.recipe-allergen-notice p {
+  display: block;
+  margin: 0;
+}
+
+.recipe-allergen-notice p + p {
+  margin-top: 0.35rem;
+}
+
+.recipe-allergen-notice--blocked {
+  border-color: rgba(235, 126, 126, 0.75);
+  background: rgba(180, 54, 54, 0.18);
+}
+
+.recipe-allergen-notice--review {
+  border-color: rgba(232, 200, 122, 0.75);
+}
+
 .recipe-description {
   padding: 16px 20px 0;
   font-size: 0.9375rem;
@@ -2765,4 +2784,8 @@ textarea:focus-visible {
   margin-top: 8px;
   color: #a5d6b2;
   font-size: 0.74rem;
+}
+
+.cn-allergen-notice {
+  margin: 16px 20px 0;
 }

--- a/recipe-generation-worker/src/handlers/generate-handler.js
+++ b/recipe-generation-worker/src/handlers/generate-handler.js
@@ -255,10 +255,13 @@ async function generateRecipeWithAI(requestData, env) {
     const candidateRecipes = await findSimilarRecipes(queryEmbedding, env.RECIPE_VECTORS, env);
     const hardAllergens = requestData.hardAllergens || [];
     const similarRecipes = hardAllergens.length > 0
-      ? candidateRecipes.filter((candidate) => isRecipeSafe(
-        candidate.fullRecipe || { ingredients: [candidate.metadata?.title || ''] },
-        hardAllergens
-      ))
+      ? candidateRecipes.filter((candidate) => {
+        // A vector match without its full recipe cannot be checked. Never use
+        // the search title as a proxy for ingredients because that turns an
+        // incomplete safety check into an affirmative result.
+        if (!candidate.fullRecipe) return false;
+        return isRecipeSafe(candidate.fullRecipe, hardAllergens);
+      })
       : candidateRecipes;
     // Found allergen-safe similar recipes
     operationData.similarRecipes = similarRecipes;

--- a/recipe-generation-worker/tests/unit/generate-handler.test.js
+++ b/recipe-generation-worker/tests/unit/generate-handler.test.js
@@ -2210,4 +2210,20 @@ describe('Allergen safety enforcement', () => {
       allergenSummary: { checked: true, blocked: [] }
     });
   });
+
+
+  it('does not treat a vector-match title as ingredient evidence', async () => {
+    allergenEnv.RECIPE_VECTORS.query.mockResolvedValueOnce({
+      matches: [{ id: 'missing-recipe', score: 0.9, metadata: { title: 'Peanut bowl' } }]
+    });
+
+    const response = await handleGenerate(createPostRequest('/generate', {
+      recipeName: 'Rice bowl',
+      hardAllergens: ['peanuts']
+    }), allergenEnv, allergenCorsHeaders);
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.recipe.similarRecipesFound).toBe(0);
+  });
 });

--- a/recipe-recommendation-worker/src/recommendation-service.js
+++ b/recipe-recommendation-worker/src/recommendation-service.js
@@ -1092,11 +1092,11 @@ export async function enhanceRecommendationsWithRecipes(categoryRecommendations,
     
     metrics.increment('recipe_enhancement_errors', 1);
     
-    // Return original dish names as fallback
+    // A name-only fallback cannot be verified against a hard-allergen policy.
     return Object.fromEntries(
       Object.entries(categoryRecommendations).map(([category, dishes]) => [
         category,
-        dishes.map((dish, index) => ({
+        hardAllergens.length > 0 ? [] : dishes.map((dish, index) => ({
           id: `ai_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
           name: dish,
           description: `A delicious ${dish.toLowerCase()} perfect for ${category.toLowerCase()}`,

--- a/shared/__tests__/allergen-graph.test.js
+++ b/shared/__tests__/allergen-graph.test.js
@@ -62,6 +62,37 @@ describe('allergen graph', () => {
     expect(summary.may_contain_uncertain).toEqual(['1 cup vegetable broth'])
   })
 
+  it('surfaces needs_review for opaque terms and missing ingredient data', () => {
+    const uncertain = analyzeRecipeAllergens({
+      ingredients: ['1 cup seasoning blend'],
+    }, ['peanuts'])
+    const incomplete = analyzeRecipeAllergens({ name: 'Unverified recipe' }, ['peanuts'])
+
+    expect(uncertain).toMatchObject({
+      safe: false,
+      needs_review: true,
+      review_reasons: ['opaque_or_precautionary_ingredient_terms'],
+    })
+    expect(incomplete).toMatchObject({
+      safe: false,
+      needs_review: true,
+      review_reasons: ['ingredient_data_unavailable'],
+    })
+  })
+
+  it('checks structured ingredients and hidden instruction additives', () => {
+    const summary = analyzeRecipeAllergens({
+      ingredients: [{ name: '2 cups rice' }],
+      instructions: [{ text: 'Grease the pan with butter before adding the rice.' }],
+    }, ['milk'])
+
+    expect(summary.safe).toBe(false)
+    expect(summary.blocked).toEqual(['milk'])
+    expect(summary.matches).toEqual(expect.arrayContaining([
+      expect.objectContaining({ ingredient: 'Grease the pan with butter before adding the rice.' }),
+    ]))
+  })
+
   it('fails closed when hard-allergen checks have no ingredient data', () => {
     const summary = analyzeRecipeAllergens({ name: 'Incomplete recipe' }, ['peanuts'])
     expect(summary.ingredient_data_available).toBe(false)

--- a/shared/allergen-graph.js
+++ b/shared/allergen-graph.js
@@ -120,22 +120,54 @@ export function normalizeAllergenList(value) {
     .filter((item, index, items) => items.indexOf(item) === index)
 }
 
+function normalizeRecipeLine(value) {
+  if (typeof value === 'string') return value.trim()
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return ''
+  for (const field of ['name', 'text', 'ingredient', 'original']) {
+    if (typeof value[field] === 'string' && value[field].trim()) return value[field].trim()
+  }
+  return ''
+}
+
+function recipeLineValues(recipeOrIngredients, fields) {
+  if (!recipeOrIngredients || typeof recipeOrIngredients !== 'object') return []
+  return fields.flatMap((field) => Array.isArray(recipeOrIngredients[field])
+    ? recipeOrIngredients[field].map(normalizeRecipeLine)
+    : [])
+}
+
+/**
+ * Return recipe text that can introduce an allergen. Instructions are included
+ * deliberately: recipes occasionally hide an additive (for example, butter
+ * used to grease a pan) in a step instead of the ingredient list.
+ */
 function toIngredientLines(recipeOrIngredients) {
   if (Array.isArray(recipeOrIngredients)) {
-    return recipeOrIngredients.filter((item) => typeof item === 'string' && item.trim())
+    return recipeOrIngredients.map(normalizeRecipeLine).filter(Boolean)
   }
   if (!recipeOrIngredients || typeof recipeOrIngredients !== 'object') return []
 
-  const lines = []
-  for (const field of ['ingredients', 'sourceIngredients']) {
-    if (Array.isArray(recipeOrIngredients[field])) {
-      lines.push(...recipeOrIngredients[field])
-    }
-  }
+  const lines = [
+    ...recipeLineValues(recipeOrIngredients, [
+      'ingredients', 'sourceIngredients', 'recipeIngredient',
+    ]),
+    ...recipeLineValues(recipeOrIngredients, [
+      'instructions', 'steps', 'directions', 'recipeInstructions',
+    ]),
+  ]
   if (recipeOrIngredients.data && typeof recipeOrIngredients.data === 'object') {
     lines.push(...toIngredientLines(recipeOrIngredients.data))
   }
-  return lines.filter((item) => typeof item === 'string' && item.trim())
+  return lines.filter(Boolean)
+}
+
+function hasIngredientData(recipeOrIngredients) {
+  if (Array.isArray(recipeOrIngredients)) return recipeOrIngredients.some((item) => normalizeRecipeLine(item))
+  if (!recipeOrIngredients || typeof recipeOrIngredients !== 'object') return false
+  const direct = recipeLineValues(recipeOrIngredients, [
+    'ingredients', 'sourceIngredients', 'recipeIngredient',
+  ])
+  return direct.some(Boolean) || hasIngredientData(recipeOrIngredients.data)
 }
 
 function termPattern(term) {
@@ -225,14 +257,24 @@ export function analyzeRecipeAllergens(recipeOrIngredients, hardAllergens = []) 
   const matches = detectAllergens(recipeOrIngredients)
   const contains = [...new Set(matches.map((match) => match.allergen))]
   const blocked = contains.filter((allergen) => hard.includes(allergen))
-  const ingredientLines = toIngredientLines(recipeOrIngredients)
+  const ingredientDataAvailable = hasIngredientData(recipeOrIngredients)
   const mayContainUncertain = findUncertainIngredients(recipeOrIngredients)
   const unknownHardAllergens = hard.filter((allergen) => !KNOWN_ALLERGENS.has(allergen))
+  const needsReview = mayContainUncertain.length > 0
+    || unknownHardAllergens.length > 0
+    || (hard.length > 0 && !ingredientDataAvailable)
+  const reviewReasons = [
+    ...(mayContainUncertain.length > 0 ? ['opaque_or_precautionary_ingredient_terms'] : []),
+    ...(unknownHardAllergens.length > 0 ? ['custom_allergen_not_in_graph'] : []),
+    ...(hard.length > 0 && !ingredientDataAvailable ? ['ingredient_data_unavailable'] : []),
+  ]
 
   return {
     checked: true,
-    ingredient_data_available: ingredientLines.length > 0,
-    safe: hard.length === 0 || (ingredientLines.length > 0 && blocked.length === 0 && mayContainUncertain.length === 0 && unknownHardAllergens.length === 0),
+    ingredient_data_available: ingredientDataAvailable,
+    needs_review: needsReview,
+    review_reasons: reviewReasons,
+    safe: hard.length === 0 || (ingredientDataAvailable && blocked.length === 0 && mayContainUncertain.length === 0 && unknownHardAllergens.length === 0),
     contains,
     blocked,
     matches,


### PR DESCRIPTION
## Summary
- complete the P0 allergen trust path from issue #298 across generated, searched, clipped, recommended, adapted, and cooking flows
- make the shared graph fail closed for missing ingredient data, expose `needs_review`, scan structured ingredients and hidden instruction additives, and avoid treating vector titles as ingredient evidence
- keep allergen warnings visible at recipe-card and cooking entry, annotate clipped/search recipes for the active profile, and prevent unresolved recipes from entering the meal planner
- document the verification contract and add focused regression coverage

Closes #298

## Validation
- `npm run test:coverage` (shared): 77 tests passed; coverage thresholds met
- `npm test -- --runInBand` (recipe-app): 363 tests passed; coverage thresholds met
- `npm test -- --reporter=dot` (recipe-generation-worker): 177 tests passed
- `npm test -- --reporter=dot` (recipe-recommendation-worker): 194 passed, 11 skipped
- `npm run build` (recipe-app): passed
- `npm run lint -- --no-warn-ignored` (recipe-generation-worker): passed with existing `no-console` warnings
- `node scripts/check-coverage.mjs --package {shared,recipe-generation-worker,recipe-recommendation-worker,recipe-app}`: all minimums met

No production credentials or environment files were changed.