### PR TITLE
fix(auth): surface unconfigured JWT verification and align dev worker envs

### DIFF
--- a/recipe-app/.env.development
+++ b/recipe-app/.env.development
@@ -18,5 +18,9 @@ VITE_RECIPE_VIEW_URL=https://recipe.seasonedapp.com
 # Auth worker
 VITE_AUTH_WORKER_URL=https://auth-worker-preview.nolanfoster.workers.dev
 
-# User-owned culinary profile and pantry API
-VITE_USER_MANAGEMENT_URL=https://user-management-worker-staging.nolanfoster.workers.dev
+# User-owned culinary profile and pantry API.
+# Must be the same environment as VITE_AUTH_WORKER_URL above: the auth worker signs
+# the JWT with its own JWT_SECRET, and only the matching user-management-worker
+# environment can verify it. Crossing environments makes every kitchen profile and
+# pantry request fail with "Authentication required".
+VITE_USER_MANAGEMENT_URL=https://user-management-worker-preview.nolanfoster.workers.dev

--- a/user-management-worker/src/index.ts
+++ b/user-management-worker/src/index.ts
@@ -12,12 +12,26 @@ const app = new Hono<{ Bindings: Bindings; Variables: { userId: string } }>();
 const JWT_ISSUER = 'auth-worker.nolanfoster.workers.dev';
 const JWT_AUDIENCE = 'seasoned-app';
 
-async function getAuthenticatedUserId(c: { env: Bindings; req: { header(name: string): string | undefined } }): Promise<string | null> {
-  const authorization = c.req.header('Authorization');
+// A missing JWT_SECRET is a deployment fault, not a caller fault: without it no
+// token can ever verify, so every request would look like a rejected sign-in.
+// It is reported separately so the failure is diagnosable from the response and
+// the logs, while genuine token problems stay indistinguishable from each other.
+type AuthOutcome =
+  | { status: 'authenticated'; userId: string }
+  | { status: 'unauthenticated' }
+  | { status: 'unconfigured' };
+
+async function authenticateRequest(c: { env: Bindings; req: { header(name: string): string | undefined } }): Promise<AuthOutcome> {
   const secret = c.env.JWT_SECRET;
-  if (!authorization?.startsWith('Bearer ') || !secret) return null;
+  if (!secret) {
+    console.error('JWT_SECRET is not configured on this deployment; authenticated /me routes cannot verify tokens issued by auth-worker');
+    return { status: 'unconfigured' };
+  }
+
+  const authorization = c.req.header('Authorization');
+  if (!authorization?.startsWith('Bearer ')) return { status: 'unauthenticated' };
   const token = authorization.slice('Bearer '.length).trim();
-  if (!token || token.length > 4096) return null;
+  if (!token || token.length > 4096) return { status: 'unauthenticated' };
 
   try {
     const { payload } = await jwtVerify(token, new TextEncoder().encode(secret), {
@@ -25,10 +39,12 @@ async function getAuthenticatedUserId(c: { env: Bindings; req: { header(name: st
       audience: JWT_AUDIENCE,
       algorithms: ['HS256'],
     });
-    return typeof payload.sub === 'string' && payload.sub.length > 0 ? payload.sub : null;
+    return typeof payload.sub === 'string' && payload.sub.length > 0
+      ? { status: 'authenticated', userId: payload.sub }
+      : { status: 'unauthenticated' };
   } catch {
     // Invalid tokens are intentionally indistinguishable from missing tokens.
-    return null;
+    return { status: 'unauthenticated' };
   }
 }
 
@@ -61,9 +77,14 @@ app.use('*', async (c, next) => {
     if ((c.req.path === '/me/pantry-items' || c.req.path.startsWith('/me/pantry-items/')) && !pantryEnabled(c.env)) {
       return c.json({ success: false, message: 'Not Found' }, 404);
     }
-    const userId = await getAuthenticatedUserId(c);
-    if (!userId) return c.json({ success: false, message: 'Authentication required' }, 401);
-    c.set('userId', userId);
+    const auth = await authenticateRequest(c);
+    if (auth.status === 'unconfigured') {
+      return c.json({ success: false, message: 'Authentication is not configured on this deployment' }, 503);
+    }
+    if (auth.status === 'unauthenticated') {
+      return c.json({ success: false, message: 'Authentication required' }, 401);
+    }
+    c.set('userId', auth.userId);
     await next();
     return;
   }

--- a/user-management-worker/tests/unit/culinary-profile.test.ts
+++ b/user-management-worker/tests/unit/culinary-profile.test.ts
@@ -44,6 +44,17 @@ describe('culinary profile foundation', () => {
     expect(response.status).toBe(401);
   });
 
+  it('answers 503 when the deployment has no JWT_SECRET to verify tokens with', async () => {
+    const request = new Request('https://example.test/me/culinary-profile', {
+      headers: { authorization: `Bearer ${await tokenFor('user-a')}` },
+    });
+    const response = await app.fetch(request, env({ JWT_SECRET: undefined }));
+    const rawBody = await response.json();
+    const body = (typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody) as { success: boolean; message: string };
+    expect(response.status).toBe(503);
+    expect(body.message).toBe('Authentication is not configured on this deployment');
+  });
+
   it('returns 404 when the feature kill switch is disabled', async () => {
     const request = new Request('https://example.test/me/culinary-profile');
     const response = await app.fetch(request, env({ CULINARY_PROFILE_ENABLED: 'false' }));

--- a/user-management-worker/tests/unit/pantry.test.ts
+++ b/user-management-worker/tests/unit/pantry.test.ts
@@ -86,6 +86,18 @@ describe('authenticated pantry routes', () => {
     expect(prepare).not.toHaveBeenCalled();
   });
 
+  it('reports an unconfigured deployment separately from a rejected token', async () => {
+    const prepare = vi.fn();
+    const response = await app.fetch(new Request('https://example.test/me/pantry-items', {
+      headers: { authorization: `Bearer ${await tokenFor('user-a')}` },
+    }), env({ JWT_SECRET: undefined, USER_DB: { prepare } as never }));
+    const rawBody = await response.json();
+    const body = (typeof rawBody === 'string' ? JSON.parse(rawBody) : rawBody) as { success: boolean; message: string };
+    expect(response.status).toBe(503);
+    expect(body.message).toBe('Authentication is not configured on this deployment');
+    expect(prepare).not.toHaveBeenCalled();
+  });
+
   it('returns the authenticated user pantry rows and not a caller-supplied id', async () => {
     const all = vi.fn().mockResolvedValue({ results: [] });
     const bind = vi.fn().mockReturnValue({ all });

--- a/user-management-worker/wrangler.toml
+++ b/user-management-worker/wrangler.toml
@@ -51,7 +51,15 @@ database_id = "171ffc3f-40bd-4738-b879-4ccd8d79db39"
 [env.staging.observability]
 enabled = true
 
-# JWT_SECRET must match auth-worker for authenticated profile routes. Configure it as a secret:
+# JWT_SECRET must match the auth-worker that issued the token for authenticated
+# /me/culinary-profile and /me/pantry-items routes. Secrets are per Worker script,
+# so the top-level deployment needs its own copy — it is the script the deployed
+# frontend calls (recipe-app/.env.production points at
+# user-management-worker.nolanfoster.workers.dev), and it is not covered by any
+# --env flag. Without it every authenticated request fails; the routes answer 503
+# "Authentication is not configured on this deployment" so it is distinguishable
+# from a rejected token.
+#   wrangler secret put JWT_SECRET               # top-level deployment (auth-worker production)
 #   wrangler secret put JWT_SECRET --env preview
 #   wrangler secret put JWT_SECRET --env staging
 #   wrangler secret put JWT_SECRET --env production


### PR DESCRIPTION
## Why

Kitchen profile and pantry always fail with "Authentication required". Both features call `user-management-worker`'s `/me/*` routes with the JWT that `auth-worker` issued, and verification succeeds only when the two Worker scripts share the same `JWT_SECRET`. Issuer, audience and algorithm already match (`auth-worker/src/services/jwt-service.ts:43-44` vs `user-management-worker/src/index.ts:12-13`), so the secret is the only remaining input — and every way it can go wrong looked identical to a rejected sign-in:

```ts
if (!authorization?.startsWith('Bearer ') || !secret) return null;  // no secret == no token
```

Two places in the repo cross those secrets:

- `recipe-app/.env.development` pointed at **auth-worker-preview** for tokens but **user-management-worker-staging** for profile/pantry. Different environments, different secrets, so a preview-issued token can never verify.
- `recipe-app/.env.production` calls the **top-level** `user-management-worker` script, while `wrangler.toml` only documented `wrangler secret put JWT_SECRET --env preview|staging|production`. Secrets are per script, so following the documented steps leaves the deployment the app actually calls without a secret. Sign-in, passkeys and login history keep working because they authenticate with `PASSKEY_SERVICE_TOKEN` instead — which is why only `/me/*` fails.

## What changed

- **`user-management-worker/src/index.ts`** — `getAuthenticatedUserId` becomes `authenticateRequest`, returning a three-way outcome. A missing `JWT_SECRET` now answers `503` with `"Authentication is not configured on this deployment"` and logs an error; genuine token failures still answer `401` and stay indistinguishable from one another.
- **`recipe-app/.env.development`** — point at `user-management-worker-preview` to match the preview auth worker, with a comment on why the two must stay in the same environment.
- **`user-management-worker/wrangler.toml`** — document that the top-level deployment needs its own `JWT_SECRET`.
- **Tests** — added a case per route family asserting the 503 and its message, and that D1 is never touched.

This makes the failure diagnosable and fixes the local dev config; **the deployed 401 still needs the secret set on the top-level Worker**:

```bash
cd user-management-worker
npx wrangler secret list          # confirm JWT_SECRET is absent
npx wrangler secret put JWT_SECRET  # same value as auth-worker-production
```

After the secret is in place the routes answer normally; if it were still missing, the response is now the 503 above rather than a misleading 401.

## Testing

- `npx vitest run` in `user-management-worker` — 31 passed (6 files), including the 2 new cases
- `npx tsc --noEmit` — clean

Deployed secrets could not be verified from this environment (egress to `*.workers.dev` is blocked), so the `wrangler secret list` check above is left to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AxqzZpYYCqKtQBeEqCjdZ

---
_Generated by [Claude Code](https://claude.ai/code/session_015AxqzZpYYCqKtQBeEqCjdZ)_