### PR TITLE
feat(recipe-app): improve discovery and add pantry MVP

### DIFF
--- a/recipe-app/.env.development
+++ b/recipe-app/.env.development
@@ -18,3 +18,5 @@ VITE_RECIPE_VIEW_URL=https://recipe.seasonedapp.com
 # Auth worker
 VITE_AUTH_WORKER_URL=https://auth-worker-preview.nolanfoster.workers.dev
 
+# User-owned culinary profile and pantry API
+VITE_USER_MANAGEMENT_URL=https://user-management-worker-staging.nolanfoster.workers.dev

--- a/recipe-app/.env.production
+++ b/recipe-app/.env.production
@@ -9,3 +9,5 @@ VITE_RECIPE_VIEW_URL=https://recipe.seasonedapp.com
 # Auth worker
 VITE_AUTH_WORKER_URL=https://auth.seasonedapp.com
 
+# User-owned culinary profile and pantry API
+VITE_USER_MANAGEMENT_URL=https://user-management-worker.nolanfoster.workers.dev

--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -237,6 +237,20 @@ export function buildAdaptRequest({ baseRecipe, profile = null, overrides = null
   return body
 }
 
+function getRecipeSourceLabel(recipe) {
+  if (recipe.source === 'ai_generated' || recipe.id?.startsWith('ai-')) return 'AI'
+  if (recipe.source === 'adapted' || recipe.id?.startsWith('adapt-')) return 'Adapted'
+  if (recipe.source === 'elevated') return 'Elevated'
+  if (recipe.source === 'youtube' || isYouTubeUrl(recipe.source_url || '')) return 'YouTube'
+  if (recipe.source === 'clipped') return 'Clipped'
+
+  try {
+    return new URL(recipe.source_url).hostname.replace(/^www\./, '')
+  } catch {
+    return 'Recipe'
+  }
+}
+
 export function annotateRecipeForProfile(recipe, profile) {
   const hardAllergens = profile?.hard_allergens || profile?.hardAllergens || []
   if (!Array.isArray(hardAllergens) || hardAllergens.length === 0) return recipe
@@ -269,7 +283,7 @@ export default function App() {
   const [input, setInput] = useState('')
   const [status, setStatus] = useState('idle') // idle | searching | clipping | generating | elevating | adapting | error
   const [errorMsg, setErrorMsg] = useState('')
-  const [generationRetry, setGenerationRetry] = useState(null)
+  const [retryAction, setRetryAction] = useState(null)
   const [searchResults, setSearchResults] = useState([])
   const [lastSearchQuery, setLastSearchQuery] = useState('')
   const [showDropdown, setShowDropdown] = useState(false)
@@ -307,6 +321,7 @@ export default function App() {
       return
     }
     setStatus('searching')
+    setRetryAction({ mode: 'search', query: normalizedQuery })
     setShowDropdown(true)
     setActiveOptionKey(null)
     try {
@@ -348,11 +363,13 @@ export default function App() {
 
       setSearchResults(results.filter(Boolean))
       setLastSearchQuery(normalizedQuery)
+      setRetryAction(null)
     } catch (e) {
       if (requestId !== searchRequestIdRef.current) return
       setSearchResults([])
       setShowDropdown(false)
       setActiveOptionKey(null)
+      setRetryAction({ mode: 'search', query: normalizedQuery })
       setErrorMsg(e.message)
       setStatus('error')
       return
@@ -400,6 +417,8 @@ export default function App() {
   useEffect(() => {
     if (activeRecipe) {
       setIsDrawerOpen(false)
+      setShowDropdown(false)
+      setActiveOptionKey(null)
     }
   }, [activeRecipe])
 
@@ -410,6 +429,8 @@ export default function App() {
   const isSearchView = hasText
   const searchResultsMatchInput = isSearchView && lastSearchQuery === input.trim()
   const isBrowseView = input.trim().length === 0
+  const dropdownVisible = showDropdown && (!activeRecipe || isSearchView)
+  const isEmptyState = !activeRecipe && !busy && status !== 'error' && !input.trim() && recentRecipes.length === 0 && !dropdownVisible
   const visibleOptions = (searchResultsMatchInput
     ? searchResults.map((recipe, index) => ({
         key: `search-${recipe.id || index}-${index}`,
@@ -475,7 +496,7 @@ export default function App() {
     latestInputRef.current = val
     setInput(val)
     setErrorMsg('')
-    setGenerationRetry(null)
+    setRetryAction(null)
     setActiveOptionKey(null)
     searchRequestIdRef.current += 1
     if (!isValidUrl(val.trim()) && val.trim().length >= 2) {
@@ -494,7 +515,7 @@ export default function App() {
 
   // --- Clip ---
   async function doClip(url) {
-    setGenerationRetry(null)
+    setRetryAction({ mode: 'clip', url })
     invalidateSearch()
     latestInputRef.current = ''
     setStatus('clipping')
@@ -529,6 +550,7 @@ export default function App() {
       setActiveRecipe(clippedRecipe)
       addRecentRecipe(clippedRecipe)
       setInput('')
+      setRetryAction(null)
     } catch (e) {
       setErrorMsg(e.message)
       setStatus('error')
@@ -542,7 +564,7 @@ export default function App() {
   // --- Generate ---
   async function doGenerate(query, { elevate = false, baseRecipe = null, overrides = null } = {}) {
     invalidateSearch()
-    setGenerationRetry({ query, options: { elevate, baseRecipe, overrides } })
+    setRetryAction({ mode: 'generate', query, options: { elevate, baseRecipe, overrides } })
     latestInputRef.current = ''
     const dishName = elevate && baseRecipe ? baseRecipe.name : query
     setGeneratingName(dishName)
@@ -588,7 +610,7 @@ export default function App() {
       }
       setActiveRecipe(generatedRecipe)
       addRecentRecipe(generatedRecipe)
-      setGenerationRetry(null)
+      setRetryAction(null)
       setGeneratingName('')
     } catch (e) {
       setGeneratingName('')
@@ -601,7 +623,7 @@ export default function App() {
 
   async function doAdapt(baseRecipe, overrides = null) {
     invalidateSearch()
-    setGenerationRetry({ mode: 'adapt', recipe: baseRecipe, overrides })
+    setRetryAction({ mode: 'adapt', recipe: baseRecipe, overrides })
     latestInputRef.current = ''
     setGeneratingName(baseRecipe.name)
     setInput('')
@@ -646,7 +668,7 @@ export default function App() {
       }
       setActiveRecipe(adaptedRecipe)
       addRecentRecipe(adaptedRecipe)
-      setGenerationRetry(null)
+      setRetryAction(null)
       setGeneratingName('')
     } catch (e) {
       setGeneratingName('')
@@ -701,7 +723,7 @@ export default function App() {
     }
 
     if (e.key === 'Enter') {
-      if (showDropdown && activeOption) {
+      if (dropdownVisible && activeOption) {
         e.preventDefault()
         selectOption(activeOption)
       } else {
@@ -775,14 +797,32 @@ export default function App() {
         onMouseEnter={() => setActiveOptionKey(option.key)}
         onClick={() => selectOption(option)}
       >
-        <span className="dropdown-name">{r.name}</span>
-        <span className="dropdown-meta">
-          {r.prep_time && <span className="dropdown-pill">Prep: {parseDuration(r.prep_time)}</span>}
-          {r.cook_time && <span className="dropdown-pill">Cook: {parseDuration(r.cook_time)}</span>}
-          {r.recipe_yield && <span className="dropdown-pill">Serves: {r.recipe_yield}</span>}
+        {r.image ? (
+          <img className="dropdown-thumbnail" src={r.image} alt="" loading="lazy" />
+        ) : (
+          <span className="dropdown-thumbnail dropdown-thumbnail--placeholder" aria-hidden="true" />
+        )}
+        <span className="dropdown-item-content">
+          <span className="dropdown-name">{r.name}</span>
+          <span className="dropdown-meta">
+            <span className="dropdown-pill dropdown-source-pill">{getRecipeSourceLabel(r)}</span>
+            {r.prep_time && <span className="dropdown-pill">Prep: {parseDuration(r.prep_time)}</span>}
+            {r.cook_time && <span className="dropdown-pill">Cook: {parseDuration(r.cook_time)}</span>}
+            {r.recipe_yield && <span className="dropdown-pill">Serves: {r.recipe_yield}</span>}
+          </span>
         </span>
       </button>
     )
+  }
+
+  function applySuggestion(suggestion) {
+    latestInputRef.current = suggestion
+    setInput(suggestion)
+    setErrorMsg('')
+    setRetryAction(null)
+    setActiveOptionKey(null)
+    setShowDropdown(false)
+    inputRef.current?.focus()
   }
 
   // --- Save ---
@@ -837,7 +877,7 @@ export default function App() {
     clearActiveRecipe()
     setGeneratingName('')
     setErrorMsg('')
-    setGenerationRetry(null)
+    setRetryAction(null)
     setStatus('idle')
     setSaveState('idle')
     setSavedRecipeId(null)
@@ -895,7 +935,7 @@ export default function App() {
               Search, clip, or generate a recipe
             </label>
             <span id="omnibox-instructions" className="sr-only">
-              Use the up and down arrow keys to review recipe suggestions, then press Enter to open one.
+              Type to search saved recipes, paste a link to clip, or describe a dish to generate one. Use the up and down arrow keys to review suggestions, then press Enter to open one.
             </span>
             <input
               id="recipe-omnibox-input"
@@ -903,7 +943,7 @@ export default function App() {
               className="omnibox-input"
               type="text"
               role="combobox"
-              placeholder="Search recipes, paste a URL, or describe a dish…"
+              placeholder="Search recipes, paste a link, or describe a dish…"
               value={input}
               onChange={handleInputChange}
               onKeyDown={handleKeyDown}
@@ -911,20 +951,32 @@ export default function App() {
               disabled={inputBusy}
               aria-autocomplete="list"
               aria-haspopup="listbox"
-              aria-expanded={showDropdown}
-              aria-controls={showDropdown ? listboxId : undefined}
-              aria-activedescendant={showDropdown && activeOption ? activeOption.domId : undefined}
+              aria-expanded={dropdownVisible}
+              aria-controls={dropdownVisible ? listboxId : undefined}
+              aria-activedescendant={dropdownVisible && activeOption ? activeOption.domId : undefined}
               aria-busy={status === 'searching'}
-              aria-describedby={`omnibox-instructions${status === 'error' && errorMsg ? ' omnibox-error' : ''}`}
+              aria-describedby={`omnibox-instructions omnibox-helper${status === 'error' && errorMsg ? ' omnibox-error' : ''}`}
               autoFocus
               autoComplete="off"
               spellCheck="false"
             />
 
-            <div className="omnibox-actions">
-              {/* Generate button — always visible when there's text and it's not a URL */}
+            <div className={`omnibox-actions ${isUrl ? 'omnibox-actions--clip' : ''}`}>
+              {/* Search is the contextual primary for text queries; generation stays secondary. */}
               {hasText && (
                 <>
+                  <button
+                    className="action-btn primary-btn search-btn"
+                    title="Search saved recipes"
+                    onClick={handleSubmit}
+                    disabled={busy}
+                  >
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                      <circle cx="11" cy="11" r="7" />
+                      <path d="m16.5 16.5 4 4" />
+                    </svg>
+                    <span>Search</span>
+                  </button>
                   {constraintGenerateEnabled && (
                     <button
                       className="action-btn tune-btn"
@@ -975,6 +1027,9 @@ export default function App() {
               )}
             </div>
           </div>
+          <p id="omnibox-helper" className="omnibox-helper">
+            Paste a recipe link to clip · type to search · describe a dish to generate
+          </p>
 
           {/* Loading label — for search/clip only; generate/elevate use GeneratingCard */}
           {busy && (status === 'searching' || status === 'clipping') && (
@@ -988,22 +1043,25 @@ export default function App() {
           {status === 'error' && errorMsg && (
             <div id="omnibox-error" className="error-label" role="alert">
               <span>{errorMsg}</span>
-              {generationRetry && (
+              {retryAction && (
                 <button
                   type="button"
                   className="error-retry"
-                  onClick={() => generationRetry.mode === 'adapt'
-                    ? doAdapt(generationRetry.recipe, generationRetry.overrides)
-                    : doGenerate(generationRetry.query, generationRetry.options)}
+                  onClick={() => {
+                    if (retryAction.mode === 'search') doSearch(retryAction.query)
+                    else if (retryAction.mode === 'clip') doClip(retryAction.url)
+                    else if (retryAction.mode === 'adapt') doAdapt(retryAction.recipe, retryAction.overrides)
+                    else doGenerate(retryAction.query, retryAction.options)
+                  }}
                 >
-                  Retry generation
+                  {retryAction.mode === 'generate' || retryAction.mode === 'adapt' ? 'Retry generation' : 'Retry'}
                 </button>
               )}
             </div>
           )}
 
           {/* Search dropdown */}
-          {showDropdown && (
+          {dropdownVisible && (
             <div className="dropdown" ref={dropdownRef}>
               {!isSearchView && recentRecipes.length > 0 && (
                 <div className="dropdown-section-label">
@@ -1083,6 +1141,24 @@ export default function App() {
           )}
         </div>
 
+        {isEmptyState && (
+          <section className="omnibox-empty-state" aria-labelledby="omnibox-empty-title">
+            <h2 id="omnibox-empty-title">Start with a recipe idea</h2>
+            <p>Search your collection, clip a favorite link, or let Seasoned shape a dish around your constraints.</p>
+            <div className="omnibox-suggestions" aria-label="Recipe ideas">
+              <button type="button" className="suggestion-chip" onClick={() => applySuggestion('20-minute vegetarian dinner')}>
+                20-minute vegetarian dinner
+              </button>
+              <button type="button" className="suggestion-chip" onClick={() => applySuggestion('high-protein weeknight pasta')}>
+                High-protein weeknight pasta
+              </button>
+              <button type="button" className="suggestion-chip" onClick={() => applySuggestion('cozy one-pot meal')}>
+                Cozy one-pot meal
+              </button>
+            </div>
+          </section>
+        )}
+
         {/* GeneratingCard — shown while generate/elevate is in-flight */}
         <GenerationComposer
           open={generationComposerOpen && constraintGenerateEnabled && hasText}
@@ -1107,7 +1183,7 @@ export default function App() {
         )}
 
         {/* Recipe card */}
-        {activeRecipe && !['generating', 'adapting'].includes(status) && (
+        {activeRecipe && !['generating', 'adapting'].includes(status) && !(dropdownVisible && isSearchView) && (
           <RecipeCard
             recipe={activeRecipe}
             onClose={handleClose}

--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -249,9 +249,9 @@ export function buildAdaptRequest({ baseRecipe, profile = null, overrides = null
 }
 
 function getRecipeSourceLabel(recipe) {
+  if (recipe.source === 'elevated') return 'Elevated'
   if (recipe.source === 'ai_generated' || recipe.id?.startsWith('ai-')) return 'AI'
   if (recipe.source === 'adapted' || recipe.id?.startsWith('adapt-')) return 'Adapted'
-  if (recipe.source === 'elevated') return 'Elevated'
   if (recipe.source === 'youtube' || isYouTubeUrl(recipe.source_url || '')) return 'YouTube'
   if (recipe.source === 'clipped') return 'Clipped'
 

--- a/recipe-app/src/App.jsx
+++ b/recipe-app/src/App.jsx
@@ -12,6 +12,8 @@ import CulinaryProfile from './CulinaryProfile.jsx'
 import GenerationComposer from './GenerationComposer.jsx'
 import AdaptComposer from './AdaptComposer.jsx'
 import { useCulinaryProfile } from './useCulinaryProfile.js'
+import { usePantry } from './usePantry.js'
+import PantryModal from './PantryModal.jsx'
 import { withAllergenSummary } from '../../shared/allergen-graph.js'
 
 const SEARCH_DB_URL = import.meta.env.VITE_SEARCH_DB_URL
@@ -74,7 +76,7 @@ function useDebounce(fn, delay) {
   return [schedule, cancel]
 }
 
-function UserMenu({ user, onSignOut, onRegisterPasskey, onOpenProfile }) {
+function UserMenu({ user, onSignOut, onRegisterPasskey, onOpenProfile, onOpenPantry }) {
   const [open, setOpen] = useState(false)
   const [opacity, setOpacity] = useState(1)
   const [passkeyStatus, setPasskeyStatus] = useState('idle')
@@ -168,6 +170,15 @@ function UserMenu({ user, onSignOut, onRegisterPasskey, onOpenProfile }) {
                 <path d="M8 12h8M12 8v8"/>
               </svg>
               Kitchen profile
+            </button>
+          )}
+          {onOpenPantry && (
+            <button className="user-menu-item" role="menuitem" onClick={() => { closeMenu({ restoreFocus: true }); onOpenPantry() }}>
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M4 6h16M4 12h16M4 18h16" />
+                <path d="M7 4v4M17 10v4M10 16v4" />
+              </svg>
+              My pantry
             </button>
           )}
           {onRegisterPasskey && (
@@ -271,9 +282,13 @@ export default function App() {
   const constraintGenerateEnabled = useFlag('constraint-generate')
   const recipeAdaptEnabled = useFlag('recipe-adapt')
   const [profileOpen, setProfileOpen] = useState(false)
+  const [pantryOpen, setPantryOpen] = useState(false)
   const [generationComposerOpen, setGenerationComposerOpen] = useState(false)
   const [adaptComposerOpen, setAdaptComposerOpen] = useState(false)
   const culinaryProfile = useCulinaryProfile(auth.token, culinaryProfileEnabled)
+  const pantryEnabled = useFlag('pantry')
+  const pantryUserId = auth.user?.id || auth.user?.user_id || auth.user?.email || ''
+  const pantry = usePantry(auth.token, pantryUserId, pantryEnabled)
 
   useEffect(() => {
     if (auth.loading) return
@@ -902,6 +917,7 @@ export default function App() {
         onSignOut={auth.signOut}
         onRegisterPasskey={auth.registerPasskey}
         onOpenProfile={culinaryProfileEnabled && culinaryProfile.available ? () => setProfileOpen(true) : undefined}
+        onOpenPantry={pantryEnabled && pantry.available ? () => setPantryOpen(true) : undefined}
       />
       <div className="omnibox-wrapper">
         <div className="brand">
@@ -1205,6 +1221,17 @@ export default function App() {
           error={culinaryProfile.error}
           onSave={culinaryProfile.saveProfile}
           onClose={() => setProfileOpen(false)}
+        />
+        <PantryModal
+          open={pantryOpen && pantryEnabled && pantry.available}
+          items={pantry.items}
+          loading={pantry.loading}
+          syncError={pantry.syncError}
+          activeRecipe={activeRecipe}
+          onAdd={pantry.addItem}
+          onUpdate={pantry.updateItem}
+          onRemove={pantry.removeItem}
+          onClose={() => setPantryOpen(false)}
         />
       </div>
     </div>

--- a/recipe-app/src/PantryModal.jsx
+++ b/recipe-app/src/PantryModal.jsx
@@ -1,0 +1,276 @@
+import React, { useEffect, useMemo, useState } from 'react'
+import { PANTRY_LOCATIONS } from './usePantry.js'
+
+const LOCATION_LABELS = {
+  fridge: 'Fridge',
+  freezer: 'Freezer',
+  pantry: 'Pantry',
+  other: 'Other',
+}
+
+const EMPTY_FORM = {
+  name: '',
+  quantity: '',
+  unit: '',
+  location: 'pantry',
+  expiresOn: '',
+  tags: '',
+}
+
+const KNOWN_UNITS = new Set([
+  'bag', 'bags', 'bottle', 'bottles', 'box', 'boxes', 'can', 'cans', 'cup', 'cups',
+  'g', 'gram', 'grams', 'kg', 'lb', 'lbs', 'ounce', 'ounces', 'oz', 'pinch', 'pound',
+  'pounds', 'tbsp', 'tablespoon', 'tablespoons', 'tsp', 'teaspoon', 'teaspoons',
+])
+
+function parseQuantity(value) {
+  const parts = value.trim().split(/\s+/)
+  if (parts.length === 2 && parts[1].includes('/')) {
+    const whole = Number(parts[0])
+    const [numerator, denominator] = parts[1].split('/').map(Number)
+    if (Number.isFinite(whole) && denominator) return whole + numerator / denominator
+  }
+  if (value.includes('/')) {
+    const [numerator, denominator] = value.split('/').map(Number)
+    if (denominator) return numerator / denominator
+  }
+  const number = Number(value)
+  return Number.isFinite(number) ? number : null
+}
+
+export function parsePantryIngredient(ingredient) {
+  if (ingredient && typeof ingredient === 'object') {
+    return {
+      name: String(ingredient.name || ingredient.ingredient || ingredient.text || '').trim(),
+      quantity: ingredient.quantity ?? '',
+      unit: ingredient.unit || '',
+    }
+  }
+  const value = String(ingredient || '').trim()
+  const match = value.match(/^((?:\d+\s+)?\d+(?:\.\d+)?(?:\/\d+)?)\s+([a-zA-Z]+)\s+(.+)$/)
+  if (!match || !KNOWN_UNITS.has(match[2].toLowerCase())) return { name: value, quantity: '', unit: '' }
+  return { name: match[3].trim(), quantity: parseQuantity(match[1]) ?? '', unit: match[2].toLowerCase() }
+}
+
+function formFromItem(item) {
+  return {
+    name: item.name || '',
+    quantity: item.quantity ?? '',
+    unit: item.unit || '',
+    location: item.location || 'pantry',
+    expiresOn: item.expiresOn || item.expires_on || '',
+    tags: Array.isArray(item.tags) ? item.tags.join(', ') : '',
+  }
+}
+
+function inputFromForm(form) {
+  return {
+    name: form.name.trim(),
+    quantity: form.quantity === '' ? null : Number(form.quantity),
+    unit: form.unit.trim() || null,
+    location: form.location,
+    expiresOn: form.expiresOn || null,
+    tags: form.tags.split(',').map((tag) => tag.trim()).filter(Boolean),
+  }
+}
+
+function expiryState(value) {
+  if (!value) return null
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const expiry = new Date(`${value}T00:00:00`)
+  const days = Math.ceil((expiry.getTime() - today.getTime()) / 86400000)
+  if (days < 0) return 'expired'
+  if (days <= 7) return 'soon'
+  return null
+}
+
+function itemLabel(item) {
+  const quantity = item.quantity === null || item.quantity === undefined || item.quantity === ''
+    ? ''
+    : `${item.quantity}${item.unit ? ` ${item.unit}` : ''}`
+  return [quantity, item.name].filter(Boolean).join(' ')
+}
+
+export default function PantryModal({
+  open,
+  items = [],
+  loading = false,
+  syncError = '',
+  activeRecipe = null,
+  onAdd,
+  onUpdate,
+  onRemove,
+  onClose,
+}) {
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [editingId, setEditingId] = useState(null)
+  const [message, setMessage] = useState('')
+  const [working, setWorking] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setEditingId(null)
+      setForm(EMPTY_FORM)
+      setMessage('')
+    }
+  }, [open])
+
+  const groupedItems = useMemo(() => PANTRY_LOCATIONS
+    .map((location) => ({
+      location,
+      items: items.filter((item) => item.location === location),
+    }))
+    .filter((group) => group.items.length > 0), [items])
+
+  if (!open) return null
+
+  function updateField(field, value) {
+    setForm((current) => ({ ...current, [field]: value }))
+  }
+
+  function beginEdit(item) {
+    setEditingId(item.id)
+    setForm(formFromItem(item))
+    setMessage('')
+  }
+
+  function cancelEdit() {
+    setEditingId(null)
+    setForm(EMPTY_FORM)
+    setMessage('')
+  }
+
+  async function handleSubmit(event) {
+    event.preventDefault()
+    if (!form.name.trim()) {
+      setMessage('Add an ingredient name first.')
+      return
+    }
+    setWorking(true)
+    setMessage('')
+    try {
+      if (editingId !== null) await onUpdate(editingId, inputFromForm(form))
+      else await onAdd(inputFromForm(form))
+      cancelEdit()
+    } catch {
+      setMessage('Could not sync that pantry change. It is still available locally.')
+    } finally {
+      setWorking(false)
+    }
+  }
+
+  async function addRecipeIngredients() {
+    const ingredients = activeRecipe?.ingredients || []
+    if (!ingredients.length) return
+    setWorking(true)
+    setMessage('')
+    try {
+      for (const ingredient of ingredients) {
+        const parsed = parsePantryIngredient(ingredient)
+        if (parsed.name) await onAdd({ ...parsed, location: 'pantry' })
+      }
+      setMessage(`${ingredients.length} ingredient${ingredients.length === 1 ? '' : 's'} added to your pantry.`)
+    } catch {
+      setMessage('Some ingredients were saved locally and will sync when available.')
+    } finally {
+      setWorking(false)
+    }
+  }
+
+  async function handleRemove(item) {
+    try {
+      await onRemove(item.id)
+    } catch {
+      setMessage('Could not sync the removal. The item was restored.')
+    }
+  }
+
+  return (
+    <div className="pantry-backdrop" role="presentation" onMouseDown={(event) => {
+      if (event.target === event.currentTarget) onClose()
+    }}>
+      <section className="pantry-sheet" role="dialog" aria-modal="true" aria-labelledby="pantry-title">
+        <div className="pantry-header">
+          <div>
+            <h2 id="pantry-title">My pantry</h2>
+            <p>Keep track of what you have so future planning can start with your kitchen.</p>
+          </div>
+          <button type="button" className="pantry-close" aria-label="Close pantry" onClick={onClose}>×</button>
+        </div>
+
+        {syncError && <p className="pantry-status pantry-status--offline" role="status">Working offline: {syncError}</p>}
+        {message && <p className="pantry-status" role="status">{message}</p>}
+
+        {activeRecipe?.ingredients?.length > 0 && (
+          <button type="button" className="pantry-leftovers" onClick={addRecipeIngredients} disabled={working}>
+            Add leftovers from “{activeRecipe.name || 'this recipe'}”
+          </button>
+        )}
+
+        <form className="pantry-form" onSubmit={handleSubmit}>
+          <div className="pantry-form-heading">
+            <h3>{editingId === null ? 'Add an item' : 'Edit item'}</h3>
+            {editingId !== null && <button type="button" className="pantry-form-cancel" onClick={cancelEdit}>Cancel edit</button>}
+          </div>
+          <label className="pantry-field pantry-field--wide">Ingredient
+            <input autoFocus={editingId === null} type="text" value={form.name} onChange={(event) => updateField('name', event.target.value)} placeholder="e.g. chickpeas" maxLength={200} />
+          </label>
+          <div className="pantry-form-grid">
+            <label className="pantry-field">Quantity
+              <input type="number" min="0" step="any" value={form.quantity} onChange={(event) => updateField('quantity', event.target.value)} placeholder="Optional" />
+            </label>
+            <label className="pantry-field">Unit
+              <input type="text" value={form.unit} onChange={(event) => updateField('unit', event.target.value)} placeholder="can, cup…" maxLength={40} />
+            </label>
+            <label className="pantry-field">Location
+              <select value={form.location} onChange={(event) => updateField('location', event.target.value)}>
+                {PANTRY_LOCATIONS.map((location) => <option key={location} value={location}>{LOCATION_LABELS[location]}</option>)}
+              </select>
+            </label>
+            <label className="pantry-field">Use by
+              <input type="date" value={form.expiresOn} onChange={(event) => updateField('expiresOn', event.target.value)} />
+            </label>
+          </div>
+          <label className="pantry-field pantry-field--wide">Tags <span className="pantry-help">comma separated</span>
+            <input type="text" value={form.tags} onChange={(event) => updateField('tags', event.target.value)} placeholder="breakfast, staple" />
+          </label>
+          <button type="submit" className="pantry-primary" disabled={working}>{working ? 'Saving…' : editingId === null ? 'Add to pantry' : 'Save changes'}</button>
+        </form>
+
+        <div className="pantry-list" aria-live="polite">
+          <div className="pantry-list-heading"><h3>On hand</h3><span>{items.length} item{items.length === 1 ? '' : 's'}</span></div>
+          {loading ? <p className="pantry-empty">Loading your pantry…</p> : groupedItems.length === 0 ? (
+            <div className="pantry-empty">
+              <strong>Your pantry is empty</strong>
+              <p>Add a few staples above, or add ingredients from the open recipe.</p>
+            </div>
+          ) : groupedItems.map((group) => (
+            <section key={group.location} className="pantry-group" aria-labelledby={`pantry-group-${group.location}`}>
+              <h4 id={`pantry-group-${group.location}`}>{LOCATION_LABELS[group.location]}</h4>
+              <ul>
+                {group.items.map((item) => {
+                  const expiry = item.expiresOn || item.expires_on
+                  const state = expiryState(expiry)
+                  return (
+                    <li key={item.id} className="pantry-item">
+                      <div className="pantry-item-copy">
+                        <strong>{itemLabel(item)}</strong>
+                        <span>{item.tags?.join(' · ') || 'No tags'}</span>
+                        {expiry && <small className={`pantry-expiry pantry-expiry--${state || 'normal'}`}>{state === 'expired' ? 'Expired' : state === 'soon' ? 'Use soon' : 'Use by'} {expiry}</small>}
+                      </div>
+                      <div className="pantry-item-actions">
+                        <button type="button" onClick={() => beginEdit(item)} aria-label={`Edit ${item.name}`}>Edit</button>
+                        <button type="button" onClick={() => handleRemove(item)} aria-label={`Remove ${item.name}`}>Remove</button>
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/recipe-app/src/__tests__/App.test.jsx
+++ b/recipe-app/src/__tests__/App.test.jsx
@@ -157,6 +157,24 @@ describe('Generation request builder', () => {
 
 // ── isValidUrl (tested via omnibox UI behaviour) ───────────────────────────
 
+describe('Omnibox first-run guidance', () => {
+  test('shows an actionable empty state and fills the omnibox from a suggestion', () => {
+    renderApp()
+
+    expect(screen.getByRole('heading', { name: 'Start with a recipe idea' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '20-minute vegetarian dinner' }))
+
+    expect(screen.getByRole('combobox')).toHaveValue('20-minute vegetarian dinner')
+    expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Generate' })).toBeInTheDocument()
+  })
+
+  test('explains the search, clip, and generate paths beside the field', () => {
+    renderApp()
+    expect(screen.getByText('Paste a recipe link to clip · type to search · describe a dish to generate')).toBeInTheDocument()
+  })
+})
+
 describe('Omnibox input mode detection', () => {
   test('shows Generate button for plain text input', () => {
     renderApp();
@@ -292,6 +310,7 @@ describe('Search behaviour', () => {
     await waitFor(() =>
       expect(screen.getByText(/Search failed: 500/i)).toBeInTheDocument()
     );
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
   test('fetches full recipe data for each search result', async () => {
@@ -308,6 +327,19 @@ describe('Search behaviour', () => {
       expect.stringContaining('/api/recipes/abc123')
     );
   });
+
+  test('shows available thumbnails and source labels in result rows', async () => {
+    mockFetchOk(SEARCH_RESPONSE)
+    mockFetchOk(FULL_RECIPE_RESPONSE)
+
+    renderApp()
+    setInputValue('cake')
+    pressEnter()
+
+    await waitFor(() => screen.getByText('Chocolate Cake'))
+    expect(document.querySelector('.dropdown-thumbnail')).toHaveAttribute('src', 'https://example.com/cake.jpg')
+    expect(screen.getByText('example.com')).toBeInTheDocument()
+  })
 });
 
 describe('Core chrome accessibility', () => {
@@ -606,6 +638,7 @@ describe('Clip behaviour', () => {
     await waitFor(() =>
       expect(screen.getByText(/Clip failed: 422/i)).toBeInTheDocument()
     );
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   });
 
   test('shows Clip button for YouTube URLs', () => {

--- a/recipe-app/src/__tests__/App.test.jsx
+++ b/recipe-app/src/__tests__/App.test.jsx
@@ -1014,6 +1014,22 @@ describe('Recently viewed recipes', () => {
     localStorage.clear();
   });
 
+  test('prioritizes the explicit Elevated source label over an AI id', () => {
+    seedLocalStorage([{
+      id: 'ai-elevated-1',
+      source: 'elevated',
+      name: 'Elevated Pasta',
+      image: '',
+      ingredients: [],
+      instructions: [],
+    }])
+
+    renderApp()
+    fireEvent.focus(screen.getByRole('combobox'))
+
+    expect(screen.getByText('Elevated')).toBeInTheDocument()
+  })
+
   test('stores a recipe in localStorage after viewing a search result', async () => {
     mockFetchOk(SEARCH_RESPONSE);
     mockFetchOk(FULL_RECIPE_RESPONSE);

--- a/recipe-app/src/__tests__/PantryModal.test.jsx
+++ b/recipe-app/src/__tests__/PantryModal.test.jsx
@@ -1,0 +1,141 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import PantryModal, { parsePantryIngredient } from '../PantryModal.jsx'
+
+describe('parsePantryIngredient', () => {
+  test('separates a quantity and known unit from an ingredient line', () => {
+    expect(parsePantryIngredient('1 1/2 cups chickpeas')).toEqual({
+      name: 'chickpeas',
+      quantity: 1.5,
+      unit: 'cups',
+    })
+  })
+
+  test('parses a simple fraction quantity', () => {
+    expect(parsePantryIngredient('1/2 cup oats')).toEqual({ name: 'oats', quantity: 0.5, unit: 'cup' })
+  })
+
+  test('keeps free-form ingredients intact', () => {
+    expect(parsePantryIngredient('salt and pepper to taste')).toEqual({
+      name: 'salt and pepper to taste',
+      quantity: '',
+      unit: '',
+    })
+  })
+})
+
+describe('PantryModal', () => {
+  const baseProps = {
+    open: true,
+    items: [],
+    loading: false,
+    syncError: '',
+    activeRecipe: null,
+    onAdd: jest.fn(() => Promise.resolve()),
+    onUpdate: jest.fn(() => Promise.resolve()),
+    onRemove: jest.fn(() => Promise.resolve()),
+    onClose: jest.fn(),
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  test('explains an empty pantry and adds a manually entered item', async () => {
+    render(<PantryModal {...baseProps} />)
+
+    expect(screen.getByText('Your pantry is empty')).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText('Ingredient'), { target: { value: 'chickpeas' } })
+    fireEvent.change(screen.getByLabelText('Quantity'), { target: { value: '2' } })
+    fireEvent.change(screen.getByLabelText('Unit'), { target: { value: 'cans' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Add to pantry' }))
+
+    await waitFor(() => expect(baseProps.onAdd).toHaveBeenCalledWith({
+      name: 'chickpeas',
+      quantity: 2,
+      unit: 'cans',
+      location: 'pantry',
+      expiresOn: null,
+      tags: [],
+    }))
+  })
+
+  test('renders expiry and exposes edit and remove actions', async () => {
+    render(<PantryModal {...baseProps} items={[{
+      id: 12,
+      name: 'spinach',
+      quantity: 1,
+      unit: 'bag',
+      location: 'fridge',
+      expiresOn: '2099-01-01',
+      tags: ['greens'],
+    }]} />)
+
+    expect(screen.getByRole('heading', { name: 'Fridge' })).toBeInTheDocument()
+    expect(screen.getByText('1 bag spinach')).toBeInTheDocument()
+    expect(screen.getByText('greens')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit spinach' }))
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText('Ingredient'), { target: { value: 'baby spinach' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+    await waitFor(() => expect(baseProps.onUpdate).toHaveBeenCalledWith(12, expect.objectContaining({ name: 'baby spinach' })))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove spinach' }))
+    await waitFor(() => expect(baseProps.onRemove).toHaveBeenCalledWith(12))
+  })
+
+  test('adds parsed ingredients from the active recipe', async () => {
+    render(<PantryModal {...baseProps} activeRecipe={{ name: 'Bean bowl', ingredients: ['1 cup rice', 'lime juice'] }} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Add leftovers from/ }))
+    await waitFor(() => expect(baseProps.onAdd).toHaveBeenNthCalledWith(1, {
+      name: 'rice', quantity: 1, unit: 'cup', location: 'pantry',
+    }))
+    expect(baseProps.onAdd).toHaveBeenNthCalledWith(2, {
+      name: 'lime juice', quantity: '', unit: '', location: 'pantry',
+    })
+  })
+
+  test('handles optional fields, loading state, validation, and offline failures', async () => {
+    const onAdd = jest.fn(() => Promise.reject(new Error('offline')))
+    const onUpdate = jest.fn(() => Promise.reject(new Error('offline')))
+    const onRemove = jest.fn(() => Promise.reject(new Error('offline')))
+    const onClose = jest.fn()
+    const { rerender } = render(<PantryModal
+      {...baseProps}
+      onAdd={onAdd}
+      onUpdate={onUpdate}
+      onRemove={onRemove}
+      onClose={onClose}
+      syncError="sync unavailable"
+      loading
+    />)
+    expect(screen.getByText('Working offline: sync unavailable')).toBeInTheDocument()
+    expect(screen.getByText('Loading your pantry…')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Add to pantry' }))
+    expect(screen.getByText('Add an ingredient name first.')).toBeInTheDocument()
+
+    rerender(<PantryModal
+      {...baseProps}
+      onAdd={onAdd}
+      onUpdate={onUpdate}
+      onRemove={onRemove}
+      onClose={onClose}
+      activeRecipe={{ ingredients: [{ ingredient: '1/2 cup oats' }] }}
+      items={[{ id: 2, name: 'salt', quantity: null, unit: null, location: 'other', tags: [], expiresOn: '2000-01-01' }]}
+    />)
+    expect(screen.getByRole('heading', { name: 'Other' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Edit salt' }))
+    fireEvent.change(screen.getByLabelText('Location'), { target: { value: 'fridge' } })
+    fireEvent.change(screen.getByLabelText('Use by'), { target: { value: '2099-02-02' } })
+    fireEvent.change(screen.getByLabelText(/Tags/), { target: { value: 'staple, baking' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+    await waitFor(() => expect(screen.getByText('Could not sync that pantry change. It is still available locally.')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /Add leftovers from/ }))
+    await waitFor(() => expect(screen.getByText('Some ingredients were saved locally and will sync when available.')).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: 'Remove salt' }))
+    await waitFor(() => expect(screen.getByText('Could not sync the removal. The item was restored.')).toBeInTheDocument())
+    fireEvent.mouseDown(screen.getByRole('presentation'), { target: screen.getByRole('presentation') })
+    expect(onClose).toHaveBeenCalled()
+  })
+
+})

--- a/recipe-app/src/__tests__/usePantry.test.jsx
+++ b/recipe-app/src/__tests__/usePantry.test.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { sortPantryItems, usePantry } from '../usePantry.js'
+
+function PantryHarness() {
+  const pantry = usePantry('token-a', 'user-a', true, 'https://test-user.example.com')
+  return (
+    <div>
+      <output data-testid="count">{pantry.items.length}</output>
+      <output data-testid="error">{pantry.syncError}</output>
+      <button type="button" onClick={() => pantry.addItem({ name: 'Rice', location: 'pantry' })}>Add rice</button>
+      <button type="button" onClick={() => void pantry.updateItem(7, { name: 'Brown rice', location: 'pantry' }).catch(() => {})}>Rename rice</button>
+      <button type="button" onClick={() => void pantry.removeItem(7).catch(() => {})}>Remove rice</button>
+    </div>
+  )
+}
+
+describe('usePantry', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    global.fetch.mockImplementation((url, options = {}) => {
+      if (!options.method) {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ success: true, data: [{
+          id: 7, name: 'Rice', quantity: 1, unit: 'bag', location: 'pantry', tags: [], expires_on: null,
+        }] }) })
+      }
+      if (options.method === 'POST') {
+        return Promise.resolve({ ok: true, status: 201, json: () => Promise.resolve({ success: true, data: {
+          id: 8, name: 'Rice', quantity: null, unit: null, location: 'pantry', tags: [],
+        } }) })
+      }
+      if (options.method === 'PATCH') {
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ success: true, data: {
+          id: 7, name: 'Brown rice', quantity: null, unit: null, location: 'pantry', tags: [],
+        } }) })
+      }
+      return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ success: true }) })
+    })
+  })
+
+  test('sorts expiring items before items without an expiry', () => {
+    expect(sortPantryItems([{ name: 'open', expiresOn: null }, { name: 'soon', expiresOn: '2026-01-01' }, { name: 'later', expiresOn: '2026-02-01' }]).map((item) => item.name)).toEqual(['soon', 'later', 'open'])
+  })
+
+  test('keeps local state and reports sync errors when the API is unavailable', async () => {
+    global.fetch.mockRejectedValue(new Error('offline'))
+    const setItem = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => { throw new Error('storage full') })
+    render(<PantryHarness />)
+    await waitFor(() => expect(screen.getByTestId('error')).toHaveTextContent('offline'))
+    fireEvent.click(screen.getByRole('button', { name: 'Add rice' }))
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('1'))
+    fireEvent.click(screen.getByRole('button', { name: 'Rename rice' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove rice' }))
+    setItem.mockRestore()
+  })
+
+  test('uses local-only mode when no token is available', async () => {
+    function LocalHarness() {
+      const pantry = usePantry(null, 'local-user', true, 'https://test-user.example.com')
+      return <button type="button" onClick={() => pantry.addItem({ name: 'Beans' })}>Add local</button>
+    }
+    render(<LocalHarness />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add local' }))
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  test('loads, adds, updates, and removes user-scoped items through the API', async () => {
+    render(<PantryHarness />)
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('1'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add rice' }))
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('2'))
+    expect(global.fetch).toHaveBeenCalledWith('https://test-user.example.com/me/pantry-items', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer token-a' }),
+    }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Rename rice' }))
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledWith('https://test-user.example.com/me/pantry-items/7', expect.objectContaining({ method: 'PATCH' })))
+    fireEvent.click(screen.getByRole('button', { name: 'Remove rice' }))
+    await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('1'))
+  })
+})

--- a/recipe-app/src/flaggly.js
+++ b/recipe-app/src/flaggly.js
@@ -23,6 +23,7 @@ try {
       'culinary-profile': true,
       'constraint-generate': true,
       'recipe-adapt': true,
+      'pantry': true,
     },
   })
 } catch (err) {
@@ -65,7 +66,7 @@ export async function syncFlagglyUser(user) {
     const keys = state ? Object.keys(state) : []
     if (keys.length === 0) {
       console.warn(
-        '[flaggly] Eval succeeded but returned zero flags. In Flaggly admin, create flags with the same ids as in code (voice-control, gesture-support, dictation, elevate-recipe, meal-planner, culinary-profile, constraint-generate, recipe-adapt) for app `default` / env `production`, or set VITE_FLAGGLY_APP_ID / VITE_FLAGGLY_ENV_ID if you use other names.'
+        '[flaggly] Eval succeeded but returned zero flags. In Flaggly admin, create flags with the same ids as in code (voice-control, gesture-support, dictation, elevate-recipe, meal-planner, culinary-profile, constraint-generate, recipe-adapt, pantry) for app `default` / env `production`, or set VITE_FLAGGLY_APP_ID / VITE_FLAGGLY_ENV_ID if you use other names.'
       )
     } else if (import.meta.env.DEV) {
       console.info(`[flaggly] Eval OK — ${keys.length} flag(s):`, keys.join(', '))

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -3110,3 +3110,308 @@ textarea:focus-visible {
   font-size: 0.75rem;
   line-height: 1.4;
 }
+
+/* ── Pantry inventory ──────────────────────────────────────────────── */
+.pantry-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 260;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(12, 19, 16, 0.48);
+  padding: 1rem;
+}
+
+.pantry-sheet {
+  display: flex;
+  flex-direction: column;
+  width: min(100%, 34rem);
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
+  padding: 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 1.25rem;
+  background: var(--surface, #18221d);
+  color: var(--text, #f2f5ef);
+  box-shadow: 0 1.5rem 4rem rgba(0, 0, 0, 0.35);
+}
+
+.pantry-header,
+.pantry-form-heading,
+.pantry-list-heading,
+.pantry-item,
+.pantry-item-actions {
+  display: flex;
+  align-items: center;
+}
+
+.pantry-header {
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.pantry-header h2,
+.pantry-header p,
+.pantry-form h3,
+.pantry-list-heading h3,
+.pantry-group h4,
+.pantry-empty p {
+  margin: 0;
+}
+
+.pantry-header p {
+  max-width: 28rem;
+  margin-top: 0.3rem;
+  color: var(--muted, #aab5ad);
+  font-size: 0.86rem;
+  line-height: 1.4;
+}
+
+.pantry-close {
+  flex: 0 0 auto;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  font-size: 1.7rem;
+  cursor: pointer;
+}
+
+.pantry-close:hover,
+.pantry-close:focus-visible {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.pantry-status {
+  margin: 0 0 0.8rem;
+  color: var(--accent, #c8a96e);
+  font-size: 0.86rem;
+}
+
+.pantry-status--offline {
+  color: #e6b477;
+}
+
+.pantry-leftovers,
+.pantry-primary {
+  min-height: 2.75rem;
+  border: 1px solid rgba(200, 169, 110, 0.6);
+  border-radius: 0.7rem;
+  background: rgba(200, 169, 110, 0.14);
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.pantry-leftovers {
+  width: 100%;
+  margin-bottom: 1.1rem;
+  padding: 0.6rem 0.85rem;
+  text-align: left;
+}
+
+.pantry-leftovers:hover,
+.pantry-leftovers:focus-visible,
+.pantry-primary:hover,
+.pantry-primary:focus-visible {
+  background: rgba(200, 169, 110, 0.24);
+}
+
+.pantry-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.pantry-form-heading {
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.pantry-form-cancel {
+  border: 0;
+  background: transparent;
+  color: var(--accent, #c8a96e);
+  cursor: pointer;
+}
+
+.pantry-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.pantry-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: var(--muted, #aab5ad);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.pantry-field--wide {
+  width: 100%;
+}
+
+.pantry-field input,
+.pantry-field select {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 2.65rem;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 0.55rem;
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--text, #f2f5ef);
+  font: inherit;
+  font-weight: 400;
+}
+
+.pantry-field input:focus,
+.pantry-field select:focus {
+  border-color: var(--accent, #c8a96e);
+  outline: 2px solid rgba(200, 169, 110, 0.25);
+}
+
+.pantry-help {
+  color: var(--muted, #aab5ad);
+  font-weight: 400;
+}
+
+.pantry-primary {
+  align-self: flex-start;
+  padding: 0.6rem 1rem;
+}
+
+.pantry-primary:disabled,
+.pantry-leftovers:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.pantry-list {
+  margin-top: 1.3rem;
+}
+
+.pantry-list-heading {
+  justify-content: space-between;
+  margin-bottom: 0.7rem;
+}
+
+.pantry-list-heading span {
+  color: var(--muted, #aab5ad);
+  font-size: 0.82rem;
+}
+
+.pantry-group {
+  margin-top: 1rem;
+}
+
+.pantry-group h4 {
+  margin-bottom: 0.35rem;
+  color: var(--accent, #c8a96e);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pantry-group ul {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pantry-item {
+  justify-content: space-between;
+  gap: 0.7rem;
+  padding: 0.7rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.pantry-item-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.pantry-item-copy strong {
+  overflow-wrap: anywhere;
+}
+
+.pantry-item-copy > span,
+.pantry-expiry {
+  color: var(--muted, #aab5ad);
+  font-size: 0.76rem;
+}
+
+.pantry-expiry--soon {
+  color: #e6b477;
+}
+
+.pantry-expiry--expired {
+  color: #ed8b83;
+}
+
+.pantry-item-actions {
+  flex: 0 0 auto;
+  gap: 0.25rem;
+}
+
+.pantry-item-actions button {
+  min-height: 2.2rem;
+  padding: 0.35rem 0.5rem;
+  border: 0;
+  border-radius: 0.45rem;
+  background: transparent;
+  color: var(--accent, #c8a96e);
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.pantry-item-actions button:last-child {
+  color: #ed9a92;
+}
+
+.pantry-item-actions button:hover,
+.pantry-item-actions button:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.pantry-empty {
+  padding: 1.25rem 0;
+  color: var(--muted, #aab5ad);
+  line-height: 1.45;
+}
+
+.pantry-empty strong {
+  display: block;
+  margin-bottom: 0.3rem;
+  color: var(--text, #f2f5ef);
+}
+
+@media (max-width: 600px) {
+  .pantry-backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .pantry-sheet {
+    width: 100%;
+    max-height: 92vh;
+    border-radius: 1.25rem 1.25rem 0 0;
+  }
+}

--- a/recipe-app/src/index.css
+++ b/recipe-app/src/index.css
@@ -235,7 +235,7 @@ textarea:focus-visible {
 }
 
 .brand-tagline {
-  font-size: 0.65rem;
+  font-size: var(--fs-xs);
   color: var(--text-muted);
   letter-spacing: 0.02em;
 }
@@ -253,7 +253,7 @@ textarea:focus-visible {
   border-radius: var(--radius);
   padding: 6px 6px 6px var(--spacing-lg);
   gap: var(--spacing-sm);
-  transition: border-color 0.2s, box-shadow 0.2s;
+  transition: border-color var(--duration-short), box-shadow var(--duration-short);
 }
 
 .omnibox-inner:focus-within {
@@ -298,8 +298,48 @@ textarea:focus-visible {
 
 .omnibox-actions {
   display: flex;
-  gap: 6px;
+  gap: var(--spacing-sm);
   flex-shrink: 0;
+}
+
+.omnibox-helper {
+  margin: var(--spacing-sm) var(--spacing-sm) 0;
+  color: var(--text-muted);
+  font-size: var(--fs-xs);
+  line-height: var(--lh-body);
+  text-align: center;
+}
+
+@media (max-width: 560px) {
+  .omnibox-inner {
+    flex-wrap: wrap;
+    padding: var(--spacing-sm);
+  }
+
+  .omnibox-input {
+    flex-basis: 100%;
+    width: 100%;
+    padding: var(--spacing-sm) var(--spacing-xs);
+  }
+
+  .omnibox-actions {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+  }
+
+  .omnibox-actions--clip {
+    grid-template-columns: 1fr;
+  }
+
+  .omnibox-actions .action-btn {
+    min-width: 0;
+    justify-content: center;
+  }
+
+  .omnibox-helper {
+    margin-inline: var(--spacing-xs);
+  }
 }
 
 /* ── Action buttons ── */
@@ -314,7 +354,7 @@ textarea:focus-visible {
   font-size: var(--fs-sm);
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s, opacity 0.15s;
+  transition: background var(--duration-short), opacity var(--duration-short);
   white-space: nowrap;
 }
 
@@ -404,13 +444,12 @@ textarea:focus-visible {
 
 .dropdown-item {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
+  align-items: center;
+  gap: var(--spacing-md);
   width: 100%;
   background: none;
   border: none;
-  padding: 12px 16px;
+  padding: var(--spacing-md) var(--spacing-lg);
   cursor: pointer;
   text-align: left;
   transition: background 0.1s, border-left-color 0.1s;
@@ -428,16 +467,50 @@ textarea:focus-visible {
   box-shadow: inset 3px 0 0 var(--accent);
 }
 
+.dropdown-thumbnail {
+  width: 48px;
+  height: 48px;
+  flex: 0 0 48px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  background: var(--surface2);
+}
+
+.dropdown-thumbnail--placeholder {
+  border: 1px solid var(--border);
+  background:
+    linear-gradient(135deg, rgb(var(--color-primary-rgb) / var(--state-hover)), transparent),
+    var(--surface2);
+}
+
+.dropdown-item-content {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--spacing-xs);
+}
+
 .dropdown-name {
-  font-size: 0.9375rem;
+  overflow: hidden;
+  width: 100%;
+  font-size: var(--fs-md);
   font-weight: 500;
   color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .dropdown-meta {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: var(--spacing-sm);
+}
+
+.dropdown-source-pill {
+  color: var(--accent);
+  font-weight: 600;
 }
 
 .dropdown-pill {
@@ -537,6 +610,56 @@ textarea:focus-visible {
     outline: 2px solid Highlight;
     outline-offset: -2px;
   }
+}
+
+/* ── Empty first-run state ── */
+.omnibox-empty-state {
+  padding: var(--spacing-xl) var(--spacing-lg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, var(--surface), var(--surface2));
+  box-shadow: var(--elev-1);
+  text-align: center;
+}
+
+.omnibox-empty-state h2 {
+  color: var(--text);
+  font-size: var(--fs-lg);
+  line-height: var(--lh-tight);
+}
+
+.omnibox-empty-state p {
+  max-width: 520px;
+  margin: var(--spacing-sm) auto 0;
+  color: var(--text-muted);
+  font-size: var(--fs-sm);
+}
+
+.omnibox-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-lg);
+}
+
+.suggestion-chip {
+  min-height: 44px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgb(var(--color-primary-rgb) / var(--state-hover));
+  color: var(--text);
+  font: inherit;
+  font-size: var(--fs-sm);
+  cursor: pointer;
+  transition: background var(--duration-short), border-color var(--duration-short), color var(--duration-short);
+}
+
+.suggestion-chip:hover {
+  border-color: var(--accent);
+  background: rgb(var(--color-primary-rgb) / var(--state-focus));
+  color: var(--accent);
 }
 
 /* ── Skeleton loading items ── */
@@ -2849,9 +2972,16 @@ textarea:focus-visible {
   }
 }
 
+.error-label {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
 .error-retry {
-  min-height: 36px;
-  margin-left: 8px;
+  min-height: 44px;
+  margin-left: 0;
   padding: 5px 10px;
   border: 1px solid rgb(var(--color-error-rgb) / 0.55);
   border-radius: var(--radius-sm);

--- a/recipe-app/src/usePantry.js
+++ b/recipe-app/src/usePantry.js
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+const USER_MANAGEMENT_URL = import.meta.env.VITE_USER_MANAGEMENT_URL
+const CACHE_PREFIX = 'seasoned_pantry_'
+
+export const PANTRY_LOCATIONS = ['fridge', 'freezer', 'pantry', 'other']
+
+function cacheKey(userId) {
+  return `${CACHE_PREFIX}${encodeURIComponent(String(userId || 'guest'))}`
+}
+
+function readCache(userId) {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    const value = JSON.parse(localStorage.getItem(cacheKey(userId)) || '[]')
+    return Array.isArray(value) ? value : []
+  } catch {
+    return []
+  }
+}
+
+function writeCache(userId, items) {
+  if (typeof localStorage === 'undefined') return
+  try { localStorage.setItem(cacheKey(userId), JSON.stringify(items)) } catch { /* storage is best effort */ }
+}
+
+function itemPayload(item) {
+  return {
+    name: item.name,
+    quantity: item.quantity === '' ? null : item.quantity ?? null,
+    unit: item.unit || null,
+    location: item.location || 'pantry',
+    expiresOn: item.expiresOn || item.expires_on || null,
+    tags: Array.isArray(item.tags) ? item.tags : [],
+  }
+}
+
+function normalizeItem(item) {
+  return {
+    ...item,
+    id: item.id ?? `local-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    quantity: item.quantity === '' || item.quantity === undefined ? null : item.quantity,
+    unit: item.unit || null,
+    location: PANTRY_LOCATIONS.includes(item.location) ? item.location : 'pantry',
+    expiresOn: item.expiresOn || item.expires_on || null,
+    tags: Array.isArray(item.tags) ? item.tags : [],
+  }
+}
+
+function errorMessage(error, fallback = 'Pantry sync is unavailable') {
+  return error instanceof Error ? error.message : fallback
+}
+
+export function sortPantryItems(items) {
+  return [...items].sort((a, b) => {
+    if (!a.expiresOn && !a.expires_on) return !b.expiresOn && !b.expires_on ? 0 : 1
+    if (!b.expiresOn && !b.expires_on) return -1
+    return String(a.expiresOn || a.expires_on).localeCompare(String(b.expiresOn || b.expires_on))
+  })
+}
+
+export function usePantry(token, userId, enabled = true, apiUrl = USER_MANAGEMENT_URL) {
+  const initialItems = useMemo(() => readCache(userId), [userId])
+  const [items, setItems] = useState(initialItems)
+  const [loading, setLoading] = useState(Boolean(token && userId && enabled && apiUrl))
+  const [syncError, setSyncError] = useState('')
+
+  const persist = useCallback((nextItems) => {
+    setItems(nextItems)
+    writeCache(userId, nextItems)
+  }, [userId])
+
+  const request = useCallback(async (path, options = {}) => {
+    if (!apiUrl || !token) throw new Error('Pantry sync is unavailable')
+    const response = await fetch(`${apiUrl}${path}`, {
+      ...options,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        ...(options.headers || {}),
+      },
+    })
+    const body = await response.json().catch(() => ({}))
+    if (!response.ok || !body.success) throw new Error(body.message || `Pantry request failed: ${response.status}`)
+    return body
+  }, [apiUrl, token])
+
+  const refresh = useCallback(async () => {
+    if (!enabled || !token || !userId || !apiUrl) {
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    try {
+      const body = await request('/me/pantry-items')
+      persist((body.data || []).map(normalizeItem))
+      setSyncError('')
+    } catch (error) {
+      setSyncError(errorMessage(error))
+    } finally {
+      setLoading(false)
+    }
+  }, [apiUrl, enabled, persist, request, token, userId])
+
+  useEffect(() => {
+    setItems(readCache(userId))
+    void refresh()
+  }, [refresh, userId])
+
+  const addItem = useCallback(async (input) => {
+    const optimistic = normalizeItem(itemPayload(input))
+    const previous = items
+    persist([optimistic, ...items])
+    if (!token || !apiUrl) return optimistic
+    try {
+      const body = await request('/me/pantry-items', { method: 'POST', body: JSON.stringify(itemPayload(input)) })
+      const saved = normalizeItem(body.data || optimistic)
+      persist([saved, ...previous])
+      setSyncError('')
+      return saved
+    } catch (error) {
+      setSyncError(errorMessage(error))
+      return optimistic
+    }
+  }, [apiUrl, items, persist, request, token])
+
+  const updateItem = useCallback(async (id, input) => {
+    const previous = items
+    const nextItem = normalizeItem({ ...items.find((item) => item.id === id), ...input, id })
+    const nextItems = items.map((item) => item.id === id ? nextItem : item)
+    persist(nextItems)
+    if (!token || !apiUrl || String(id).startsWith('local-')) return nextItem
+    try {
+      const body = await request(`/me/pantry-items/${encodeURIComponent(id)}`, {
+        method: 'PATCH',
+        body: JSON.stringify(itemPayload(input)),
+      })
+      const saved = normalizeItem(body.data || nextItem)
+      persist(items.map((item) => item.id === id ? saved : item))
+      setSyncError('')
+      return saved
+    } catch (error) {
+      persist(previous)
+      setSyncError(errorMessage(error))
+      throw error
+    }
+  }, [apiUrl, items, persist, request, token])
+
+  const removeItem = useCallback(async (id) => {
+    const previous = items
+    persist(items.filter((item) => item.id !== id))
+    if (!token || !apiUrl || String(id).startsWith('local-')) return
+    try {
+      await request(`/me/pantry-items/${encodeURIComponent(id)}`, { method: 'DELETE' })
+      setSyncError('')
+    } catch (error) {
+      persist(previous)
+      setSyncError(errorMessage(error))
+      throw error
+    }
+  }, [apiUrl, items, persist, request, token])
+
+  return {
+    items: sortPantryItems(items),
+    loading,
+    syncError,
+    refresh,
+    addItem,
+    updateItem,
+    removeItem,
+    available: Boolean(enabled && (apiUrl || !token)),
+  }
+}

--- a/user-management-worker/migrations/003_add_pantry_items.sql
+++ b/user-management-worker/migrations/003_add_pantry_items.sql
@@ -1,0 +1,20 @@
+-- Additive migration for the authenticated manual pantry MVP.
+-- Pantry rows are always scoped by user_id in the worker service.
+CREATE TABLE IF NOT EXISTS pantry_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL CHECK (length(trim(name)) BETWEEN 1 AND 200),
+    quantity REAL,
+    unit TEXT,
+    location TEXT NOT NULL DEFAULT 'pantry' CHECK (location IN ('fridge', 'freezer', 'pantry', 'other')),
+    expires_on TEXT,
+    tags TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(tags)),
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_pantry_items_user_expiry
+    ON pantry_items(user_id, expires_on, created_at);
+CREATE INDEX IF NOT EXISTS idx_pantry_items_user_location
+    ON pantry_items(user_id, location);

--- a/user-management-worker/package.json
+++ b/user-management-worker/package.json
@@ -21,7 +21,10 @@
     "migrate:production": "wrangler d1 execute user-db-production --env production --remote --file migrations/001_add_passkey_credentials.sql",
     "migrate:profile:preview": "wrangler d1 execute user-db-preview --env preview --remote --file migrations/002_add_culinary_profiles.sql",
     "migrate:profile:staging": "wrangler d1 execute user-db-staging --env staging --remote --file migrations/002_add_culinary_profiles.sql",
-    "migrate:profile:production": "wrangler d1 execute user-db-production --env production --remote --file migrations/002_add_culinary_profiles.sql"
+    "migrate:profile:production": "wrangler d1 execute user-db-production --env production --remote --file migrations/002_add_culinary_profiles.sql",
+    "migrate:pantry:preview": "wrangler d1 execute user-db-preview --env preview --remote --file migrations/003_add_pantry_items.sql",
+    "migrate:pantry:staging": "wrangler d1 execute user-db-staging --env staging --remote --file migrations/003_add_pantry_items.sql",
+    "migrate:pantry:production": "wrangler d1 execute user-db-production --env production --remote --file migrations/003_add_pantry_items.sql"
   },
   "dependencies": {
     "hono": "^3.12.0",

--- a/user-management-worker/schema.sql
+++ b/user-management-worker/schema.sql
@@ -217,3 +217,23 @@ CREATE TRIGGER IF NOT EXISTS update_user_activity_passkey_trigger
     BEGIN
         UPDATE users SET last_activity_at = NEW.login_timestamp WHERE user_id = NEW.user_id;
     END;
+
+-- Pantry inventory. Existing databases should use migrations/003_add_pantry_items.sql.
+CREATE TABLE IF NOT EXISTS pantry_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL CHECK (length(trim(name)) BETWEEN 1 AND 200),
+    quantity REAL,
+    unit TEXT,
+    location TEXT NOT NULL DEFAULT 'pantry' CHECK (location IN ('fridge', 'freezer', 'pantry', 'other')),
+    expires_on TEXT,
+    tags TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(tags)),
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_pantry_items_user_expiry
+    ON pantry_items(user_id, expires_on, created_at);
+CREATE INDEX IF NOT EXISTS idx_pantry_items_user_location
+    ON pantry_items(user_id, location);

--- a/user-management-worker/src/index.ts
+++ b/user-management-worker/src/index.ts
@@ -5,6 +5,7 @@ import { logger } from 'hono/logger';
 import { Bindings } from './types/env';
 import { UserDatabaseService } from './services/user-database';
 import { DEFAULT_PROFILE, validateCulinaryProfileInput } from './services/culinary-profile';
+import { PantryService, validatePantryItemInput } from './services/pantry';
 
 const app = new Hono<{ Bindings: Bindings; Variables: { userId: string } }>();
 
@@ -35,6 +36,10 @@ function culinaryProfileEnabled(env: Bindings): boolean {
   return env.CULINARY_PROFILE_ENABLED !== 'false';
 }
 
+function pantryEnabled(env: Bindings): boolean {
+  return env.PANTRY_ENABLED !== 'false';
+}
+
 function hasPasskeyServiceAccess(c: { env: Bindings; req: { header(name: string): string | undefined } }): boolean {
   const configuredToken = c.env.PASSKEY_SERVICE_TOKEN;
   if (c.env.ENVIRONMENT === 'development') return true;
@@ -49,8 +54,11 @@ app.use('*', cors({ origin: '*', allowHeaders: ['Content-Type', 'Authorization']
 // existing local workflow convenient; deployed environments require the shared
 // PASSKEY_SERVICE_TOKEN secret configured on both workers.
 app.use('*', async (c, next) => {
-  if (c.req.path === '/me/culinary-profile') {
-    if (!culinaryProfileEnabled(c.env)) {
+  if (c.req.path === '/me/culinary-profile' || c.req.path === '/me/pantry-items' || c.req.path.startsWith('/me/pantry-items/')) {
+    if (c.req.path === '/me/culinary-profile' && !culinaryProfileEnabled(c.env)) {
+      return c.json({ success: false, message: 'Not Found' }, 404);
+    }
+    if ((c.req.path === '/me/pantry-items' || c.req.path.startsWith('/me/pantry-items/')) && !pantryEnabled(c.env)) {
       return c.json({ success: false, message: 'Not Found' }, 404);
     }
     const userId = await getAuthenticatedUserId(c);
@@ -143,6 +151,73 @@ app.put('/me/culinary-profile', async (c) => {
     return c.json({ success: true, data: result.data });
   } catch (error) {
     console.error('Error saving culinary profile:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+// Authenticated pantry inventory endpoints. Every query is scoped to the
+// verified JWT subject so a caller cannot read or mutate another user's items.
+app.get('/me/pantry-items', async (c) => {
+  try {
+    const items = await new PantryService(c.env.USER_DB).listItems(c.get('userId'));
+    return c.json({ success: true, data: items });
+  } catch (error) {
+    console.error('Error listing pantry items:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+app.post('/me/pantry-items', async (c) => {
+  try {
+    const body = await c.req.json();
+    const input = body && typeof body === 'object' && !Array.isArray(body) && body.item && typeof body.item === 'object'
+      ? body.item
+      : body;
+    const errors = validatePantryItemInput(input);
+    if (errors.length > 0) return c.json({ success: false, message: 'Invalid pantry item', errors }, 400);
+
+    const item = await new PantryService(c.env.USER_DB).createItem(c.get('userId'), input);
+    if (!item) return c.json({ success: false, message: 'Failed to create pantry item' }, 500);
+    return c.json({ success: true, data: item }, 201);
+  } catch (error) {
+    console.error('Error creating pantry item:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+app.patch('/me/pantry-items/:item_id', async (c) => {
+  try {
+    const itemId = Number(c.req.param('item_id'));
+    if (!Number.isSafeInteger(itemId) || itemId < 1) {
+      return c.json({ success: false, message: 'Invalid pantry item id' }, 400);
+    }
+    const body = await c.req.json();
+    const input = body && typeof body === 'object' && !Array.isArray(body) && body.item && typeof body.item === 'object'
+      ? body.item
+      : body;
+    const errors = validatePantryItemInput(input, { partial: true });
+    if (errors.length > 0) return c.json({ success: false, message: 'Invalid pantry item', errors }, 400);
+
+    const item = await new PantryService(c.env.USER_DB).updateItem(c.get('userId'), itemId, input);
+    if (!item) return c.json({ success: false, message: 'Pantry item not found or no fields to update' }, 404);
+    return c.json({ success: true, data: item });
+  } catch (error) {
+    console.error('Error updating pantry item:', error);
+    return c.json({ success: false, message: 'Internal server error' }, 500);
+  }
+});
+
+app.delete('/me/pantry-items/:item_id', async (c) => {
+  try {
+    const itemId = Number(c.req.param('item_id'));
+    if (!Number.isSafeInteger(itemId) || itemId < 1) {
+      return c.json({ success: false, message: 'Invalid pantry item id' }, 400);
+    }
+    const affectedRows = await new PantryService(c.env.USER_DB).deleteItem(c.get('userId'), itemId);
+    if (affectedRows === 0) return c.json({ success: false, message: 'Pantry item not found' }, 404);
+    return c.json({ success: true, affectedRows });
+  } catch (error) {
+    console.error('Error deleting pantry item:', error);
     return c.json({ success: false, message: 'Internal server error' }, 500);
   }
 });
@@ -743,6 +818,11 @@ app.get('/', (c) => {
         path: '/me/culinary-profile',
         method: 'GET|PUT',
         description: 'Read or update the authenticated user culinary profile (Bearer JWT required)'
+      },
+      {
+        path: '/me/pantry-items',
+        method: 'GET|POST|PATCH|DELETE',
+        description: 'Manage authenticated user pantry inventory (Bearer JWT required)'
       },
       {
         path: '/passkey-credentials/*',

--- a/user-management-worker/src/services/pantry.ts
+++ b/user-management-worker/src/services/pantry.ts
@@ -1,0 +1,176 @@
+import type { D1Database } from '@cloudflare/workers-types';
+import type { PantryItem, PantryItemInput, PantryLocation } from '../types/database';
+
+export const PANTRY_LOCATIONS = ['fridge', 'freezer', 'pantry', 'other'] as const;
+
+const MAX_NAME_LENGTH = 200;
+const MAX_UNIT_LENGTH = 40;
+const MAX_TAGS = 20;
+const MAX_TAG_LENGTH = 40;
+
+type PantryRow = Omit<PantryItem, 'tags'> & { tags: string | null };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeTags(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const tags: string[] = [];
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const tag = item.trim().toLowerCase().replace(/\s+/g, ' ').slice(0, MAX_TAG_LENGTH);
+    if (tag && !tags.includes(tag)) tags.push(tag);
+  }
+  return tags.slice(0, MAX_TAGS);
+}
+
+function normalizeDate(value: unknown): string | null {
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value ? null : value;
+}
+
+function valueFor(input: Record<string, unknown>, snake: string, camel: string): unknown {
+  return input[snake] !== undefined ? input[snake] : input[camel];
+}
+
+export function validatePantryItemInput(input: unknown, { partial = false } = {}): string[] {
+  if (!isRecord(input)) return ['Pantry item must be a JSON object'];
+  const errors: string[] = [];
+  const name = valueFor(input, 'name', 'name');
+  if (!partial || name !== undefined) {
+    if (typeof name !== 'string' || name.trim().length === 0 || name.trim().length > MAX_NAME_LENGTH) {
+      errors.push(`name must be a non-empty string of at most ${MAX_NAME_LENGTH} characters`);
+    }
+  }
+
+  const quantity = valueFor(input, 'quantity', 'quantity');
+  if (quantity !== undefined && quantity !== null && quantity !== '' &&
+      (!Number.isFinite(Number(quantity)) || Number(quantity) < 0)) {
+    errors.push('quantity must be a non-negative number');
+  }
+
+  const unit = valueFor(input, 'unit', 'unit');
+  if (unit !== undefined && unit !== null && unit !== '' &&
+      (typeof unit !== 'string' || unit.trim().length > MAX_UNIT_LENGTH)) {
+    errors.push(`unit must be at most ${MAX_UNIT_LENGTH} characters`);
+  }
+
+  const location = valueFor(input, 'location', 'location');
+  if (location !== undefined && !PANTRY_LOCATIONS.includes(location as PantryLocation)) {
+    errors.push(`location must be one of ${PANTRY_LOCATIONS.join(', ')}`);
+  }
+
+  const expiresOn = valueFor(input, 'expires_on', 'expiresOn');
+  if (expiresOn !== undefined && expiresOn !== null && expiresOn !== '' && normalizeDate(expiresOn) === null) {
+    errors.push('expires_on must be a valid date in YYYY-MM-DD format');
+  }
+
+  const tags = valueFor(input, 'tags', 'tags');
+  if (tags !== undefined && (!Array.isArray(tags) || tags.some((tag) => typeof tag !== 'string'))) {
+    errors.push('tags must be an array of strings');
+  }
+  return errors;
+}
+
+export function normalizePantryItemInput(input: PantryItemInput | Record<string, unknown>, { partial = false } = {}): Record<string, unknown> {
+  const source = isRecord(input) ? input : {};
+  const normalized: Record<string, unknown> = {};
+  const name = valueFor(source, 'name', 'name');
+  const quantity = valueFor(source, 'quantity', 'quantity');
+  const unit = valueFor(source, 'unit', 'unit');
+  const location = valueFor(source, 'location', 'location');
+  const expiresOn = valueFor(source, 'expires_on', 'expiresOn');
+  const tags = valueFor(source, 'tags', 'tags');
+
+  if (!partial || name !== undefined) normalized.name = typeof name === 'string' ? name.trim().slice(0, MAX_NAME_LENGTH) : '';
+  if (!partial || quantity !== undefined) normalized.quantity = quantity === null || quantity === '' || quantity === undefined ? null : Number(quantity);
+  if (!partial || unit !== undefined) normalized.unit = typeof unit === 'string' && unit.trim() ? unit.trim().slice(0, MAX_UNIT_LENGTH) : null;
+  if (!partial || location !== undefined) normalized.location = PANTRY_LOCATIONS.includes(location as PantryLocation) ? location : 'pantry';
+  if (!partial || expiresOn !== undefined) normalized.expires_on = normalizeDate(expiresOn);
+  if (!partial || tags !== undefined) normalized.tags = normalizeTags(tags);
+  return normalized;
+}
+
+function parseTags(value: unknown): string[] {
+  if (Array.isArray(value)) return normalizeTags(value);
+  if (typeof value !== 'string') return [];
+  try { return normalizeTags(JSON.parse(value)); } catch { return []; }
+}
+
+function itemFromRow(row: PantryRow): PantryItem {
+  return {
+    id: Number(row.id),
+    user_id: String(row.user_id),
+    name: String(row.name),
+    quantity: row.quantity === null || row.quantity === undefined ? null : Number(row.quantity),
+    unit: row.unit ? String(row.unit) : null,
+    location: PANTRY_LOCATIONS.includes(row.location as PantryLocation) ? row.location as PantryLocation : 'other',
+    expires_on: row.expires_on ? String(row.expires_on) : null,
+    tags: parseTags(row.tags),
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+export class PantryService {
+  constructor(private db: D1Database) {}
+
+  async listItems(userId: string): Promise<PantryItem[]> {
+    const result = await this.db.prepare(`
+      SELECT * FROM pantry_items
+      WHERE user_id = ?
+      ORDER BY CASE WHEN expires_on IS NULL THEN 1 ELSE 0 END, expires_on ASC, created_at DESC
+    `).bind(userId).all<PantryRow>();
+    return (result.results || []).map(itemFromRow);
+  }
+
+  async createItem(userId: string, input: PantryItemInput): Promise<PantryItem | null> {
+    const values = normalizePantryItemInput(input);
+    const row = await this.db.prepare(`
+      INSERT INTO pantry_items (user_id, name, quantity, unit, location, expires_on, tags)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+      RETURNING *
+    `).bind(
+      userId,
+      values.name,
+      values.quantity,
+      values.unit,
+      values.location,
+      values.expires_on,
+      JSON.stringify(values.tags),
+    ).first<PantryRow>();
+    return row ? itemFromRow(row) : null;
+  }
+
+  async updateItem(userId: string, itemId: number, input: PantryItemInput): Promise<PantryItem | null> {
+    const values = normalizePantryItemInput(input, { partial: true });
+    const fields: string[] = [];
+    const bindings: unknown[] = [];
+    const columns: Record<string, string> = {
+      name: 'name', quantity: 'quantity', unit: 'unit', location: 'location', expires_on: 'expires_on', tags: 'tags',
+    };
+    for (const [key, column] of Object.entries(columns)) {
+      if (!(key in values)) continue;
+      fields.push(`${column} = ?`);
+      bindings.push(key === 'tags' ? JSON.stringify(values[key]) : values[key]);
+    }
+    if (fields.length === 0) return null;
+    bindings.push(userId, itemId);
+    const row = await this.db.prepare(`
+      UPDATE pantry_items SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP
+      WHERE user_id = ? AND id = ?
+      RETURNING *
+    `).bind(...bindings).first<PantryRow>();
+    return row ? itemFromRow(row) : null;
+  }
+
+  async deleteItem(userId: string, itemId: number): Promise<number> {
+    const result = await this.db.prepare(`
+      DELETE FROM pantry_items WHERE user_id = ? AND id = ?
+    `).bind(userId, itemId).run();
+    return result.meta?.changes || 0;
+  }
+}

--- a/user-management-worker/src/types/database.ts
+++ b/user-management-worker/src/types/database.ts
@@ -63,6 +63,30 @@ export interface CulinaryProfileInput {
   consent_flags?: ConsentFlags;
 }
 
+export type PantryLocation = 'fridge' | 'freezer' | 'pantry' | 'other';
+
+export interface PantryItem {
+  id: number;
+  user_id: string;
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+  location: PantryLocation;
+  expires_on: string | null;
+  tags: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PantryItemInput {
+  name: string;
+  quantity?: number | null;
+  unit?: string | null;
+  location?: PantryLocation;
+  expires_on?: string | null;
+  tags?: string[];
+}
+
 export type LoginMethod = 'OTP' | 'MAGIC_LINK' | 'PASSKEY';
 
 export interface UserLoginHistory {

--- a/user-management-worker/src/types/env.ts
+++ b/user-management-worker/src/types/env.ts
@@ -8,6 +8,8 @@ export interface Env {
   JWT_SECRET?: string;
   // Explicit kill switch; omitted keeps the additive profile API enabled.
   CULINARY_PROFILE_ENABLED?: string;
+  // Explicit kill switch for the additive manual pantry API.
+  PANTRY_ENABLED?: string;
   // Optional service-to-service secret for passkey credential routes.
   PASSKEY_SERVICE_TOKEN?: string;
 }

--- a/user-management-worker/tests/setup.js
+++ b/user-management-worker/tests/setup.js
@@ -67,6 +67,10 @@ global.Request = class MockRequest {
   header(name) {
     return this.headers.get(name);
   }
+
+  async json() {
+    return typeof this.body === 'string' ? JSON.parse(this.body) : this.body;
+  }
 };
 
 // Mock fetch for testing external calls

--- a/user-management-worker/tests/unit/pantry.test.ts
+++ b/user-management-worker/tests/unit/pantry.test.ts
@@ -1,0 +1,120 @@
+import { SignJWT } from 'jose';
+import { describe, expect, it, vi } from 'vitest';
+import app from '../../src/index';
+import { PantryService, normalizePantryItemInput, validatePantryItemInput } from '../../src/services/pantry';
+import type { Bindings } from '../../src/types/env';
+
+const SECRET = 'test-secret-that-is-long-enough-for-hs256';
+
+async function tokenFor(userId: string) {
+  return new SignJWT({ email: `${userId}@example.com` })
+    .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
+    .setSubject(userId)
+    .setIssuer('auth-worker.nolanfoster.workers.dev')
+    .setAudience('seasoned-app')
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(new TextEncoder().encode(SECRET));
+}
+
+function env(overrides: Partial<Bindings> = {}): Bindings {
+  return {
+    ENVIRONMENT: 'preview',
+    JWT_SECRET: SECRET,
+    PANTRY_ENABLED: 'true',
+    USER_DB: { prepare: vi.fn() } as never,
+    ...overrides,
+  };
+}
+
+describe('pantry validation and normalization', () => {
+  it('normalizes tags, location, and optional values', () => {
+    expect(normalizePantryItemInput({ name: '  Chickpeas  ', quantity: '2', unit: ' cans ', tags: ['Staple', 'staple'] })).toEqual({
+      name: 'Chickpeas', quantity: 2, unit: 'cans', location: 'pantry', expires_on: null, tags: ['staple'],
+    });
+  });
+
+  it('rejects invalid names, locations, quantities, and dates', () => {
+    expect(validatePantryItemInput({ name: '', location: 'counter', quantity: -1, expiresOn: 'tomorrow' })).toEqual([
+      'name must be a non-empty string of at most 200 characters',
+      'quantity must be a non-negative number',
+      'location must be one of fridge, freezer, pantry, other',
+      'expires_on must be a valid date in YYYY-MM-DD format',
+    ]);
+  });
+
+  it('allows partial updates without silently requiring a name', () => {
+    expect(validatePantryItemInput({ location: 'freezer' }, { partial: true })).toEqual([]);
+    expect(validatePantryItemInput({}, { partial: true })).toEqual([]);
+  });
+});
+
+describe('PantryService', () => {
+  it('lists normalized rows for only the requested user', async () => {
+    const prepare = vi.fn().mockReturnValue({
+      bind: vi.fn().mockReturnValue({
+        all: vi.fn().mockResolvedValue({ results: [{
+          id: 3, user_id: 'user-a', name: 'Tomatoes', quantity: 2, unit: 'cans', location: 'pantry',
+          expires_on: null, tags: '["staple"]', created_at: '2026-01-01', updated_at: '2026-01-01',
+        }] }),
+      }),
+    });
+    const items = await new PantryService({ prepare } as never).listItems('user-a');
+    expect(items[0]).toMatchObject({ id: 3, user_id: 'user-a', tags: ['staple'] });
+    expect(prepare.mock.calls[0][0]).toContain('WHERE user_id = ?');
+    expect(prepare.mock.results[0].value.bind).toHaveBeenCalledWith('user-a');
+  });
+
+  it('updates using both the authenticated user and item id', async () => {
+    const bind = vi.fn().mockReturnValue({ first: vi.fn().mockResolvedValue({
+      id: 4, user_id: 'user-a', name: 'Rice', quantity: 1, unit: 'bag', location: 'freezer',
+      expires_on: null, tags: '[]', created_at: '2026-01-01', updated_at: '2026-01-02',
+    }) });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const item = await new PantryService({ prepare } as never).updateItem('user-a', 4, { location: 'freezer' });
+    expect(item?.location).toBe('freezer');
+    expect(bind).toHaveBeenCalledWith('freezer', 'user-a', 4);
+    expect(prepare.mock.calls[0][0]).toContain('WHERE user_id = ? AND id = ?');
+  });
+});
+
+describe('authenticated pantry routes', () => {
+  it('rejects missing authentication before touching D1', async () => {
+    const prepare = vi.fn();
+    const response = await app.fetch(new Request('https://example.test/me/pantry-items'), env({ USER_DB: { prepare } as never }));
+    expect(response.status).toBe(401);
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
+  it('returns the authenticated user pantry rows and not a caller-supplied id', async () => {
+    const all = vi.fn().mockResolvedValue({ results: [] });
+    const bind = vi.fn().mockReturnValue({ all });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const response = await app.fetch(new Request('https://example.test/me/pantry-items?user_id=other', {
+      headers: { authorization: `Bearer ${await tokenFor('user-a')}` },
+    }), env({ USER_DB: { prepare } as never }));
+    const rawBody = await response.json();
+    const body = (typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody) as { success: boolean; data: unknown[] };
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, data: [] });
+    expect(bind).toHaveBeenCalledWith('user-a');
+  });
+
+  it('validates and creates an item under the verified subject', async () => {
+    const bind = vi.fn().mockReturnValue({ first: vi.fn().mockResolvedValue({
+      id: 8, user_id: 'user-a', name: 'Oats', quantity: 1, unit: 'bag', location: 'pantry',
+      expires_on: '2026-12-01', tags: '["breakfast"]', created_at: '2026-01-01', updated_at: '2026-01-01',
+    }) });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const response = await app.fetch(new Request('https://example.test/me/pantry-items', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${await tokenFor('user-a')}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Oats', quantity: 1, unit: 'bag', expiresOn: '2026-12-01', tags: ['breakfast'] }),
+    }), env({ USER_DB: { prepare } as never }));
+    expect(response.status).toBe(201);
+    const rawBody = await response.json();
+    const body = typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody;
+    expect(body).toMatchObject({ success: true, data: { user_id: 'user-a', name: 'Oats', tags: ['breakfast'] } });
+    expect(bind).toHaveBeenCalledWith('user-a', 'Oats', 1, 'bag', 'pantry', '2026-12-01', '["breakfast"]');
+  });
+});

--- a/user-management-worker/wrangler.toml
+++ b/user-management-worker/wrangler.toml
@@ -15,7 +15,7 @@ enabled = true
 # Preview environment (development)
 [env.preview]
 name = "user-management-worker-preview"
-vars = { ENVIRONMENT = "preview", CULINARY_PROFILE_ENABLED = "true" }
+vars = { ENVIRONMENT = "preview", CULINARY_PROFILE_ENABLED = "true", PANTRY_ENABLED = "true" }
 
 [[env.preview.d1_databases]]
 binding = "USER_DB"
@@ -28,7 +28,7 @@ enabled = true
 # Production environment
 [env.production]
 name = "user-management-worker-production"
-vars = { ENVIRONMENT = "production", CULINARY_PROFILE_ENABLED = "true" }
+vars = { ENVIRONMENT = "production", CULINARY_PROFILE_ENABLED = "true", PANTRY_ENABLED = "true" }
 
 [[env.production.d1_databases]]
 binding = "USER_DB"
@@ -41,7 +41,7 @@ enabled = true
 # Staging environment
 [env.staging]
 name = "user-management-worker-staging"
-vars = { ENVIRONMENT = "staging", CULINARY_PROFILE_ENABLED = "true" }
+vars = { ENVIRONMENT = "staging", CULINARY_PROFILE_ENABLED = "true", PANTRY_ENABLED = "true" }
 
 [[env.staging.d1_databases]]
 binding = "USER_DB"


### PR DESCRIPTION
## Summary
- clarify the omnibox's contextual primary action (Search or Clip) while keeping Generate as a secondary path
- add helper copy, an actionable first-run empty state, richer search suggestions, retry handling, and recipe-card visibility safeguards
- implement the first functional slice of high-priority pantry issue #299: authenticated D1-backed inventory CRUD, fridge/freezer/pantry/other locations, expiry-aware sorting, tags, offline-friendly optimistic local caching, and quick-add leftovers from the active recipe
- add the Pantry account affordance, responsive modal UI, feature flag bootstrap, and staging/production user-management API URLs

Closes #288
Related to #299 (manual pantry Phase A; multimodal scan and pantry-aware generation remain follow-up work)

## Validation
- `cd recipe-app && npm test -- --runInBand` — 17 suites, 379 tests passed
- `cd recipe-app && npm run test:coverage -- --runInBand` — passed (69.36% lines; 60% required)
- `cd recipe-app && npm run build` — passed
- `cd user-management-worker && npm test` — 6 files, 29 tests passed
- `cd user-management-worker && npm run test:coverage` — passed
- `cd user-management-worker && npx tsc --noEmit` — passed
- `git diff --cached --check` — passed

## Deployment note
Apply `user-management-worker/migrations/003_add_pantry_items.sql` to each D1 environment before enabling the pantry API. The package includes `migrate:pantry:preview`, `migrate:pantry:staging`, and `migrate:pantry:production` helpers.