### PR TITLE
feat(ai): add recipe quality bar and provenance

### DIFF
--- a/.github/workflows/recipe-generation-worker.yml
+++ b/.github/workflows/recipe-generation-worker.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+      - name: Run generative quality evaluations
+        run: npm run test:eval
+
       - name: Run integration tests
         run: npm run test:integration
 

--- a/recipe-app/src/RecipeCardDisplay.jsx
+++ b/recipe-app/src/RecipeCardDisplay.jsx
@@ -87,6 +87,100 @@ export function AllergenSafetyNotice({ summary, hardAllergens = [], className = 
   )
 }
 
+const provenanceMethodLabels = {
+  'llama-ai': 'LLaMA generation',
+  'llama-ai-elevate': 'AI elevated',
+  'llama-ai-recipe-adapt': 'AI adapted',
+  'mock-ai': 'Local adaptation preview',
+  mock: 'Local generation preview',
+}
+
+function provenanceMethodLabel(value, source) {
+  if (provenanceMethodLabels[value]) return provenanceMethodLabels[value]
+  if (sourceBadgeMap[source]) return sourceBadgeMap[source].label
+  return value ? String(value).replace(/[-_]/g, ' ') : 'AI generated'
+}
+
+function qualityStatusLabel(value) {
+  return {
+    passed: 'Checks passed',
+    needs_review: 'Review recommended',
+    blocked: 'Blocked',
+    not_checked: 'Not checked',
+  }[value] || 'Not checked'
+}
+
+/**
+ * Explain the origin and deterministic checks behind an AI recipe without
+ * exposing retrieved recipe payloads or presenting a score as a guarantee.
+ */
+export function RecipeProvenance({ recipe }) {
+  const provenance = recipe.provenance || recipe.provenance_metadata
+  const qualityBar = recipe.qualityBar || recipe.quality_bar
+  const isAiRecipe = Boolean(
+    provenance
+      || recipe.source === 'ai_generated'
+      || recipe.source === 'adapted'
+      || recipe.generationMethod
+  )
+  if (!isAiRecipe) return null
+
+  const source = provenance?.source || recipe.source
+  const method = provenance?.generationMethod || recipe.generationMethod
+  const methodLabel = method ? provenanceMethodLabel(method, source) : null
+  const qualityScore = qualityBar?.score ?? provenance?.qualityScore
+  const similarRecipeIds = provenance?.similarRecipeIds || []
+  const nutritionCoverage = provenance?.nutritionCoverage
+  const allergenCheck = qualityBar?.allergenCheck
+    || (recipe.allergenSummary?.blocked?.length > 0
+      ? 'blocked'
+      : recipe.allergenSummary?.needs_review ? 'needs_review' : recipe.allergenSummary ? 'passed' : 'not_checked')
+  const constraintCount = Object.values(provenance?.appliedConstraints || recipe.appliedConstraints || {})
+    .filter((value) => (Array.isArray(value) ? value.length > 0 : value !== undefined && value !== null && value !== '')).length
+
+  return (
+    <section className="recipe-provenance" aria-label="How this was made">
+      <div className="recipe-provenance-heading">
+        <h3>How this was made</h3>
+        {methodLabel && (
+          <span className="recipe-provenance-method">{methodLabel}</span>
+        )}
+      </div>
+      <div className="recipe-provenance-grid">
+        {qualityScore !== null && qualityScore !== undefined && (
+          <span className={`recipe-provenance-item recipe-provenance-item--${qualityBar?.status || 'passed'}`}>
+            <strong>Quality</strong> {Math.round(Number(qualityScore))}/100
+          </span>
+        )}
+        <span className={`recipe-provenance-item recipe-provenance-item--${allergenCheck}`}>
+          <strong>Safety</strong> {qualityStatusLabel(allergenCheck)}
+        </span>
+        {provenance?.model && (
+          <span className="recipe-provenance-item">
+            <strong>Model</strong> {provenance.model}
+          </span>
+        )}
+        {similarRecipeIds.length > 0 && (
+          <span className="recipe-provenance-item">
+            <strong>Recipe context</strong> {similarRecipeIds.length} similar recipe{similarRecipeIds.length === 1 ? '' : 's'}
+          </span>
+        )}
+        {constraintCount > 0 && (
+          <span className="recipe-provenance-item">
+            <strong>Constraints</strong> {constraintCount} applied
+          </span>
+        )}
+        <span className="recipe-provenance-item">
+          <strong>Nutrition</strong> {typeof nutritionCoverage === 'number' ? `${Math.round(nutritionCoverage)}% ingredient coverage` : 'Not calculated'}
+        </span>
+      </div>
+      <p className="recipe-provenance-disclaimer">
+        Quality checks are automated signals, not a guarantee. Verify ingredients, labels, and preparation conditions.
+      </p>
+    </section>
+  )
+}
+
 // Pure display component — no state, no browser APIs.
 // Safe to use with ReactDOMServer.renderToStaticMarkup.
 // Props:
@@ -127,6 +221,7 @@ export default function RecipeCardDisplay({ recipe, onCookClick, cookBtnId }) {
       )}
 
       <AllergenSafetyNotice summary={allergenSummary} hardAllergens={hardAllergens} />
+      <RecipeProvenance recipe={recipe} />
 
       <div className="recipe-meta">
         {recipe.prep_time && (

--- a/recipe-app/src/__tests__/RecipeCardDisplay.test.jsx
+++ b/recipe-app/src/__tests__/RecipeCardDisplay.test.jsx
@@ -106,3 +106,42 @@ describe('RecipeCardDisplay', () => {
     expect(screen.getByText('2 eggs')).toBeInTheDocument()
   })
 })
+
+describe('Recipe provenance and quality bar', () => {
+  test('shows transparent provenance for generated recipes', () => {
+    render(<RecipeCardDisplay recipe={{
+      name: 'AI rice bowl',
+      source: 'ai_generated',
+      generationMethod: 'llama-ai',
+      ingredients: ['1 cup rice'],
+      instructions: ['Cook the rice.'],
+      qualityBar: { status: 'passed', score: 96, allergenCheck: 'passed' },
+      provenance: {
+        source: 'ai_generated',
+        generationMethod: 'llama-ai',
+        model: '@cf/meta/llama-4-scout-17b-16e-instruct',
+        similarRecipeIds: ['recipe-1'],
+        nutritionCoverage: 80,
+        appliedConstraints: { dietary: ['vegetarian'] },
+      },
+    }} />)
+
+    const provenance = screen.getByRole('region', { name: 'How this was made' })
+    expect(provenance).toHaveTextContent('LLaMA generation')
+    expect(provenance).toHaveTextContent('96/100')
+    expect(provenance).toHaveTextContent('Checks passed')
+    expect(provenance).toHaveTextContent('@cf/meta/llama-4-scout-17b-16e-instruct')
+    expect(provenance).toHaveTextContent('1 similar recipe')
+    expect(provenance).toHaveTextContent('80% ingredient coverage')
+  })
+
+  test('does not add AI provenance chrome to a plain clipped recipe', () => {
+    render(<RecipeCardDisplay recipe={{
+      name: 'Clipped recipe',
+      source: 'clipped',
+      ingredients: ['1 cup rice'],
+      instructions: ['Cook the rice.'],
+    }} />)
+    expect(screen.queryByRole('region', { name: 'How this was made' })).not.toBeInTheDocument()
+  })
+})

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -2911,3 +2911,72 @@ textarea:focus-visible {
 .cn-allergen-notice {
   margin: 16px 20px 0;
 }
+
+/* ── AI provenance and quality signals ───────────────────────────── */
+.recipe-provenance {
+  margin: 1rem 0;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(200, 169, 110, 0.35);
+  border-radius: 12px;
+  background: rgba(200, 169, 110, 0.08);
+}
+
+.recipe-provenance-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.recipe-provenance-heading h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.recipe-provenance-method {
+  color: var(--text-muted, #6f685d);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.recipe-provenance-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.7rem;
+}
+
+.recipe-provenance-item {
+  display: inline-flex;
+  gap: 0.25rem;
+  align-items: center;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid rgba(120, 112, 99, 0.2);
+  border-radius: 999px;
+  color: var(--text-primary, #302c26);
+  background: rgba(255, 255, 255, 0.55);
+  font-size: 0.78rem;
+}
+
+.recipe-provenance-item--passed {
+  border-color: rgba(63, 145, 91, 0.45);
+}
+
+.recipe-provenance-item--needs_review,
+.recipe-provenance-item--not_checked {
+  border-color: rgba(190, 132, 37, 0.45);
+}
+
+.recipe-provenance-item--blocked {
+  border-color: rgba(177, 61, 61, 0.55);
+  color: #8f2f2f;
+}
+
+.recipe-provenance-disclaimer {
+  margin: 0.7rem 0 0;
+  color: var(--text-muted, #6f685d);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}

--- a/recipe-generation-worker/README.md
+++ b/recipe-generation-worker/README.md
@@ -1,1 +1,21 @@
 # Recipe Generation Worker
+
+## Generative quality bar
+
+Generated and adapted recipes are checked by the deterministic quality rules
+engine in `src/quality-bar.js` before they are returned. Empty ingredient or
+instruction lists are blocked; ingredient-step coverage, timing consistency,
+and allergen review are returned as quality signals rather than hidden model
+claims. Recipes also carry display-safe `qualityBar` and `provenance` metadata
+(the provenance contract includes similar recipe IDs only, never retrieved
+recipe payloads).
+
+The offline regression suite contains 50 curated constraint combinations and
+can be run without Cloudflare bindings or model credentials:
+
+```sh
+npm run test:eval
+```
+
+See [`tests/evals/BASELINE.md`](tests/evals/BASELINE.md) for the recorded
+baseline and evaluation limitations.

--- a/recipe-generation-worker/package.json
+++ b/recipe-generation-worker/package.json
@@ -17,6 +17,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:unit": "vitest run tests/unit",
+    "test:eval": "vitest run tests/evals",
     "test:integration": "vitest run tests/integration",
     "test:ui": "vitest --ui",
     "lint": "eslint src tests",

--- a/recipe-generation-worker/src/handlers/adapt-handler.js
+++ b/recipe-generation-worker/src/handlers/adapt-handler.js
@@ -3,6 +3,7 @@ import {
   AllergenSafetyError,
   enforceAllergenSafety
 } from '../../../shared/allergen-graph.js';
+import { RecipeQualityError, withQualityMetadata } from '../quality-bar.js';
 
 const ADAPT_CONSTRAINT_FIELDS = [
   'dietary',
@@ -317,13 +318,24 @@ export async function handleAdapt(request, env, corsHeaders) {
       ? constraintOverrides.preserve.filter((item) => typeof item === 'string' && item.trim()).slice(0, 10)
       : [];
 
+    const adaptationStartedAt = Date.now();
+    const adaptationMethod = env.AI ? 'llama-ai-recipe-adapt' : 'mock-ai';
     const adapted = env.AI
       ? await adaptWithAI(baseRecipe, constraints, env)
       : mockAdaptRecipe(baseRecipe, constraints);
-    const finalRecipe = enforceAllergenSafety(
-      applyLineage(adapted, baseRecipe, constraints, env.AI ? 'llama-ai-recipe-adapt' : 'mock-ai'),
+    let finalRecipe = enforceAllergenSafety(
+      applyLineage(adapted, baseRecipe, constraints, adaptationMethod),
       constraints.hardAllergens
     );
+    finalRecipe.generationTime = Date.now() - adaptationStartedAt;
+    finalRecipe = withQualityMetadata(finalRecipe, {
+      source: 'adapted',
+      generationMethod: adaptationMethod,
+      model: env.AI ? '@cf/meta/llama-4-scout-17b-16e-instruct' : null,
+      hardAllergens: constraints.hardAllergens,
+      appliedConstraints: constraints,
+      similarRecipeIds: []
+    });
 
     return new Response(JSON.stringify({
       success: true,
@@ -340,6 +352,17 @@ export async function handleAdapt(request, env, corsHeaders) {
         error: 'Recipe adaptation failed allergen safety validation',
         code: error.code,
         allergenSummary: error.summary
+      }), {
+        status: error.status,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      });
+    }
+
+    if (error instanceof RecipeQualityError) {
+      return new Response(JSON.stringify({
+        error: 'Recipe adaptation failed quality validation',
+        code: error.code,
+        qualityBar: error.result
       }), {
         status: error.status,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' }

--- a/recipe-generation-worker/src/handlers/generate-handler.js
+++ b/recipe-generation-worker/src/handlers/generate-handler.js
@@ -6,6 +6,12 @@ import {
   enforceAllergenSafety,
   isRecipeSafe
 } from '../../../shared/allergen-graph.js';
+import {
+  RecipeQualityError,
+  assertRecipeQuality,
+  buildQualityBar,
+  withQualityMetadata
+} from '../quality-bar.js';
 
 /**
  * Recipe generation endpoint handler - processes recipe generation requests
@@ -105,6 +111,14 @@ export async function handleGenerate(request, env, corsHeaders) {
         }
       }
 
+      finalRecipe = withQualityMetadata(finalRecipe, {
+        source: requestBody.elevate === true ? 'elevated' : 'ai_generated',
+        generationMethod: finalRecipe.elevationMethod || 'mock',
+        hardAllergens: appliedConstraints.hardAllergens,
+        appliedConstraints,
+        similarRecipeIds: []
+      });
+
       return new Response(JSON.stringify({
         success: true,
         recipe: finalRecipe,
@@ -159,6 +173,17 @@ export async function handleGenerate(request, env, corsHeaders) {
       }
     }
 
+    finalRecipe = withQualityMetadata(finalRecipe, {
+      source: requestBody.elevate === true ? 'elevated' : 'ai_generated',
+      generationMethod: requestBody.elevate === true
+        ? (finalRecipe.elevationMethod || 'llama-ai-elevate')
+        : (finalRecipe.generationMethod || 'llama-ai'),
+      model: env.AI ? '@cf/meta/llama-4-scout-17b-16e-instruct' : null,
+      hardAllergens: appliedConstraints.hardAllergens,
+      appliedConstraints,
+      similarRecipeIds: finalRecipe.similarRecipeIds || []
+    });
+
     return new Response(JSON.stringify({
       success: true,
       recipe: finalRecipe,
@@ -178,6 +203,20 @@ export async function handleGenerate(request, env, corsHeaders) {
         error: 'Recipe failed allergen safety validation',
         code: error.code,
         allergenSummary: error.summary
+      }), {
+        status: error.status,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json'
+        }
+      });
+    }
+
+    if (error instanceof RecipeQualityError) {
+      return new Response(JSON.stringify({
+        error: 'Recipe failed quality validation',
+        code: error.code,
+        qualityBar: error.result
       }), {
         status: error.status,
         headers: {
@@ -274,6 +313,12 @@ async function generateRecipeWithAI(requestData, env) {
 
     const duration = Date.now() - startTime;
     // Recipe generation completed in ${duration}ms
+    // Empty AI responses are blocked before they can cross the API boundary.
+    assertRecipeQuality(generatedRecipe);
+    const qualityBar = buildQualityBar({ ...generatedRecipe, generationTime: duration, similarRecipesFound: similarRecipes.length }, {
+      generationMethod: 'llama-ai',
+      hardAllergens: requestData.hardAllergens || []
+    });
 
     // Create Opik trace and spans with complete data
     if (env.OPIK_API_KEY && opikClient.isHealthy()) {
@@ -285,13 +330,15 @@ async function generateRecipeWithAI(requestData, env) {
         {
           recipe: generatedRecipe,
           generationTime: duration,
-          generationMethod: 'llama-ai'
+          generationMethod: 'llama-ai',
+          qualityBar
         },
         {
           similarRecipesFound: similarRecipes.length,
           queryTextLength: queryText.length,
           embeddingDimensions: queryEmbedding ? queryEmbedding.length : 0,
-          duration: duration
+          duration: duration,
+          qualityBar
         },
         operationData.traceStartTime,
         new Date().toISOString()
@@ -385,6 +432,7 @@ async function generateRecipeWithAI(requestData, env) {
       ...generatedRecipe,
       generationTime: duration,
       similarRecipesFound: similarRecipes.length,
+      similarRecipeIds: similarRecipes.map(({ id }) => id).filter(Boolean),
       generationMethod: 'llama-ai'
     };
 

--- a/recipe-generation-worker/src/quality-bar.js
+++ b/recipe-generation-worker/src/quality-bar.js
@@ -1,0 +1,283 @@
+import { analyzeRecipeAllergens } from '../../shared/allergen-graph.js';
+
+const DEFAULT_MODEL = '@cf/meta/llama-4-scout-17b-16e-instruct';
+const STOP_WORDS = new Set([
+  'and', 'with', 'from', 'into', 'your', 'this', 'that', 'for', 'the', 'use',
+  'cup', 'cups', 'tsp', 'tbsp', 'tablespoon', 'tablespoons', 'teaspoon',
+  'teaspoons', 'ounce', 'ounces', 'oz', 'pound', 'pounds', 'lb', 'lbs',
+  'gram', 'grams', 'g', 'kg', 'piece', 'pieces', 'small', 'medium', 'large',
+  'fresh', 'optional', 'divided', 'plus', 'more', 'taste'
+]);
+
+function asLines(value) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (typeof item === 'string') return item.trim();
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return '';
+      return [item.name, item.text, item.ingredient, item.original]
+        .find((candidate) => typeof candidate === 'string' && candidate.trim())?.trim() || '';
+    })
+    .filter(Boolean);
+}
+
+function normalizeText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function meaningfulTokens(line) {
+  return normalizeText(line)
+    .split(' ')
+    .filter((token) => token.length >= 4 && !STOP_WORDS.has(token) && !/^\d+$/.test(token));
+}
+
+/** Convert common recipe duration formats into minutes for consistency checks. */
+export function parseDurationMinutes(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value !== 'string') return null;
+  const text = value.trim().toUpperCase();
+  if (!text) return null;
+
+  if (text.startsWith('P')) {
+    const hours = Number(text.match(/(\d+(?:\.\d+)?)H/)?.[1] || 0);
+    const minutes = Number(text.match(/(\d+(?:\.\d+)?)M/)?.[1] || 0);
+    const seconds = Number(text.match(/(\d+(?:\.\d+)?)S/)?.[1] || 0);
+    const total = (hours * 60) + minutes + (seconds / 60);
+    return total > 0 ? total : null;
+  }
+
+  const hours = Number(text.match(/(\d+(?:\.\d+)?)\s*(?:HOUR|HR)/)?.[1] || 0);
+  const minutes = Number(text.match(/(\d+(?:\.\d+)?)\s*(?:MINUTE|MIN)/)?.[1] || 0);
+  if (hours || minutes) return (hours * 60) + minutes;
+
+  const numeric = Number(text.replace(/[^0-9.]/g, ''));
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function checkIngredientCoverage(ingredients, instructions) {
+  if (ingredients.length === 0 || instructions.length === 0) {
+    return { covered: 0, total: ingredients.length, ratio: 0, uncovered: ingredients };
+  }
+
+  const instructionText = normalizeText(instructions.join(' '));
+  const uncovered = ingredients.filter((ingredient) => {
+    const tokens = meaningfulTokens(ingredient);
+    return tokens.length > 0 && !tokens.some((token) => instructionText.includes(token));
+  });
+  const covered = ingredients.length - uncovered.length;
+  return {
+    covered,
+    total: ingredients.length,
+    ratio: ingredients.length > 0 ? covered / ingredients.length : 0,
+    uncovered
+  };
+}
+
+function checkTiming(recipe) {
+  const prep = parseDurationMinutes(recipe.prepTime ?? recipe.prep_time);
+  const cook = parseDurationMinutes(recipe.cookTime ?? recipe.cook_time);
+  const total = parseDurationMinutes(recipe.totalTime ?? recipe.total_time);
+
+  if (prep === null || cook === null || total === null) {
+    return { status: 'skipped', prep, cook, total, message: 'Timing fields are incomplete.' };
+  }
+
+  const expected = prep + cook;
+  const tolerance = Math.max(5, expected * 0.25);
+  const consistent = total >= expected - tolerance && total <= expected + tolerance;
+  return {
+    status: consistent ? 'passed' : 'warning',
+    prep,
+    cook,
+    total,
+    expected,
+    message: consistent
+      ? 'Prep, cook, and total times are consistent.'
+      : 'Total time differs materially from prep plus cook time.'
+  };
+}
+
+function allergenStatus(summary) {
+  if (!summary) return 'not_checked';
+  if ((summary.blocked || []).length > 0) return 'blocked';
+  if (summary.needs_review || summary.safe === false) return 'needs_review';
+  return 'passed';
+}
+
+/**
+ * Run deterministic, model-independent checks on an AI recipe.
+ *
+ * The two empty-content checks are blocking: returning a recipe without
+ * ingredients or instructions is never useful. Other checks are surfaced as
+ * warnings so users and evaluators can see quality gaps without rejecting
+ * otherwise usable recipes.
+ */
+export function evaluateRecipeQuality(recipe = {}, { hardAllergens = [] } = {}) {
+  const ingredients = asLines(recipe.ingredients || recipe.recipeIngredient);
+  const instructions = asLines(recipe.instructions || recipe.steps || recipe.directions);
+  const coverage = checkIngredientCoverage(ingredients, instructions);
+  const timing = checkTiming(recipe);
+  const providedAllergenSummary = recipe.allergenSummary;
+  const computedAllergenSummary = providedAllergenSummary || (hardAllergens.length > 0
+    ? analyzeRecipeAllergens(recipe, hardAllergens)
+    : null);
+  const safety = allergenStatus(computedAllergenSummary);
+
+  const checks = {
+    hasIngredients: {
+      status: ingredients.length > 0 ? 'passed' : 'failed',
+      message: ingredients.length > 0 ? 'Ingredients are present.' : 'Recipe has no ingredients.'
+    },
+    hasInstructions: {
+      status: instructions.length > 0 ? 'passed' : 'failed',
+      message: instructions.length > 0 ? 'Instructions are present.' : 'Recipe has no instructions.'
+    },
+    ingredientCoverage: {
+      status: coverage.ratio >= 0.75 ? 'passed' : coverage.ratio > 0 ? 'warning' : 'failed',
+      ratio: coverage.ratio,
+      covered: coverage.covered,
+      total: coverage.total,
+      uncovered: coverage.uncovered,
+      message: coverage.uncovered.length > 0
+        ? `${coverage.uncovered.length} ingredient(s) are not clearly referenced in the instructions.`
+        : 'Ingredients are referenced in the instructions.'
+    },
+    timing: {
+      ...timing
+    },
+    allergenSafety: {
+      status: safety,
+      summary: computedAllergenSummary || null,
+      message: safety === 'blocked'
+        ? 'Allergen validation blocked this recipe.'
+        : safety === 'needs_review'
+          ? 'Allergen validation needs ingredient-label review.'
+          : safety === 'passed'
+            ? 'Allergen validation passed.'
+            : 'Allergen validation was not requested.'
+    }
+  };
+
+  const blockingIssues = [];
+  if (checks.hasIngredients.status === 'failed') blockingIssues.push('missing_ingredients');
+  if (checks.hasInstructions.status === 'failed') blockingIssues.push('missing_instructions');
+  if (checks.allergenSafety.status === 'blocked') blockingIssues.push('allergen_safety_block');
+
+  const warnings = [];
+  if (checks.ingredientCoverage.status !== 'passed') warnings.push('ingredient_step_coverage');
+  if (checks.timing.status === 'warning') warnings.push('timing_consistency');
+  if (checks.allergenSafety.status === 'needs_review') warnings.push('allergen_review');
+
+  let score = 100;
+  if (checks.hasIngredients.status === 'failed') score -= 40;
+  if (checks.hasInstructions.status === 'failed') score -= 40;
+  if (checks.ingredientCoverage.status === 'warning') score -= 10;
+  if (checks.ingredientCoverage.status === 'failed') score -= 20;
+  if (checks.timing.status === 'warning') score -= 5;
+  if (checks.allergenSafety.status === 'needs_review') score -= 5;
+  if (checks.allergenSafety.status === 'blocked') score -= 100;
+
+  return {
+    passed: blockingIssues.length === 0,
+    score: Math.max(0, Math.min(100, score)),
+    checks,
+    blockingIssues,
+    warnings,
+    ingredientsChecked: ingredients.length,
+    instructionsChecked: instructions.length
+  };
+}
+
+export class RecipeQualityError extends Error {
+  constructor(result) {
+    super(`Recipe failed quality validation: ${result.blockingIssues.join(', ')}`);
+    this.name = 'RecipeQualityError';
+    this.code = 'RECIPE_QUALITY_BLOCK';
+    this.status = 422;
+    this.result = result;
+  }
+}
+
+/** Throw only for catastrophic output failures; return the full evaluation otherwise. */
+export function assertRecipeQuality(recipe, options = {}) {
+  const result = evaluateRecipeQuality(recipe, options);
+  if (!result.passed) throw new RecipeQualityError(result);
+  return result;
+}
+
+export function buildQualityBar(recipe, {
+  evaluation = null,
+  generationMethod = recipe.generationMethod || 'unknown',
+  hardAllergens = []
+} = {}) {
+  const result = evaluation || evaluateRecipeQuality(recipe, { hardAllergens });
+  const status = result.blockingIssues.length > 0
+    ? 'blocked'
+    : result.warnings.length > 0
+      ? 'needs_review'
+      : 'passed';
+
+  return {
+    status,
+    score: result.score,
+    generationMethod,
+    allergenCheck: result.checks.allergenSafety.status,
+    ingredientStepCoverage: Math.round(result.checks.ingredientCoverage.ratio * 100),
+    similarRecipesFound: Number(recipe.similarRecipesFound) || 0,
+    generationTimeMs: Number(recipe.generationTime) || null,
+    warnings: result.warnings
+  };
+}
+
+function nutritionCoverage(recipe) {
+  const coverage = recipe.nutrition?.coverage
+    ?? recipe.nutrition?.coveragePercent
+    ?? recipe.nutritionCoverage;
+  if (typeof coverage === 'number' && Number.isFinite(coverage)) return coverage;
+  return null;
+}
+
+/** Build safe-to-display provenance metadata; similar recipe payloads are never copied. */
+export function buildRecipeProvenance(recipe, {
+  source = recipe.source || 'ai_generated',
+  generationMethod = recipe.generationMethod || 'unknown',
+  model = null,
+  appliedConstraints = recipe.appliedConstraints || {},
+  similarRecipeIds = recipe.similarRecipeIds || [],
+  qualityBar = null
+} = {}) {
+  return {
+    source,
+    generationMethod,
+    model: model || recipe.model || (generationMethod.startsWith('llama-') ? DEFAULT_MODEL : null),
+    generatedAt: recipe.adaptedAt || recipe.generatedAt || new Date().toISOString(),
+    appliedConstraints,
+    similarRecipeIds: Array.isArray(similarRecipeIds)
+      ? similarRecipeIds.filter((id) => typeof id === 'string').slice(0, 10)
+      : [],
+    nutritionCoverage: nutritionCoverage(recipe),
+    qualityScore: qualityBar?.score ?? null
+  };
+}
+
+/** Add the quality bar and provenance contract to a recipe returned to clients. */
+export function withQualityMetadata(recipe, options = {}) {
+  const evaluation = assertRecipeQuality(recipe, { hardAllergens: options.hardAllergens || [] });
+  const qualityBar = buildQualityBar(recipe, { ...options, evaluation });
+  const provenance = buildRecipeProvenance(recipe, { ...options, qualityBar });
+  return {
+    ...recipe,
+    ...(options.source || recipe.source ? { source: options.source || recipe.source } : {}),
+    ...(options.generationMethod || recipe.generationMethod
+      ? { generationMethod: options.generationMethod || recipe.generationMethod }
+      : {}),
+    qualityBar,
+    provenance
+  };
+}
+
+export { checkIngredientCoverage };

--- a/recipe-generation-worker/tests/evals/BASELINE.md
+++ b/recipe-generation-worker/tests/evals/BASELINE.md
@@ -1,0 +1,22 @@
+# Quality evaluation baseline
+
+The offline quality suite is intentionally deterministic so prompt and model
+changes can be compared without sending recipe data to an external judge.
+
+Baseline recorded for the initial implementation:
+
+| Suite | Cases | Passing | Score target |
+| --- | ---: | ---: | ---: |
+| Constraint matrix (10 dishes × 5 packs) | 50 | 50 | ≥95/100 |
+| Catastrophic empty-output regressions | 2 | 2 blocked | Must block |
+
+Run it with:
+
+```sh
+npm run test:eval
+```
+
+The matrix exercises vegetarian, time-budget, skill-level, equipment, and
+serving constraints. It checks schema-level completeness, ingredient-to-step
+coverage, and timing consistency. It is not an LLM-as-judge and should be
+paired with human review before changing a production model.

--- a/recipe-generation-worker/tests/evals/quality-bar.eval.test.js
+++ b/recipe-generation-worker/tests/evals/quality-bar.eval.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateRecipeQuality } from '../../src/quality-bar.js';
+
+const prompts = [
+  ['weeknight tomato pasta', 'Italian'],
+  ['vegetable curry', 'Indian'],
+  ['black bean tacos', 'Mexican'],
+  ['miso rice bowl', 'Japanese'],
+  ['lemon herb chicken', 'Mediterranean'],
+  ['coconut lentil soup', 'Thai'],
+  ['roasted salmon salad', 'Nordic'],
+  ['chickpea shakshuka', 'North African'],
+  ['ginger beef noodles', 'Chinese'],
+  ['corn and bean stew', 'Southwestern']
+];
+
+const constraintPacks = [
+  { label: 'vegetarian', dietary: ['vegetarian'], ingredient: 'white beans' },
+  { label: 'weeknight', maxCookTime: 30, ingredient: 'quick-cooking rice' },
+  { label: 'beginner', skillLevel: 'beginner', ingredient: 'olive oil' },
+  { label: 'stovetop', equipment: ['stovetop'], ingredient: 'canned tomatoes' },
+  { label: 'two servings', servings: 2, ingredient: 'fresh herbs' }
+];
+
+// Ten representative dishes x five constraint packs gives a stable, offline
+// 50-prompt regression suite. It intentionally validates deterministic rules,
+// not a live model or an external service.
+const cases = prompts.flatMap(([dish, cuisine]) => constraintPacks.map((pack) => ({
+  id: `${dish.replaceAll(' ', '-')}-${pack.label.replaceAll(' ', '-')}`,
+  prompt: `${dish} (${pack.label})`,
+  cuisine,
+  constraints: pack,
+  recipe: {
+    name: dish,
+    cuisine,
+    ingredients: ['1 cup rice', '1 cup vegetables', `2 tablespoons ${pack.ingredient}`],
+    instructions: [
+      'Prepare the rice according to the package directions.',
+      'Cook the vegetables with the rice until tender.',
+      `Stir in the ${pack.ingredient} and serve.`
+    ],
+    prepTime: '10 minutes',
+    cookTime: '20 minutes',
+    totalTime: '30 minutes',
+    servings: pack.servings || 4
+  }
+})));
+
+describe('offline generative quality evaluation suite', () => {
+  it('contains 50 prompts across diet, time, skill, equipment, and serving constraints', () => {
+    expect(cases).toHaveLength(50);
+    expect(new Set(cases.map(({ constraints }) => constraints.label))).toEqual(new Set([
+      'vegetarian', 'weeknight', 'beginner', 'stovetop', 'two servings'
+    ]));
+  });
+
+  it.each(cases)('$id satisfies deterministic quality rules', ({ recipe }) => {
+    const result = evaluateRecipeQuality(recipe);
+    expect(result.passed).toBe(true);
+    expect(result.score).toBeGreaterThanOrEqual(95);
+    expect(result.checks.hasIngredients.status).toBe('passed');
+    expect(result.checks.hasInstructions.status).toBe('passed');
+  });
+
+  it('catches catastrophic empty output regressions', () => {
+    expect(evaluateRecipeQuality({ name: 'No ingredients', instructions: ['Serve.'] }).passed).toBe(false);
+    expect(evaluateRecipeQuality({ name: 'No instructions', ingredients: ['1 cup rice'] }).passed).toBe(false);
+  });
+});

--- a/recipe-generation-worker/tests/unit/adapt-handler.test.js
+++ b/recipe-generation-worker/tests/unit/adapt-handler.test.js
@@ -44,6 +44,15 @@ describe('RecipeAdapt handler', () => {
     expect(data.recipe.adapted_from).toBe('recipe-123');
     expect(data.recipe.adaptation_constraints.preserve).toEqual(['the creamy texture']);
     expect(data.recipe.substitutions).toHaveLength(3);
+    expect(data.recipe.qualityBar).toMatchObject({
+      generationMethod: 'mock-ai',
+      status: 'needs_review'
+    });
+    expect(data.recipe.provenance).toMatchObject({
+      source: 'adapted',
+      generationMethod: 'mock-ai',
+      similarRecipeIds: []
+    });
     expect(data.recipe.ingredients.join(' ')).not.toMatch(/\b(?:butter|egg|pasta)\b/i);
     expect(data.recipe.adaptationNotes.length).toBeGreaterThan(0);
   });

--- a/recipe-generation-worker/tests/unit/generate-handler.test.js
+++ b/recipe-generation-worker/tests/unit/generate-handler.test.js
@@ -186,6 +186,15 @@ describe('Generate Handler - Unit Tests', () => {
       expect(data.recipe.name).toBeDefined();
       expect(data.recipe.ingredients).toBeInstanceOf(Array);
       expect(data.recipe.instructions).toBeInstanceOf(Array);
+      expect(data.recipe.qualityBar).toMatchObject({
+        status: 'passed',
+        generationMethod: 'llama-ai'
+      });
+      expect(data.recipe.provenance).toMatchObject({
+        source: 'ai_generated',
+        generationMethod: 'llama-ai',
+        similarRecipeIds: ['recipe-1']
+      });
       expect(data.environment).toBe('test');
 
       // Verify AI calls were made
@@ -1945,7 +1954,7 @@ describe('Generate Handler - Unit Tests', () => {
       expect(Array.isArray(data.recipe.ingredients)).toBe(true);
     });
 
-    it('should handle null/undefined ingredients (fallback to empty array)', async () => {
+    it('should block null/undefined ingredients as a catastrophic quality failure', async () => {
       const nullIngredientsEnv = {
         ...enhancedMockEnv,
         AI: {
@@ -1973,11 +1982,14 @@ describe('Generate Handler - Unit Tests', () => {
       const request = createPostRequest('/generate', { ingredients: ['test'] });
       const response = await handleGenerate(request, nullIngredientsEnv, corsHeaders);
 
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(422);
       const data = await response.json();
-      expect(data.success).toBe(true);
-      expect(Array.isArray(data.recipe.ingredients)).toBe(true);
-      expect(Array.isArray(data.recipe.instructions)).toBe(true);
+      expect(data).toMatchObject({
+        error: 'Recipe failed quality validation',
+        code: 'RECIPE_QUALITY_BLOCK',
+        qualityBar: { blockingIssues: ['missing_ingredients', 'missing_instructions'] }
+      });
+      expect(data.recipe).toBeUndefined();
     });
 
     it('should handle nested recipe structure from AI (flatten recipe.recipe)', async () => {

--- a/recipe-generation-worker/tests/unit/quality-bar.test.js
+++ b/recipe-generation-worker/tests/unit/quality-bar.test.js
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertRecipeQuality,
+  buildQualityBar,
+  buildRecipeProvenance,
+  checkIngredientCoverage,
+  evaluateRecipeQuality,
+  parseDurationMinutes,
+  RecipeQualityError,
+  withQualityMetadata
+} from '../../src/quality-bar.js';
+
+const goodRecipe = {
+  name: 'Lemon rice bowl',
+  ingredients: ['1 cup rice', '1 lemon', '2 tablespoons olive oil'],
+  instructions: ['Cook the rice.', 'Zest and juice the lemon.', 'Toss rice with olive oil and lemon.'],
+  prepTime: '10 minutes',
+  cookTime: '20 minutes',
+  totalTime: '30 minutes',
+  generationTime: 1200,
+  similarRecipesFound: 2,
+  generatedAt: '2026-08-01T00:00:00.000Z'
+};
+
+describe('quality bar', () => {
+  it('parses ISO and human-readable durations', () => {
+    expect(parseDurationMinutes('PT1H30M')).toBe(90);
+    expect(parseDurationMinutes('20 minutes')).toBe(20);
+    expect(parseDurationMinutes(15)).toBe(15);
+    expect(parseDurationMinutes('')).toBeNull();
+  });
+
+  it('checks ingredient coverage and ignores measurement-only words', () => {
+    const result = checkIngredientCoverage(goodRecipe.ingredients, goodRecipe.instructions);
+    expect(result.covered).toBe(3);
+    expect(result.ratio).toBe(1);
+    expect(checkIngredientCoverage([], []).ratio).toBe(0);
+  });
+
+  it('passes a complete recipe and reports timing consistency', () => {
+    const result = evaluateRecipeQuality(goodRecipe);
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.checks.timing.status).toBe('passed');
+  });
+
+  it('blocks recipes with catastrophic empty content', () => {
+    const result = evaluateRecipeQuality({ name: 'Empty' });
+    expect(result.passed).toBe(false);
+    expect(result.blockingIssues).toEqual(['missing_ingredients', 'missing_instructions']);
+    expect(() => assertRecipeQuality({ name: 'Empty' })).toThrow(RecipeQualityError);
+  });
+
+  it('surfaces coverage and timing gaps as warnings instead of blocking', () => {
+    const result = evaluateRecipeQuality({
+      ingredients: ['1 cup rice', '1 onion'],
+      instructions: ['Cook the rice.'],
+      prepTime: '60 minutes',
+      cookTime: '60 minutes',
+      totalTime: '30 minutes'
+    });
+    expect(result.passed).toBe(true);
+    expect(result.warnings).toEqual(expect.arrayContaining(['ingredient_step_coverage', 'timing_consistency']));
+    expect(result.checks.timing.status).toBe('warning');
+  });
+
+  it('includes allergen review status in the quality bar', () => {
+    const result = evaluateRecipeQuality({
+      ...goodRecipe,
+      ingredients: ['1 cup seasoning blend'],
+      instructions: ['Stir in the seasoning blend.']
+    }, { hardAllergens: ['peanuts'] });
+    expect(result.checks.allergenSafety.status).toBe('needs_review');
+    expect(buildQualityBar({ ...goodRecipe, allergenSummary: result.checks.allergenSafety.summary }, {
+      evaluation: result,
+      generationMethod: 'llama-ai'
+    })).toMatchObject({ status: 'needs_review', allergenCheck: 'needs_review' });
+  });
+
+  it('adds display-safe quality and provenance metadata without recipe internals', () => {
+    const annotated = withQualityMetadata(goodRecipe, {
+      source: 'ai_generated',
+      generationMethod: 'llama-ai',
+      model: '@cf/meta/llama-test',
+      similarRecipeIds: ['recipe-1', { id: 'private' }, 'recipe-2'],
+      appliedConstraints: { dietary: ['vegetarian'] }
+    });
+    expect(annotated.source).toBe('ai_generated');
+    expect(annotated.generationMethod).toBe('llama-ai');
+    expect(annotated.qualityBar).toMatchObject({ status: 'passed', score: 100, generationMethod: 'llama-ai' });
+    expect(annotated.provenance).toMatchObject({
+      source: 'ai_generated',
+      model: '@cf/meta/llama-test',
+      similarRecipeIds: ['recipe-1', 'recipe-2'],
+      qualityScore: 100
+    });
+    expect(annotated.provenance).not.toHaveProperty('similarRecipes');
+  });
+
+  it('builds provenance defaults for adapted recipes', () => {
+    const provenance = buildRecipeProvenance({ ...goodRecipe, source: 'adapted', adaptedAt: '2026-08-02T00:00:00.000Z' }, {
+      generationMethod: 'mock-ai',
+      qualityBar: { score: 90 }
+    });
+    expect(provenance).toMatchObject({ source: 'adapted', generationMethod: 'mock-ai', generatedAt: '2026-08-02T00:00:00.000Z', qualityScore: 90 });
+    expect(provenance.model).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Implements the deterministic recipe quality bar for generated and adapted recipes.
  - Blocks catastrophic AI output with empty ingredients or instructions.
  - Reports ingredient-step coverage, timing consistency, allergen review status, and a bounded quality score.
- Adds display-safe `qualityBar` and `provenance` metadata to generate/adapt responses, including model route, applied constraints, generation timing, nutrition coverage, and similar recipe IDs without retrieved recipe payloads.
- Adds the `How this was made` trust/provenance panel to AI recipe cards with safety, quality, model, context, constraint, nutrition, and limitation copy.
- Adds an offline 50-case constraint-matrix evaluation suite, baseline documentation, unit coverage, and a CI step.

Implements the quality-bar, provenance, and eval-harness slices of #306. The optional feedback CTA remains dependent on the preference-learning event system from #301, which is not present in this base.

## Validation
- `recipe-generation-worker`: `npm test -- --reporter=dot` — 237 passed
- `recipe-generation-worker`: `npm run test:coverage` — 237 passed; 92.7% lines overall
- `recipe-generation-worker`: `npm run test:eval` — 52 passed (50 matrix cases plus regression checks)
- `recipe-generation-worker`: `npm run lint` — no errors (existing console warnings only)
- `recipe-generation-worker`: `npm run type-check` — passed
- `recipe-app`: `npm test -- --runInBand` — 365 passed
- `recipe-app`: `npm run build` — passed

## Notes
- Quality scores are deterministic signals, not claims of culinary or medical correctness.
- Allergen enforcement remains fail-closed through the existing allergen graph; quality metadata does not expose unsafe recipes.